### PR TITLE
707 - add 'React' hint for the codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![CircleCI](https://circleci.com/gh/boxwise/boxtribute.svg?style=svg)](https://circleci.com/gh/boxwise/boxtribute)
 <a width="105" height="35" href="https://auth0.com/?utm_source=oss&utm_medium=gp&utm_campaign=oss" target="_blank" alt="Single Sign On & Token Based Authentication - Auth0">
 <img width="105" height="35" alt="JWT Auth for open source projects" src="https://cdn.auth0.com/oss/badges/a0-badge-dark.png"></a>
-[![codecov](https://codecov.io/gh/boxwise/boxtribute/branch/master/graph/badge.svg?token=646MWM6V9H)](https://codecov.io/gh/boxwise/boxtribute)
+
+React Test Coverage: [![codecov](https://codecov.io/gh/boxwise/boxtribute/branch/master/graph/badge.svg?token=646MWM6V9H)](https://codecov.io/gh/boxwise/boxtribute)
 
 # Readme
 


### PR DESCRIPTION
Adding a hint that the React codecov badge is actually only for react (since the badge is on the main README which also covers the backend). 