### PR TITLE
Configure dependabot to update pip and npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/flask/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "pylipp"
+  - package-ecosystem: "npm"
+    directory: "/react/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Basically followed the instructions [here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) and in the sibling pages.
Are you fine with the values for the check interval?
In the beginning we'll probably see some PRs to get all dependencies up-to-date.