### PR TITLE
More tables as peewee models

### DIFF
--- a/flask/README.md
+++ b/flask/README.md
@@ -65,10 +65,11 @@ Since we are working with docker you do not have to install a local MySQL server
 #### General notes on Docker network
 
 In the docker-compose file we define a separate docker network called `backend` to which the back-end containers are joined. Each container can now look up the hostname `flask` or `mysql` and get back the appropriate container’s IP address.
-To access the mysql database, there are now two possibilities:
+To access the mysql database, there are now three possibilities:
 
 1. You reach the mysql db at `MYSQL_HOST=mysql` and `MYSQL_PORT=3306` or
-2. by specifying the IP-address of the gateway for `MYSQL_HOST` and `MYSQL_PORT=32000`.
+1. You execute the mysql command line client in the running container by `docker-compose exec mysql mysql -u root -p` or
+1. by specifying the IP-address of the gateway for `MYSQL_HOST` and `MYSQL_PORT=32000`.
 
 To figure out the gateway of the docker network `backend` run
 

--- a/flask/README.md
+++ b/flask/README.md
@@ -181,8 +181,8 @@ Test data is setup in the `test/data` folder and each piece of data is split up 
 
 #### Please be aware that
 
-- for new data the fixtures need to be imported in the required `conftest.py` and
-- the call to create needs to be added to `setup_tables.py` in the `test/data` directory.
+- for new data the fixtures need to be imported in `test/data/__init__.py` and
+- the call to create needs to be added to `test/data/setup_tables.py`
 
 ### Coverage analysis
 

--- a/flask/README.md
+++ b/flask/README.md
@@ -27,7 +27,7 @@ For almost all features of our development set-up you should [install Python >=3
 These recommendations are mainly meant for people developing on the back-end. If you are just a front-end person, but would like use pre-commit and the linters and formatters defined there, you can skip these steps.
 
 - [Use a version control for python like pyenv.](https://github.com/pyenv/pyenv) It provides you with much more clarity which version you are running and makes it easy to switch versions of python.
-- [Have a look at direnv >= v2.21.0](https://github.com/direnv/direnv). Virtual environments must be activated and deactivated. If you are moving through folders in the terminal it can easily happen that you either miss activating or deactivating the venv resulting in errors and time wasted for development. With direnv you can automate the activation and deactivation of venv depending on which folder you are in. There is already a `.envrc` file in the root of this repo. If you install `direnv` and allow to run it for your local repo, it will activate the python virtual environment `venv` everytime you enter the folder via a command line.
+- [Have a look at direnv >= v2.21.0](https://github.com/direnv/direnv). Virtual environments must be activated and deactivated. If you are moving through folders in the terminal it can easily happen that you either miss activating or deactivating the venv resulting in errors and time wasted for development. With direnv you can automate the activation and deactivation of venv depending on which folder you are in. There is already a `.envrc` file in the root of this repo. If you install `direnv` and allow to run it for your local repo, it will activate the python virtual environment `venv` every time you enter the folder via a command line.
 
 ### Set-up pre-commit
 
@@ -64,7 +64,7 @@ Since we are working with docker you do not have to install a local MySQL server
 
 #### General notes on Docker network
 
-In the docker-compose file we define a separate docker network called `backend` to which the back-end containers are joined. Each container can now look up the hostname `flask` or `mysql` and get back the appropriate container’s IP address.
+In the docker-compose file we define a separate docker network called `backend` to which the back-end containers are joined. Each container can now look up the host name `flask` or `mysql` and get back the appropriate container’s IP address.
 To access the mysql database, there are now three possibilities:
 
 1. You reach the mysql db at `MYSQL_HOST=mysql` and `MYSQL_PORT=3306` or
@@ -77,7 +77,7 @@ To figure out the gateway of the docker network `backend` run
 
 #### MySQL workbend or other editors
 
-Most of our developers use [MySQL workbench](https://dev.mysql.com/doc/workbench/en/wb-installing.html) to interact with the database directly. If you want to connect to the database, choose one of the possibilites in the former to define the conneection, e.g. Hostname is 172.18.0.1 and Port is 32000.
+Most of our developers use [MySQL workbench](https://dev.mysql.com/doc/workbench/en/wb-installing.html) to interact with the database directly. If you want to connect to the database, choose one of the possibilities in the former to define the connection, e.g. Hostname is 172.18.0.1 and Port is 32000.
 
 The development database is called `dropapp_dev` and the password is `dropapp_root`.
 
@@ -100,7 +100,7 @@ By default the flask app runs in `development` mode in the Docker container whic
 
 #### Built-in flask debugger
 
-For debugging an exception in an endpoint, direct your webbrowser to that endpoint. The built-in flask debugger is shown. You can attach a console by clicking the icons on the right of the traceback lines. For more information, refer to the [documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#debug-mode).
+For debugging an exception in an endpoint, direct your web browser to that endpoint. The built-in flask debugger is shown. You can attach a console by clicking the icons on the right of the traceback lines. For more information, refer to the [documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#debug-mode).
 
 #### Debugging Back-end in VSCode
 
@@ -119,7 +119,7 @@ The following step are only required the first time or after you deleted a Docke
 Final steps: 7. [Launch the debug configuration called 'Python: Run Flask in docker container to debug'.](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations)
 
 You can now set break-points in your code.
-If you want to debug a certain endpoint, set a break-point in the endpoint and call this enpoint at the port 5001, e.g.
+If you want to debug a certain endpoint, set a break-point in the endpoint and call this endpoint at the port 5001, e.g.
 `localhost:5001/api/public`
 If you want to break on any other code lines (not endpoints), then you can only catch them during the server start-up.
 
@@ -164,7 +164,7 @@ Fixtures are configured in the `conftest.py` files which execute automatically b
 
 ### Setting up test data
 
-Test data is setup in the `test/data` folder and each piece of data is split up into 3 seperate parts
+Test data is setup in the `test/data` folder and each piece of data is split up into 3 separate parts
 
 1.  The default data function is a dictionary which has all of the data for that database table
 
@@ -196,7 +196,7 @@ and inspect the reported output. Open the HTML report via `flask/htmlcov/index.h
 ## GraphQL Playground
 
 We are setting up GraphQL as a data layer for this application. To check out the GraphQL playground, and go to `localhost:5000/graphql`.
-The GraphQL enpoint is secured and needs a Bearer token from Auth0 to authenticate and authorize. To work with the playground you have to add such a token from Auth0 as an http Header. Here, how this works:
+The GraphQL endpoint is secured and needs a Bearer token from Auth0 to authenticate and authorize. To work with the playground you have to add such a token from Auth0 as an HTTP header. Here, how this works:
 
 1.  Follow this [link](https://manage.auth0.com/dashboard/eu/boxtribute-dev/apis/5ef3760527b0da00215e6209/test) to receive a token for testing. You can also find this token in Auth0 in the menu > API > boxtribute-dev-api > Test-tab.
 

--- a/flask/boxwise_flask/models/__init__.py
+++ b/flask/boxwise_flask/models/__init__.py
@@ -1,0 +1,41 @@
+from .base import Base
+from .base_module import BaseModule
+from .beneficiary import Beneficiary
+from .box import Box
+from .box_state import BoxState
+from .language import Language
+from .location import Location
+from .organisation import Organisation
+from .product import Product
+from .product_category import ProductCategory
+from .product_gender import ProductGender
+from .qr_code import QRCode
+from .size import Size
+from .size_range import SizeRange
+from .transaction import Transaction
+from .user import User
+from .usergroup import Usergroup
+from .usergroup_access_level import UsergroupAccessLevel
+from .usergroup_base_access import UsergroupBaseAccess
+
+MODELS = (
+    Base,
+    BaseModule,
+    Beneficiary,
+    Box,
+    BoxState,
+    Language,
+    Location,
+    Organisation,
+    Product,
+    ProductCategory,
+    ProductGender,
+    QRCode,
+    Size,
+    SizeRange,
+    Transaction,
+    User,
+    Usergroup,
+    UsergroupAccessLevel,
+    UsergroupBaseAccess,
+)

--- a/flask/boxwise_flask/models/__init__.py
+++ b/flask/boxwise_flask/models/__init__.py
@@ -3,6 +3,7 @@ from .base_module import BaseModule
 from .beneficiary import Beneficiary
 from .box import Box
 from .box_state import BoxState
+from .history import DbChangeHistory
 from .language import Language
 from .location import Location
 from .log import Log
@@ -26,6 +27,7 @@ MODELS = (
     Beneficiary,
     Box,
     BoxState,
+    DbChangeHistory,
     Language,
     Location,
     Log,

--- a/flask/boxwise_flask/models/__init__.py
+++ b/flask/boxwise_flask/models/__init__.py
@@ -5,6 +5,7 @@ from .box import Box
 from .box_state import BoxState
 from .language import Language
 from .location import Location
+from .log import Log
 from .organisation import Organisation
 from .product import Product
 from .product_category import ProductCategory
@@ -26,6 +27,7 @@ MODELS = (
     BoxState,
     Language,
     Location,
+    Log,
     Organisation,
     Product,
     ProductCategory,

--- a/flask/boxwise_flask/models/__init__.py
+++ b/flask/boxwise_flask/models/__init__.py
@@ -11,6 +11,7 @@ from .product import Product
 from .product_category import ProductCategory
 from .product_gender import ProductGender
 from .qr_code import QRCode
+from .settings import Settings
 from .size import Size
 from .size_range import SizeRange
 from .transaction import Transaction
@@ -33,6 +34,7 @@ MODELS = (
     ProductCategory,
     ProductGender,
     QRCode,
+    Settings,
     Size,
     SizeRange,
     Transaction,

--- a/flask/boxwise_flask/models/beneficiary.py
+++ b/flask/boxwise_flask/models/beneficiary.py
@@ -1,0 +1,92 @@
+from boxwise_flask.db import db
+from boxwise_flask.models.base import Base
+from boxwise_flask.models.user import User
+from peewee import (
+    SQL,
+    CharField,
+    DateField,
+    DateTimeField,
+    ForeignKeyField,
+    IntegerField,
+    TextField,
+)
+
+
+class Beneficiary(db.Model):
+    approval_signed = IntegerField(
+        column_name="approvalsigned", constraints=[SQL("DEFAULT 0")]
+    )
+    bicycle_ban = DateField(column_name="bicycleban", null=True)
+    bicycle_ban_comment = TextField(column_name="bicyclebancomment",)
+    bicycle_training = IntegerField(
+        column_name="bicycletraining", constraints=[SQL("DEFAULT 0")]
+    )
+    base = ForeignKeyField(
+        column_name="camp_id", field="id", model=Base, on_update="CASCADE",
+    )
+    comments = TextField(null=True)
+    container = CharField(constraints=[SQL("DEFAULT ''")], index=True)
+    created = DateTimeField(null=True)
+    created_by = ForeignKeyField(
+        column_name="created_by",
+        field="id",
+        model=User,
+        null=True,
+        on_update="CASCADE",
+    )
+    date_of_birth = DateField(null=True)
+    date_of_signature = DateTimeField(
+        constraints=[SQL("DEFAULT '0000-00-00 00:00:00'")]
+    )
+    deleted = DateTimeField()
+    email = CharField(constraints=[SQL("DEFAULT ''")])
+    extra_portion = IntegerField(
+        column_name="extraportion", constraints=[SQL("DEFAULT 0")]
+    )
+    family_id = IntegerField()
+    first_name = CharField(column_name="firstname", constraints=[SQL("DEFAULT ''")])
+    gender = CharField(constraints=[SQL("DEFAULT ''")])
+    language = IntegerField(constraints=[SQL("DEFAULT 5")])
+    last_name = CharField(column_name="lastname", constraints=[SQL("DEFAULT ''")])
+    laundry_block = IntegerField(
+        column_name="laundryblock", constraints=[SQL("DEFAULT 0")]
+    )
+    laundry_comment = CharField(column_name="laundrycomment", null=True)
+    modified = DateTimeField(null=True)
+    modified_by = ForeignKeyField(
+        column_name="modified_by",
+        field="id",
+        model=User,
+        null=True,
+        on_update="CASCADE",
+    )
+    not_registered = IntegerField(
+        column_name="notregistered", constraints=[SQL("DEFAULT 0")]
+    )
+    parent = ForeignKeyField(
+        column_name="parent_id",
+        field="id",
+        model="self",
+        null=True,
+        on_update="CASCADE",
+    )
+    pass_ = CharField(column_name="pass", constraints=[SQL("DEFAULT ''")])
+    phone = CharField(null=True)
+    reset_password = CharField(column_name="resetpassword", null=True)
+    seq = IntegerField()
+    signature_field = TextField(column_name="signaturefield", null=True)
+    tent = CharField(constraints=[SQL("DEFAULT ''")])
+    url = IntegerField(null=True)
+    visible = IntegerField(constraints=[SQL("DEFAULT 1")])
+    volunteer = IntegerField(constraints=[SQL("DEFAULT 0")])
+    workshop_ban = DateField(column_name="workshopban", null=True)
+    workshop_ban_comment = TextField(column_name="workshopbancomment",)
+    workshop_supervisor = IntegerField(
+        column_name="workshopsupervisor", constraints=[SQL("DEFAULT 0")]
+    )
+    workshop_training = IntegerField(
+        column_name="workshoptraining", constraints=[SQL("DEFAULT 0")]
+    )
+
+    class Meta:
+        table_name = "people"

--- a/flask/boxwise_flask/models/history.py
+++ b/flask/boxwise_flask/models/history.py
@@ -1,0 +1,28 @@
+from boxwise_flask.db import db
+from boxwise_flask.models.user import User
+from peewee import (
+    CharField,
+    DateTimeField,
+    FloatField,
+    ForeignKeyField,
+    IntegerField,
+    TextField,
+)
+
+
+class DbChangeHistory(db.Model):
+    change_date = DateTimeField(column_name="changedate", null=True)
+    changes = TextField()
+    from_float = FloatField(null=True)
+    from_int = IntegerField(null=True)
+    ip = CharField(null=True)
+    record_id = IntegerField(null=True)
+    table_name = CharField(column_name="tablename", null=True)
+    to_float = FloatField(null=True)
+    to_int = IntegerField(null=True)
+    user = ForeignKeyField(
+        column_name="user_id", field="id", model=User, null=True, on_update="CASCADE",
+    )
+
+    class Meta:
+        table_name = "history"

--- a/flask/boxwise_flask/models/log.py
+++ b/flask/boxwise_flask/models/log.py
@@ -1,0 +1,12 @@
+from boxwise_flask.db import db
+from peewee import CharField, DateTimeField, TextField
+
+
+class Log(db.Model):
+    content = TextField()
+    ip = CharField(null=True)
+    date = DateTimeField(column_name="logdate", null=True)
+    user = CharField(null=True)
+
+    class Meta:
+        table_name = "log"

--- a/flask/boxwise_flask/models/settings.py
+++ b/flask/boxwise_flask/models/settings.py
@@ -1,0 +1,39 @@
+from boxwise_flask.db import db
+from boxwise_flask.models.user import User
+from peewee import (
+    SQL,
+    CharField,
+    DateTimeField,
+    ForeignKeyField,
+    IntegerField,
+    TextField,
+)
+
+
+class Settings(db.Model):
+    category_id = IntegerField()
+    code = CharField(unique=True)
+    created = DateTimeField(null=True)
+    created_by = ForeignKeyField(
+        column_name="created_by",
+        field="id",
+        model=User,
+        null=True,
+        on_update="CASCADE",
+    )
+    description = CharField(null=True)
+    hidden = IntegerField(constraints=[SQL("DEFAULT 0")])
+    modified = DateTimeField(null=True)
+    modified_by = ForeignKeyField(
+        column_name="modified_by",
+        field="id",
+        model=User,
+        null=True,
+        on_update="CASCADE",
+    )
+    options = CharField(null=True)
+    type = CharField(null=True)
+    value = TextField(null=True)
+
+    class Meta:
+        table_name = "cms_settings"

--- a/flask/boxwise_flask/models/transaction.py
+++ b/flask/boxwise_flask/models/transaction.py
@@ -1,0 +1,48 @@
+from boxwise_flask.db import db
+from boxwise_flask.models.beneficiary import Beneficiary
+from boxwise_flask.models.product import Product
+from boxwise_flask.models.size import Size
+from boxwise_flask.models.user import User
+from peewee import SQL, CharField, DateTimeField, ForeignKeyField, IntegerField
+
+
+class Transaction(db.Model):
+    beneficiary = ForeignKeyField(
+        column_name="people_id",
+        field="id",
+        model=Beneficiary,
+        null=True,
+        on_update="CASCADE",
+    )
+    count = IntegerField()
+    created = DateTimeField(null=True)
+    created_by = ForeignKeyField(
+        column_name="created_by", field="id", model=User, null=True, on_update="CASCADE"
+    )
+    description = CharField()
+    drops = IntegerField(constraints=[SQL("DEFAULT 0")])
+    modified = DateTimeField(null=True)
+    modified_by = ForeignKeyField(
+        column_name="modified_by",
+        field="id",
+        model=User,
+        null=True,
+        on_update="CASCADE",
+    )
+    product = ForeignKeyField(
+        column_name="product_id",
+        field="id",
+        model=Product,
+        null=True,
+        on_update="CASCADE",
+    )
+    size = ForeignKeyField(
+        column_name="size_id", field="id", model=Size, null=True, on_update="CASCADE"
+    )
+    transaction_date = DateTimeField(index=True)
+    user = ForeignKeyField(
+        column_name="user_id", field="id", model=User, null=True, on_update="CASCADE"
+    )
+
+    class Meta:
+        table_name = "transactions"

--- a/flask/boxwise_flask/models/x_beneficiary_language.py
+++ b/flask/boxwise_flask/models/x_beneficiary_language.py
@@ -1,0 +1,27 @@
+from boxwise_flask.db import db
+from boxwise_flask.models.beneficiary import Beneficiary
+from boxwise_flask.models.language import Language
+from peewee import ForeignKeyField
+
+
+class XBeneficiaryLanguage(db.Model):
+    language = ForeignKeyField(
+        column_name="language_id",
+        field="id",
+        model=Language,
+        on_update="CASCADE",
+        on_delete="CASCADE",
+    )
+    beneficiary = ForeignKeyField(
+        column_name="people_id",
+        field="id",
+        model=Beneficiary,
+        null=True,
+        on_update="CASCADE",
+        on_delete="CASCADE",
+    )
+
+    class Meta:
+        table_name = "x_people_languages"
+        indexes = ((("people", "language"), True),)
+        primary_key = False

--- a/flask/test/auth_tests/conftest.py
+++ b/flask/test/auth_tests/conftest.py
@@ -12,6 +12,7 @@ https://docs.pytest.org/en/stable/fixture.html#pytest-fixtures-explicit-modular-
 import pytest
 from boxwise_flask.models.base import Base
 from boxwise_flask.models.base_module import BaseModule
+from boxwise_flask.models.beneficiary import Beneficiary
 from boxwise_flask.models.box import Box
 from boxwise_flask.models.box_state import BoxState
 from boxwise_flask.models.language import Language
@@ -52,6 +53,7 @@ MODELS = (
     QRCode,
     Base,
     BaseModule,
+    Beneficiary,
     Box,
     BoxState,
     Language,

--- a/flask/test/auth_tests/conftest.py
+++ b/flask/test/auth_tests/conftest.py
@@ -10,67 +10,12 @@ https://docs.pytest.org/en/stable/fixture.html#pytest-fixtures-explicit-modular-
 """
 
 import pytest
-from boxwise_flask.models.base import Base
-from boxwise_flask.models.base_module import BaseModule
-from boxwise_flask.models.beneficiary import Beneficiary
-from boxwise_flask.models.box import Box
-from boxwise_flask.models.box_state import BoxState
-from boxwise_flask.models.language import Language
-from boxwise_flask.models.location import Location
-from boxwise_flask.models.organisation import Organisation
-from boxwise_flask.models.product import Product
-from boxwise_flask.models.product_category import ProductCategory
-from boxwise_flask.models.product_gender import ProductGender
-from boxwise_flask.models.qr_code import QRCode
-from boxwise_flask.models.size import Size
-from boxwise_flask.models.size_range import SizeRange
-from boxwise_flask.models.transaction import Transaction
-from boxwise_flask.models.user import User
-from boxwise_flask.models.usergroup import Usergroup
-from boxwise_flask.models.usergroup_access_level import UsergroupAccessLevel
-from boxwise_flask.models.usergroup_base_access import UsergroupBaseAccess
+from boxwise_flask.models import MODELS
 
 # Imports fixtures into tests
-from data.base import default_base  # noqa: F401
-from data.base import default_bases  # noqa: F401
-from data.box import default_box  # noqa: F401
-from data.box_state import default_box_state  # noqa: F401
-from data.location import default_location  # noqa: F401
-from data.organisation import default_organisation  # noqa: F401
-from data.product import default_product  # noqa: F401
-from data.product_category import default_product_category  # noqa: F401
-from data.product_gender import default_product_gender  # noqa: F401
-from data.qr_code import default_qr_code  # noqa: F401
+from data import *  # noqa: F401,F403
 from data.setup_tables import setup_tables
-from data.size_range import default_size_range  # noqa: F401
-from data.user import default_user  # noqa: F401
-from data.user import default_users  # noqa: F401
-from data.usergroup import default_usergroup  # noqa: F401
-from data.usergroup_access_level import default_usergroup_access_level  # noqa: F401
-from data.usergroup_base_access import default_usergroup_base_access_list  # noqa: F401
 from peewee import SqliteDatabase
-
-MODELS = (
-    QRCode,
-    Base,
-    BaseModule,
-    Beneficiary,
-    Box,
-    BoxState,
-    Language,
-    Location,
-    Organisation,
-    Product,
-    ProductCategory,
-    ProductGender,
-    Size,
-    SizeRange,
-    Transaction,
-    User,
-    Usergroup,
-    UsergroupAccessLevel,
-    UsergroupBaseAccess,
-)
 
 
 @pytest.fixture(autouse=True)

--- a/flask/test/auth_tests/conftest.py
+++ b/flask/test/auth_tests/conftest.py
@@ -24,6 +24,7 @@ from boxwise_flask.models.product_gender import ProductGender
 from boxwise_flask.models.qr_code import QRCode
 from boxwise_flask.models.size import Size
 from boxwise_flask.models.size_range import SizeRange
+from boxwise_flask.models.transaction import Transaction
 from boxwise_flask.models.user import User
 from boxwise_flask.models.usergroup import Usergroup
 from boxwise_flask.models.usergroup_access_level import UsergroupAccessLevel
@@ -64,6 +65,7 @@ MODELS = (
     ProductGender,
     Size,
     SizeRange,
+    Transaction,
     User,
     Usergroup,
     UsergroupAccessLevel,

--- a/flask/test/data/__init__.py
+++ b/flask/test/data/__init__.py
@@ -1,0 +1,38 @@
+from .base import default_base, default_bases
+from .beneficiary import default_beneficiary
+from .box import default_box
+from .box_state import default_box_state
+from .location import default_location
+from .organisation import default_organisation
+from .product import default_product
+from .product_category import default_product_category
+from .product_gender import default_product_gender
+from .qr_code import default_qr_code, qr_code_without_box
+from .size_range import default_size_range
+from .transaction import default_transaction
+from .user import default_user, default_users
+from .usergroup import default_usergroup
+from .usergroup_access_level import default_usergroup_access_level
+from .usergroup_base_access import default_usergroup_base_access_list
+
+__all__ = [
+    "default_beneficiary",
+    "default_base",
+    "default_bases",
+    "default_box",
+    "default_box_state",
+    "default_location",
+    "default_organisation",
+    "default_product",
+    "default_product_category",
+    "default_product_gender",
+    "default_qr_code",
+    "default_size_range",
+    "default_transaction",
+    "default_user",
+    "default_usergroup",
+    "default_usergroup_access_level",
+    "default_usergroup_base_access_list",
+    "default_users",
+    "qr_code_without_box",
+]

--- a/flask/test/data/__init__.py
+++ b/flask/test/data/__init__.py
@@ -9,6 +9,7 @@ from .product import default_product
 from .product_category import default_product_category
 from .product_gender import default_product_gender
 from .qr_code import default_qr_code, qr_code_without_box
+from .settings import default_settings
 from .size_range import default_size_range
 from .transaction import default_transaction
 from .user import default_user, default_users
@@ -29,6 +30,7 @@ __all__ = [
     "default_product_category",
     "default_product_gender",
     "default_qr_code",
+    "default_settings",
     "default_size_range",
     "default_transaction",
     "default_user",

--- a/flask/test/data/__init__.py
+++ b/flask/test/data/__init__.py
@@ -2,6 +2,7 @@ from .base import default_base, default_bases
 from .beneficiary import default_beneficiary
 from .box import default_box
 from .box_state import default_box_state
+from .history import default_history
 from .location import default_location
 from .log import default_log
 from .organisation import default_organisation
@@ -23,6 +24,7 @@ __all__ = [
     "default_bases",
     "default_box",
     "default_box_state",
+    "default_history",
     "default_location",
     "default_log",
     "default_organisation",

--- a/flask/test/data/__init__.py
+++ b/flask/test/data/__init__.py
@@ -3,6 +3,7 @@ from .beneficiary import default_beneficiary
 from .box import default_box
 from .box_state import default_box_state
 from .location import default_location
+from .log import default_log
 from .organisation import default_organisation
 from .product import default_product
 from .product_category import default_product_category
@@ -22,6 +23,7 @@ __all__ = [
     "default_box",
     "default_box_state",
     "default_location",
+    "default_log",
     "default_organisation",
     "default_product",
     "default_product_category",

--- a/flask/test/data/beneficiary.py
+++ b/flask/test/data/beneficiary.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+import pytest
+from boxwise_flask.models.beneficiary import Beneficiary
+from data.base import default_base_data
+
+TIME = datetime.now()
+
+
+def default_beneficiary_data():
+    return {
+        "id": 3,
+        "base": default_base_data()["id"],
+        "comments": "",
+        "created": TIME,
+        "created_by": None,
+        "deleted": TIME,
+        "family_id": 10,
+        "seq": 3,
+        # must not be empty acc. to Model definition
+        "bicycle_ban_comment": "",
+        "workshop_ban_comment": "",
+    }
+
+
+@pytest.fixture()
+def default_beneficiary():
+    return default_beneficiary_data()
+
+
+def create_default_beneficiary():
+    Beneficiary.create(**default_beneficiary_data())

--- a/flask/test/data/history.py
+++ b/flask/test/data/history.py
@@ -1,0 +1,16 @@
+import pytest
+from boxwise_flask.models.history import DbChangeHistory
+
+
+def default_history_data():
+    mock_history = {"id": 112, "changes": "Changes"}
+    return mock_history
+
+
+@pytest.fixture()
+def default_history():
+    return default_history_data()
+
+
+def create_default_history():
+    DbChangeHistory.create(**default_history_data())

--- a/flask/test/data/log.py
+++ b/flask/test/data/log.py
@@ -1,0 +1,16 @@
+import pytest
+from boxwise_flask.models.log import Log
+
+
+def default_log_data():
+    mock_log = {"id": 111, "content": "Content"}
+    return mock_log
+
+
+@pytest.fixture()
+def default_log():
+    return default_log_data()
+
+
+def create_default_log():
+    Log.create(**default_log_data())

--- a/flask/test/data/settings.py
+++ b/flask/test/data/settings.py
@@ -1,0 +1,20 @@
+import pytest
+from boxwise_flask.models.settings import Settings
+
+
+def default_settings_data():
+    mock_settings = {
+        "id": 111,
+        "category_id": 8,
+        "code": "CODE",
+    }
+    return mock_settings
+
+
+@pytest.fixture()
+def default_settings():
+    return default_settings_data()
+
+
+def create_default_settings():
+    Settings.create(**default_settings_data())

--- a/flask/test/data/setup_tables.py
+++ b/flask/test/data/setup_tables.py
@@ -3,6 +3,7 @@ from data.beneficiary import create_default_beneficiary
 from data.box import create_default_box
 from data.box_state import create_default_box_state
 from data.location import create_default_location
+from data.log import create_default_log
 from data.organisation import create_default_organisation
 from data.product import create_default_product
 from data.product_category import create_default_product_category
@@ -22,6 +23,7 @@ def setup_tables():
     create_default_box()
     create_default_box_state()
     create_default_location()
+    create_default_log()
     create_default_organisation()
     create_default_qr_code()
     create_qr_code_without_box()

--- a/flask/test/data/setup_tables.py
+++ b/flask/test/data/setup_tables.py
@@ -2,6 +2,7 @@ from data.base import create_default_bases
 from data.beneficiary import create_default_beneficiary
 from data.box import create_default_box
 from data.box_state import create_default_box_state
+from data.history import create_default_history
 from data.location import create_default_location
 from data.log import create_default_log
 from data.organisation import create_default_organisation
@@ -23,6 +24,7 @@ def setup_tables():
     create_default_beneficiary()
     create_default_box()
     create_default_box_state()
+    create_default_history()
     create_default_location()
     create_default_log()
     create_default_organisation()

--- a/flask/test/data/setup_tables.py
+++ b/flask/test/data/setup_tables.py
@@ -9,6 +9,7 @@ from data.product_category import create_default_product_category
 from data.product_gender import create_default_product_gender
 from data.qr_code import create_default_qr_code, create_qr_code_without_box
 from data.size_range import create_default_size_range
+from data.transaction import create_default_transaction
 from data.user import create_default_users
 from data.usergroup import create_default_usergroup
 from data.usergroup_access_level import create_default_usergroup_access_level
@@ -32,3 +33,4 @@ def setup_tables():
     create_default_product_category()
     create_default_product_gender()
     create_default_size_range()
+    create_default_transaction()

--- a/flask/test/data/setup_tables.py
+++ b/flask/test/data/setup_tables.py
@@ -9,6 +9,7 @@ from data.product import create_default_product
 from data.product_category import create_default_product_category
 from data.product_gender import create_default_product_gender
 from data.qr_code import create_default_qr_code, create_qr_code_without_box
+from data.settings import create_default_settings
 from data.size_range import create_default_size_range
 from data.transaction import create_default_transaction
 from data.user import create_default_users
@@ -27,6 +28,7 @@ def setup_tables():
     create_default_organisation()
     create_default_qr_code()
     create_qr_code_without_box()
+    create_default_settings()
     create_default_users()
     create_default_usergroup()
     create_default_usergroup_access_level()

--- a/flask/test/data/setup_tables.py
+++ b/flask/test/data/setup_tables.py
@@ -1,4 +1,5 @@
 from data.base import create_default_bases
+from data.beneficiary import create_default_beneficiary
 from data.box import create_default_box
 from data.box_state import create_default_box_state
 from data.location import create_default_location
@@ -16,6 +17,7 @@ from data.usergroup_base_access import create_default_usergroup_base_access_list
 
 def setup_tables():
     create_default_bases()
+    create_default_beneficiary()
     create_default_box()
     create_default_box_state()
     create_default_location()

--- a/flask/test/data/transaction.py
+++ b/flask/test/data/transaction.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+import pytest
+from boxwise_flask.models.transaction import Transaction
+from data.beneficiary import default_beneficiary_data
+from data.product import default_product_data
+from data.user import default_user_data
+
+TIME = datetime.now()
+
+
+def default_transaction_data():
+    return {
+        "id": 4,
+        "beneficiary": default_beneficiary_data()["id"],
+        "count": 99,
+        "description": "a transaction",
+        "product": default_product_data()["id"],
+        "transaction_date": TIME,
+        "user": default_user_data()["id"],
+    }
+
+
+@pytest.fixture()
+def default_transaction():
+    return default_transaction_data()
+
+
+def create_default_transaction():
+    Transaction.create(**default_transaction_data())

--- a/flask/test/endpoint_tests/conftest.py
+++ b/flask/test/endpoint_tests/conftest.py
@@ -15,72 +15,15 @@ import tempfile
 import pytest
 from boxwise_flask.app import create_app
 from boxwise_flask.db import db
-from boxwise_flask.models.base import Base
-from boxwise_flask.models.base_module import BaseModule
-from boxwise_flask.models.beneficiary import Beneficiary
-from boxwise_flask.models.box import Box
-from boxwise_flask.models.box_state import BoxState
-from boxwise_flask.models.language import Language
-from boxwise_flask.models.location import Location
-from boxwise_flask.models.organisation import Organisation
-from boxwise_flask.models.product import Product
-from boxwise_flask.models.product_category import ProductCategory
-from boxwise_flask.models.product_gender import ProductGender
-from boxwise_flask.models.qr_code import QRCode
-from boxwise_flask.models.size import Size
-from boxwise_flask.models.size_range import SizeRange
-from boxwise_flask.models.transaction import Transaction
-from boxwise_flask.models.user import User
-from boxwise_flask.models.usergroup import Usergroup
-from boxwise_flask.models.usergroup_access_level import UsergroupAccessLevel
-from boxwise_flask.models.usergroup_base_access import UsergroupBaseAccess
+from boxwise_flask.models import MODELS
 
 # Imports fixtures into tests
-from data.base import default_base  # noqa: F401
-from data.base import default_bases  # noqa: F401
-from data.box import default_box  # noqa: F401
-from data.box_state import default_box_state  # noqa: F401
-from data.location import default_location  # noqa: F401
-from data.organisation import default_organisation  # noqa: F401
-from data.product import default_product  # noqa: F401
-from data.product_category import default_product_category  # noqa: F401
-from data.product_gender import default_product_gender  # noqa: F401
-from data.qr_code import default_qr_code  # noqa: F401
-from data.qr_code import qr_code_without_box  # noqa: F401
+from data import *  # noqa: F401,F403
 from data.setup_tables import setup_tables
-from data.size_range import default_size_range  # noqa: F401
-from data.user import default_user  # noqa: F401
-from data.user import default_users  # noqa: F401
-from data.usergroup import default_usergroup  # noqa: F401
-from data.usergroup_access_level import default_usergroup_access_level  # noqa: F401
-from data.usergroup_base_access import default_usergroup_base_access_list  # noqa: F401
 from patches import authorization_test_patch, requires_auth_patch
 
 requires_auth_patch.start()
 authorization_test_patch.start()
-
-
-MODELS = (
-    Base,
-    BaseModule,
-    Beneficiary,
-    Box,
-    BoxState,
-    Language,
-    Location,
-    Organisation,
-    Product,
-    ProductCategory,
-    ProductGender,
-    QRCode,
-    Size,
-    SizeRange,
-    Transaction,
-    User,
-    Usergroup,
-    UsergroupAccessLevel,
-    UsergroupBaseAccess,
-)
 
 
 @pytest.fixture()

--- a/flask/test/endpoint_tests/conftest.py
+++ b/flask/test/endpoint_tests/conftest.py
@@ -17,6 +17,7 @@ from boxwise_flask.app import create_app
 from boxwise_flask.db import db
 from boxwise_flask.models.base import Base
 from boxwise_flask.models.base_module import BaseModule
+from boxwise_flask.models.beneficiary import Beneficiary
 from boxwise_flask.models.box import Box
 from boxwise_flask.models.box_state import BoxState
 from boxwise_flask.models.language import Language
@@ -61,6 +62,7 @@ authorization_test_patch.start()
 MODELS = (
     Base,
     BaseModule,
+    Beneficiary,
     Box,
     BoxState,
     Language,

--- a/flask/test/endpoint_tests/conftest.py
+++ b/flask/test/endpoint_tests/conftest.py
@@ -29,6 +29,7 @@ from boxwise_flask.models.product_gender import ProductGender
 from boxwise_flask.models.qr_code import QRCode
 from boxwise_flask.models.size import Size
 from boxwise_flask.models.size_range import SizeRange
+from boxwise_flask.models.transaction import Transaction
 from boxwise_flask.models.user import User
 from boxwise_flask.models.usergroup import Usergroup
 from boxwise_flask.models.usergroup_access_level import UsergroupAccessLevel
@@ -74,6 +75,7 @@ MODELS = (
     QRCode,
     Size,
     SizeRange,
+    Transaction,
     User,
     Usergroup,
     UsergroupAccessLevel,

--- a/flask/test/model_tests/conftest.py
+++ b/flask/test/model_tests/conftest.py
@@ -24,6 +24,7 @@ from boxwise_flask.models.product_gender import ProductGender
 from boxwise_flask.models.qr_code import QRCode
 from boxwise_flask.models.size import Size
 from boxwise_flask.models.size_range import SizeRange
+from boxwise_flask.models.transaction import Transaction
 from boxwise_flask.models.user import User
 from boxwise_flask.models.usergroup import Usergroup
 from boxwise_flask.models.usergroup_access_level import UsergroupAccessLevel
@@ -43,6 +44,7 @@ from data.product_gender import default_product_gender  # noqa: F401
 from data.qr_code import default_qr_code  # noqa: F401
 from data.setup_tables import setup_tables
 from data.size_range import default_size_range  # noqa: F401
+from data.transaction import default_transaction  # noqa: F401
 from data.user import default_user  # noqa: F401
 from data.user import default_users  # noqa: F401
 from data.usergroup import default_usergroup  # noqa: F401
@@ -65,6 +67,7 @@ MODELS = (
     ProductGender,
     Size,
     SizeRange,
+    Transaction,
     User,
     Usergroup,
     UsergroupAccessLevel,

--- a/flask/test/model_tests/conftest.py
+++ b/flask/test/model_tests/conftest.py
@@ -12,6 +12,7 @@ https://docs.pytest.org/en/stable/fixture.html#pytest-fixtures-explicit-modular-
 import pytest
 from boxwise_flask.models.base import Base
 from boxwise_flask.models.base_module import BaseModule
+from boxwise_flask.models.beneficiary import Beneficiary
 from boxwise_flask.models.box import Box
 from boxwise_flask.models.box_state import BoxState
 from boxwise_flask.models.language import Language
@@ -31,6 +32,7 @@ from boxwise_flask.models.usergroup_base_access import UsergroupBaseAccess
 # Imports fixtures into tests
 from data.base import default_base  # noqa: F401
 from data.base import default_bases  # noqa: F401
+from data.beneficiary import default_beneficiary  # noqa: F401
 from data.box import default_box  # noqa: F401
 from data.box_state import default_box_state  # noqa: F401
 from data.location import default_location  # noqa: F401
@@ -52,6 +54,7 @@ MODELS = (
     QRCode,
     Base,
     BaseModule,
+    Beneficiary,
     Box,
     BoxState,
     Language,

--- a/flask/test/model_tests/conftest.py
+++ b/flask/test/model_tests/conftest.py
@@ -10,69 +10,12 @@ https://docs.pytest.org/en/stable/fixture.html#pytest-fixtures-explicit-modular-
 """
 
 import pytest
-from boxwise_flask.models.base import Base
-from boxwise_flask.models.base_module import BaseModule
-from boxwise_flask.models.beneficiary import Beneficiary
-from boxwise_flask.models.box import Box
-from boxwise_flask.models.box_state import BoxState
-from boxwise_flask.models.language import Language
-from boxwise_flask.models.location import Location
-from boxwise_flask.models.organisation import Organisation
-from boxwise_flask.models.product import Product
-from boxwise_flask.models.product_category import ProductCategory
-from boxwise_flask.models.product_gender import ProductGender
-from boxwise_flask.models.qr_code import QRCode
-from boxwise_flask.models.size import Size
-from boxwise_flask.models.size_range import SizeRange
-from boxwise_flask.models.transaction import Transaction
-from boxwise_flask.models.user import User
-from boxwise_flask.models.usergroup import Usergroup
-from boxwise_flask.models.usergroup_access_level import UsergroupAccessLevel
-from boxwise_flask.models.usergroup_base_access import UsergroupBaseAccess
+from boxwise_flask.models import MODELS
 
 # Imports fixtures into tests
-from data.base import default_base  # noqa: F401
-from data.base import default_bases  # noqa: F401
-from data.beneficiary import default_beneficiary  # noqa: F401
-from data.box import default_box  # noqa: F401
-from data.box_state import default_box_state  # noqa: F401
-from data.location import default_location  # noqa: F401
-from data.organisation import default_organisation  # noqa: F401
-from data.product import default_product  # noqa: F401
-from data.product_category import default_product_category  # noqa: F401
-from data.product_gender import default_product_gender  # noqa: F401
-from data.qr_code import default_qr_code  # noqa: F401
+from data import *  # noqa: F401,F403
 from data.setup_tables import setup_tables
-from data.size_range import default_size_range  # noqa: F401
-from data.transaction import default_transaction  # noqa: F401
-from data.user import default_user  # noqa: F401
-from data.user import default_users  # noqa: F401
-from data.usergroup import default_usergroup  # noqa: F401
-from data.usergroup_access_level import default_usergroup_access_level  # noqa: F401
-from data.usergroup_base_access import default_usergroup_base_access_list  # noqa: F401
 from peewee import SqliteDatabase
-
-MODELS = (
-    QRCode,
-    Base,
-    BaseModule,
-    Beneficiary,
-    Box,
-    BoxState,
-    Language,
-    Location,
-    Organisation,
-    Product,
-    ProductCategory,
-    ProductGender,
-    Size,
-    SizeRange,
-    Transaction,
-    User,
-    Usergroup,
-    UsergroupAccessLevel,
-    UsergroupBaseAccess,
-)
 
 
 @pytest.fixture(autouse=True)

--- a/flask/test/model_tests/test_beneficiary.py
+++ b/flask/test/model_tests/test_beneficiary.py
@@ -1,0 +1,20 @@
+import pytest
+from boxwise_flask.models.beneficiary import Beneficiary
+from playhouse.shortcuts import model_to_dict
+
+
+@pytest.mark.usefixtures("default_base")
+@pytest.mark.usefixtures("default_beneficiary")
+def test_beneficiary_model(default_base, default_beneficiary):
+    queried_beneficiary = Beneficiary.get_by_id(default_beneficiary["id"])
+
+    queried_beneficiary_dict = model_to_dict(queried_beneficiary)
+
+    assert queried_beneficiary_dict["id"] == default_beneficiary["id"]
+    assert queried_beneficiary_dict["comments"] == default_beneficiary["comments"]
+    assert queried_beneficiary_dict["created"] == default_beneficiary["created"]
+    assert queried_beneficiary_dict["created_by"] == default_beneficiary["created_by"]
+    assert queried_beneficiary_dict["deleted"] == default_beneficiary["deleted"]
+    assert queried_beneficiary_dict["family_id"] == default_beneficiary["family_id"]
+    assert queried_beneficiary_dict["seq"] == default_beneficiary["seq"]
+    assert queried_beneficiary_dict["base"]["id"] == default_base["id"]

--- a/flask/test/model_tests/test_history.py
+++ b/flask/test/model_tests/test_history.py
@@ -1,0 +1,9 @@
+import pytest
+from boxwise_flask.models.history import DbChangeHistory
+
+
+@pytest.mark.usefixtures("default_history")
+def test_history_model(default_history):
+    query = DbChangeHistory.get_by_id(default_history["id"])
+
+    assert query.changes == default_history["changes"]

--- a/flask/test/model_tests/test_log.py
+++ b/flask/test/model_tests/test_log.py
@@ -1,0 +1,12 @@
+import pytest
+from boxwise_flask.models.log import Log
+
+
+@pytest.mark.usefixtures("default_log")
+def test_log_model(default_log):
+    query = Log.get_by_id(default_log["id"])
+
+    assert query.content == "Content"
+    assert query.ip is None
+    assert query.date is None
+    assert query.user is None

--- a/flask/test/model_tests/test_settings.py
+++ b/flask/test/model_tests/test_settings.py
@@ -1,0 +1,10 @@
+import pytest
+from boxwise_flask.models.settings import Settings
+
+
+@pytest.mark.usefixtures("default_settings")
+def test_settings_model(default_settings):
+    query = Settings.get_by_id(default_settings["id"])
+
+    assert query.category_id == default_settings["category_id"]
+    assert query.code == default_settings["code"]

--- a/flask/test/model_tests/test_transaction.py
+++ b/flask/test/model_tests/test_transaction.py
@@ -1,0 +1,22 @@
+import pytest
+from boxwise_flask.models.transaction import Transaction
+from playhouse.shortcuts import model_to_dict
+
+
+@pytest.mark.usefixtures("default_transaction")
+@pytest.mark.usefixtures("default_beneficiary")
+@pytest.mark.usefixtures("default_product")
+@pytest.mark.usefixtures("default_user")
+def test_beneficiary_model(
+    default_transaction, default_beneficiary, default_product, default_user
+):
+    query = Transaction.get_by_id(default_transaction["id"])
+
+    query_dict = model_to_dict(query)
+
+    assert query_dict["id"] == default_transaction["id"]
+    assert query_dict["beneficiary"]["id"] == default_beneficiary["id"]
+    assert query_dict["count"] == default_transaction["count"]
+    assert query_dict["description"] == default_transaction["description"]
+    assert query_dict["product"]["id"] == default_product["id"]
+    assert query_dict["user"]["id"] == default_user["id"]


### PR DESCRIPTION
Just wanting to get some early feedback here - I added four new peewee models using pwiz (two are covered by unit tests).
Following the 'Python Models Import for Peewee document', the following transfers are still missing
* people_tags
* tags
* x_people_languages
* history (mentioned twice in the document with ChangeHistory / DBChangeHistory as Python model)

1. Should I add those here?
2. Regarding the field naming: do we go for underscored names rather?