### PR TITLE
Add integration test using actual MySQL database connection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,9 +123,14 @@ jobs:
       - run:
           name: Run pytest
           command: |
+            cd ..
+            docker-compose up --no-start mysql
+            docker-compose up -d mysql && sleep 20
+            cd -
             source env/bin/activate
             mkdir test-results
-            pytest --cov-report xml:test-results/coverage.xml --cov=. test
+            pytest --cov-report xml:test-results/coverage.xml --cov=. -k test_backend_connection test
+            docker-compose down
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,14 @@ jobs:
   test-flask:
     docker:
       - image: circleci/python:3.8-buster
+      - image: circleci/mysql:5.7.32
+        environment:
+          MYSQL_ROOT_PASSWORD: dropapp_root
+          MYSQL_DATABASE: dropapp_dev
+          MYSQL_ROOT_HOST: "%"
+          MYSQL_USER: root
+          MYSQL_PASSWORD: dropapp_root
+        command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     working_directory: ~/flask
     steps:
       # Attach workspace from build
@@ -120,19 +128,29 @@ jobs:
       #       - env
       # run linting checks
       # run tests https://circleci.com/docs/2.0/collect-test-data/#pytest
-      - setup_remote_docker
+      # https://circleci.com/docs/2.0/postgres-config/#example-mysql-project
+      - run:
+      # Our primary container isn't MYSQL so run a sleep command until it's ready.
+          name: Waiting for MySQL to be ready
+          command: |
+            for i in `seq 1 10`;
+            do
+              nc -z 127.0.0.1 3306 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for MySQL && exit 1
+      - run:
+          name: Install MySQL CLI; Import test data
+          command: |
+            sudo apt-get install default-mysql-client
+            mysql -h 127.0.0.1 -u root -pdropapp_root dropapp_dev < init.sql
       - run:
           name: Run pytest
           command: |
-            cd ..
-            docker-compose up --no-start mysql
-            docker-compose up -d mysql && sleep 20
-            cd -
-            export MYSQL_HOST=$(docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' circleci_backend)
             source env/bin/activate
             mkdir test-results
             pytest --cov-report xml:test-results/coverage.xml --cov=. -k test_backend_connection test
-            docker-compose down
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,6 @@ jobs:
           MYSQL_ROOT_PASSWORD: dropapp_root
           MYSQL_DATABASE: dropapp_dev
           MYSQL_ROOT_HOST: "%"
-          MYSQL_USER: root
           MYSQL_PASSWORD: dropapp_root
         command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     working_directory: ~/flask

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,12 @@ jobs:
       #       - env
       # run linting checks
       # run tests https://circleci.com/docs/2.0/collect-test-data/#pytest
+      - run:
+          name: Run pytest for unit tests
+          command: |
+            source env/bin/activate
+            mkdir test-results
+            pytest --cov-report xml:test-results/coverage.xml --cov=. -k 'not test_backend_connection' test
       # https://circleci.com/docs/2.0/postgres-config/#example-mysql-project
       - run:
       # Our primary container isn't MYSQL so run a sleep command until it's ready.
@@ -144,11 +150,10 @@ jobs:
             sudo apt-get install default-mysql-client
             mysql -h 127.0.0.1 -u root -pdropapp_root dropapp_dev < init.sql
       - run:
-          name: Run pytest
+          name: Run pytest for integration tests
           command: |
             source env/bin/activate
-            mkdir test-results
-            pytest --cov-report xml:test-results/coverage.xml --cov=. -k test_backend_connection test
+            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=. -k test_backend_connection test
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
             docker-compose up --no-start mysql
             docker-compose up -d mysql && sleep 20
             cd -
-            export MYSQL_HOST=$(docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' boxtribute_backend)
+            export MYSQL_HOST=$(docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' circleci_backend)
             source env/bin/activate
             mkdir test-results
             pytest --cov-report xml:test-results/coverage.xml --cov=. -k test_backend_connection test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,6 @@ jobs:
           MYSQL_ROOT_PASSWORD: dropapp_root
           MYSQL_DATABASE: dropapp_dev
           MYSQL_ROOT_HOST: "%"
-          MYSQL_PASSWORD: dropapp_root
         command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     working_directory: ~/flask
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
       #       - env
       # run linting checks
       # run tests https://circleci.com/docs/2.0/collect-test-data/#pytest
+      - setup_remote_docker
       - run:
           name: Run pytest
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ jobs:
             docker-compose up --no-start mysql
             docker-compose up -d mysql && sleep 20
             cd -
+            export MYSQL_HOST=$(docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' boxtribute_backend)
             source env/bin/activate
             mkdir test-results
             pytest --cov-report xml:test-results/coverage.xml --cov=. -k test_backend_connection test

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -1,5 +1,4 @@
-import shlex
-import subprocess
+import os
 
 from boxwise_flask.app import create_app
 from boxwise_flask.db import db
@@ -24,17 +23,7 @@ def test_backend_connection():
     app = create_app()
     app.testing = True
 
-    host = (
-        subprocess.run(
-            shlex.split(
-                "docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' "
-                "boxtribute_backend"
-            ),
-            capture_output=True,
-        )
-        .stdout.decode()
-        .strip()
-    )
+    host = os.getenv("MYSQL_HOST")
     print(host)
 
     # cf. main.py but inserting values from docker-compose.yml

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -23,7 +23,7 @@ def test_backend_connection():
     app = create_app()
     app.testing = True
 
-    host = os.getenv("MYSQL_HOST")
+    host = os.getenv("MYSQL_HOST", "localhost")
     print(host)
 
     # cf. main.py but inserting values from docker-compose.yml

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -27,7 +27,7 @@ def test_backend_connection():
     print(host)
 
     # cf. main.py but inserting values from docker-compose.yml
-    app.config["DATABASE"] = f"mysql://root:dropapp_root@{host}:32000/dropapp_dev"
+    app.config["DATABASE"] = f"mysql://root:dropapp_root@{host}:3306/dropapp_dev"
 
     db.init_app(app)
 

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from boxwise_flask.app import create_app
 from boxwise_flask.db import db
 
@@ -14,6 +15,7 @@ def test_private_endpoint(client):
     )
 
 
+@pytest.mark.skipif("CIRCLECI" not in os.environ, reason="only functional in CircleCI")
 def test_backend_connection():
     """Verify that database connection is established and operational.
 
@@ -24,8 +26,7 @@ def test_backend_connection():
     app.testing = True
 
     # cf. main.py but inserting values from docker-compose.yml
-    host = os.getenv("MYSQL_HOST", "127.0.0.1")
-    app.config["DATABASE"] = f"mysql://root:dropapp_root@{host}:3306/dropapp_dev"
+    app.config["DATABASE"] = "mysql://root:dropapp_root@127.0.0.1:3306/dropapp_dev"
 
     db.init_app(app)
 

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -1,3 +1,7 @@
+from boxwise_flask.app import create_app
+from boxwise_flask.db import db
+
+
 def test_private_endpoint(client):
     """example test for private endpoint"""
     response_data = client.get("/api/private")
@@ -6,3 +10,35 @@ def test_private_endpoint(client):
         "Hello from a private endpoint! You need to be authenticated to see this."
         == response_data.json["message"]
     )
+
+
+def test_backend_connection():
+    """Verify that database connection is established and operational.
+
+    Follow the setup-proceduce of the main module, instantiate a test client,
+    and query a box via the GraphQL endpoint.
+    """
+    app = create_app()
+    app.testing = True
+    # cf. main.py but inserting values from docker-compose.yml
+    app.config["DATABASE"] = "mysql://root:dropapp_root@localhost:32000/dropapp_dev"
+
+    db.init_app(app)
+
+    client = app.test_client()
+
+    data = {
+        "query": """query Box {
+                box(qr_code: "fff74d8503b1a5773c301cbe1e1ff43") {
+                    box_id
+                    items
+                    created
+                }
+            }"""
+    }
+    response = client.post("/graphql", json=data)
+    queried_box = response.json["data"]["box"]
+    assert response.status_code == 200
+    assert queried_box == {"box_id": "751464", "items": 92, "created": None}
+
+    db.close_db(None)

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -23,10 +23,8 @@ def test_backend_connection():
     app = create_app()
     app.testing = True
 
-    host = os.getenv("MYSQL_HOST", "127.0.0.1")
-    print(host)
-
     # cf. main.py but inserting values from docker-compose.yml
+    host = os.getenv("MYSQL_HOST", "127.0.0.1")
     app.config["DATABASE"] = f"mysql://root:dropapp_root@{host}:3306/dropapp_dev"
 
     db.init_app(app)

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -1,3 +1,6 @@
+import shlex
+import subprocess
+
 from boxwise_flask.app import create_app
 from boxwise_flask.db import db
 
@@ -20,8 +23,22 @@ def test_backend_connection():
     """
     app = create_app()
     app.testing = True
+
+    host = (
+        subprocess.run(
+            shlex.split(
+                "docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' "
+                "boxtribute_backend"
+            ),
+            capture_output=True,
+        )
+        .stdout.decode()
+        .strip()
+    )
+    print(host)
+
     # cf. main.py but inserting values from docker-compose.yml
-    app.config["DATABASE"] = "mysql://root:dropapp_root@localhost:32000/dropapp_dev"
+    app.config["DATABASE"] = f"mysql://root:dropapp_root@{host}:32000/dropapp_dev"
 
     db.init_app(app)
 

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -23,7 +23,7 @@ def test_backend_connection():
     app = create_app()
     app.testing = True
 
-    host = os.getenv("MYSQL_HOST", "localhost")
+    host = os.getenv("MYSQL_HOST", "127.0.0.1")
     print(host)
 
     # cf. main.py but inserting values from docker-compose.yml


### PR DESCRIPTION
- combination of test_box endpoint unit test and database configuration
  from main.py (use read request)
- configure circleci to launch a MySQL server, and run unit / integration tests separately

@HaGuesto why do we expose the mysql docker-compose service on port 32000 instead of 3306?