### PR TITLE
Proof of concept: box resolvers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           command: |
             source env/bin/activate
             mkdir test-results
-            pytest --cov-report xml:test-results/coverage.xml --cov=. -k 'not test_backend_connection' test
+            pytest --cov-report xml:test-results/coverage.xml --cov=. --ignore test/endpoint_tests/test_app.py test
       # https://circleci.com/docs/2.0/postgres-config/#example-mysql-project
       - run:
       # Our primary container isn't MYSQL so run a sleep command until it's ready.
@@ -163,7 +163,7 @@ jobs:
           name: Run pytest for integration tests
           command: |
             source env/bin/activate
-            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=. -k test_backend_connection test
+            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=. test/endpoint_tests/test_app.py
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
           name: Run pytest for integration tests
           command: |
             source env/bin/activate
-            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=. test -k 'backend or box_details or boxes_by'
+            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=. test -k 'box_details or get_boxes'
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           command: |
             source env/bin/activate
             mkdir test-results
-            pytest --cov-report xml:test-results/coverage.xml --cov=. --ignore test/endpoint_tests/test_app.py test
+            pytest --cov-report xml:test-results/coverage.xml --cov=boxwise_flask --ignore test/endpoint_tests/test_app.py test
       # https://circleci.com/docs/2.0/postgres-config/#example-mysql-project
       - run:
       # Our primary container isn't MYSQL so run a sleep command until it's ready.
@@ -163,7 +163,7 @@ jobs:
           name: Run pytest for integration tests
           command: |
             source env/bin/activate
-            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=. test -k 'box_details or get_boxes'
+            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=boxwise_flask -k 'box_details or get_boxes' test
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,13 +135,6 @@ jobs:
           key: precommit-deps-{{ checksum "../.pre-commit-config.yaml" }}
           paths:
             - ~/.cache/pre-commit
-      # run tests https://circleci.com/docs/2.0/collect-test-data/#pytest
-      - run:
-          name: Run pytest for unit tests
-          command: |
-            source env/bin/activate
-            mkdir test-results
-            pytest --cov-report xml:test-results/coverage.xml --cov=boxwise_flask --ignore test/endpoint_tests/test_app.py test
       # https://circleci.com/docs/2.0/postgres-config/#example-mysql-project
       - run:
       # Our primary container isn't MYSQL so run a sleep command until it's ready.
@@ -159,11 +152,12 @@ jobs:
           command: |
             sudo apt-get install default-mysql-client
             mysql -h 127.0.0.1 -u root -pdropapp_root dropapp_dev < init.sql
+      # run tests https://circleci.com/docs/2.0/collect-test-data/#pytest
       - run:
-          name: Run pytest for integration tests
+          name: Run pytest
           command: |
             source env/bin/activate
-            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=boxwise_flask -k 'box_details or get_boxes' test
+            pytest --cov-report xml:test-results/coverage.xml --cov=boxwise_flask
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
           name: Run pytest for integration tests
           command: |
             source env/bin/activate
-            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=. test/endpoint_tests/test_app.py
+            pytest --cov-report xml:test-results/coverage.xml --cov-append --cov=. test -k 'backend or box_details or boxes_by'
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
             - ./flask/init.sql:/docker-entrypoint-initdb.d/init.sql
         ports:
             # <Port exposed> : < MySQL Port running inside container>
-            - 32000:3306
+            - 3306:3306
         networks:
             - backend
 

--- a/flask/README.md
+++ b/flask/README.md
@@ -196,7 +196,7 @@ Test data is setup in the `test/data` folder and each piece of data is split up 
 
 From the repository root, run
 
-    pytest --cov --cov-report=term --cov-report=html flask
+    pytest --cov=flask/boxwise_flask --cov-report=term --cov-report=html flask
 
 and inspect the reported output. Open the HTML report via `flask/htmlcov/index.html` to browse coverage for individual source code files.
 

--- a/flask/README.md
+++ b/flask/README.md
@@ -69,7 +69,7 @@ To access the mysql database, there are now three possibilities:
 
 1. You reach the mysql db at `MYSQL_HOST=mysql` and `MYSQL_PORT=3306` or
 1. You execute the mysql command line client in the running container by `docker-compose exec mysql mysql -u root -p` or
-1. by specifying the IP-address of the gateway for `MYSQL_HOST` and `MYSQL_PORT=32000`.
+1. by specifying the IP-address of the gateway for `MYSQL_HOST` and `MYSQL_PORT=3306`.
 
 To figure out the gateway of the docker network `backend` run
 
@@ -77,7 +77,7 @@ To figure out the gateway of the docker network `backend` run
 
 #### MySQL workbend or other editors
 
-Most of our developers use [MySQL workbench](https://dev.mysql.com/doc/workbench/en/wb-installing.html) to interact with the database directly. If you want to connect to the database, choose one of the possibilities in the former to define the connection, e.g. Hostname is 172.18.0.1 and Port is 32000.
+Most of our developers use [MySQL workbench](https://dev.mysql.com/doc/workbench/en/wb-installing.html) to interact with the database directly. If you want to connect to the database, choose one of the possibilities in the former to define the connection, e.g. Hostname is 172.18.0.1 and Port is 3306.
 
 The development database is called `dropapp_dev` and the password is `dropapp_root`.
 
@@ -92,7 +92,7 @@ The `pwiz` utility helps to generate peewee model definitions by inspecting a ru
 
 1. Start the database by `docker-compose up mysql`
 1. Obtain the gateway IP of the Docker network `boxtribute_backend` as described above.
-1. Run `python -m pwiz -H XXX.XX.X.X -p 32000 -u root -e mysql -t camps -P dropapp_dev > base.py` to generate the model definitions of the `camps` table, and write them into the file `base.py`.
+1. Run `python -m pwiz -H XXX.XX.X.X -p 3306 -u root -e mysql -t camps -P dropapp_dev > base.py` to generate the model definitions of the `camps` table, and write them into the file `base.py`.
 
 ### Debugging
 
@@ -136,11 +136,18 @@ and log with:
 
 ## Testing
 
-### Writing tests
+### Executing tests
 
 Run the test suite on your machine by executing
 
     pytest
+
+Some tests require a running MySQL server and are disabled unless during a CircleCI pipeline. Local testing is possible by
+
+    docker-compose up -d mysql
+    CIRCLECI=1 pytest
+
+### Writing tests
 
 Two types of tests can be setup. Model (unit) tests and endpoint (integration) tests.
 

--- a/flask/README.md
+++ b/flask/README.md
@@ -202,16 +202,21 @@ and inspect the reported output. Open the HTML report via `flask/htmlcov/index.h
 
 ## GraphQL Playground
 
-We are setting up GraphQL as a data layer for this application. To check out the GraphQL playground, and go to `localhost:5000/graphql`.
-The GraphQL endpoint is secured and needs a Bearer token from Auth0 to authenticate and authorize. To work with the playground you have to add such a token from Auth0 as an HTTP header. Here, how this works:
+The back-end exposes the GraphQL API at the `/graphql` endpoint. You can experiment with the API in the GraphQL playground.
 
-1.  Follow this [link](https://manage.auth0.com/dashboard/eu/boxtribute-dev/apis/5ef3760527b0da00215e6209/test) to receive a token for testing. You can also find this token in Auth0 in the menu > API > boxtribute-dev-api > Test-tab.
-
-2.  Insert the access token in the following format on the playground in the section on the bottom left of the playground called HTTP Headers.
+1. Start the required services by `docker-compose up flask mysql`
+1. Open `localhost:5000/graphql`.
+1. Simulate being a valid, logged-in user (here: `admin@admin.co`) by fetching an authorization token (use client ID and secret from the boxtribute-dev-api test application from the Auth0 website)
+    curl --request POST \
+         --url https://boxtribute-dev.eu.auth0.com/oauth/token \
+         --header 'content-type: application/json' \
+         --data '{"client_id":"***","client_secret":"***","audience":"boxtribute-dev-api","grant_type":"password","username":"admin@admin.co","password":"Browser_tests"}'
+1. Copy the content of the `access_token` field (alternatively, you can pipe the above command ` | jq -r .access_token | xclip -i -selection c` to copy it to the system clipboard)
+1.  Insert the access token in the following format on the playground in the section on the bottom left of the playground called HTTP Headers.
 
         { "authorization": "Bearer <the token you retrieved from Auth0>"}
 
-A sample query you can try if it works is:
+1. A sample query you can try if it works is:
 
     query {
         allBases {

--- a/flask/boxwise_flask/graph_ql/query_defs.py
+++ b/flask/boxwise_flask/graph_ql/query_defs.py
@@ -10,10 +10,9 @@ query_defs = gql(
         base(id: Int!): Base
         allUsers: [User]
         user(email: String): User
-        box(qr_code: String): Box
         qrExists(qr_code: String): Boolean
         qrBoxExists(qr_code: String): Boolean
-        getBoxDetails(box_id: Int!): Box
+        getBoxDetails(box_id: Int, qr_code: String): Box
         getBoxesByLocation(location_id: Int!): [Box]
     }
     """

--- a/flask/boxwise_flask/graph_ql/query_defs.py
+++ b/flask/boxwise_flask/graph_ql/query_defs.py
@@ -14,6 +14,7 @@ query_defs = gql(
         qrExists(qr_code: String): Boolean
         qrBoxExists(qr_code: String): Boolean
         getBoxDetails(box_id: Int!): Box
+        getBoxesByLocation(location_id: Int!): [Box]
     }
     """
 )

--- a/flask/boxwise_flask/graph_ql/query_defs.py
+++ b/flask/boxwise_flask/graph_ql/query_defs.py
@@ -6,14 +6,14 @@ query_defs = gql(
     type Query {
         hello: String!
         allBases: [Base]
-        orgBases(org_id: Int): [Base]
+        orgBases(orgId: Int): [Base]
         base(id: Int!): Base
         allUsers: [User]
         user(email: String): User
-        qrExists(qr_code: String): Boolean
-        qrBoxExists(qr_code: String): Boolean
-        getBoxDetails(box_id: Int, qr_code: String): Box
-        getBoxesByLocation(location_id: Int!): [Box]
+        qrExists(qrCode: String): Boolean
+        qrBoxExists(qrCode: String): Boolean
+        getBoxDetails(boxId: Int, qrCode: String): Box
+        getBoxesByLocation(locationId: Int!): [Box]
     }
     """
 )

--- a/flask/boxwise_flask/graph_ql/query_defs.py
+++ b/flask/boxwise_flask/graph_ql/query_defs.py
@@ -13,6 +13,7 @@ query_defs = gql(
         box(qr_code: String): Box
         qrExists(qr_code: String): Boolean
         qrBoxExists(qr_code: String): Boolean
+        getBoxDetails(box_id: Int!): Box
     }
     """
 )

--- a/flask/boxwise_flask/graph_ql/query_defs.py
+++ b/flask/boxwise_flask/graph_ql/query_defs.py
@@ -14,6 +14,7 @@ query_defs = gql(
         qrBoxExists(qrCode: String): Boolean
         getBoxDetails(boxId: Int, qrCode: String): Box
         getBoxesByLocation(locationId: Int!): [Box]
+        getBoxesByGender(genderId: ProductGender!): [Box]
     }
     """
 )

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -91,7 +91,9 @@ def resolve_qr_box_exists(_, info, qr_code):
 @query.field("box")
 def resolve_box(_, info, qr_code):
     qr_id = QRCode.get_id_from_code(qr_code)
-    return Box.get_box_from_qr(qr_id)
+    data = Box.select().where(Box.qr_id == qr_id).dicts().get()
+    data["id"] = data["box_id"]
+    return data
 
 
 @query.field("getBoxDetails")

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -88,17 +88,19 @@ def resolve_qr_box_exists(_, info, qr_code):
     return True
 
 
-@query.field("box")
-def resolve_box(_, info, qr_code):
+@query.field("getBoxDetails")
+def resolve_get_box_details_by_id(_, info, box_id=None, qr_code=None):
+    if bool(box_id) == bool(qr_code):
+        # Either both or none of the arguments are given
+        return None
+
+    elif box_id is not None:
+        return Box.get(Box.box_id == box_id)
+
     qr_id = QRCode.get_id_from_code(qr_code)
     data = Box.select().where(Box.qr_id == qr_id).dicts().get()
     data["id"] = data["box_id"]
     return data
-
-
-@query.field("getBoxDetails")
-def resolve_get_box_details_by_id(_, info, box_id):
-    return Box.get(Box.box_id == box_id)
 
 
 @query.field("getBoxesByLocation")

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -3,6 +3,7 @@ from ariadne import (
     MutationType,
     ObjectType,
     ScalarType,
+    convert_kwargs_to_snake_case,
     gql,
     make_executable_schema,
     snake_case_fallback_resolvers,
@@ -45,6 +46,7 @@ def resolve_all_bases(_, info):
 # not everyone can see all the bases
 # see the comment in https://github.com/boxwise/boxwise-flask/pull/19
 @query.field("orgBases")
+@convert_kwargs_to_snake_case
 def resolve_org_bases(_, info, org_id):
     response = Base.get_for_organisation(org_id)
     return response
@@ -70,6 +72,7 @@ def resolve_user(_, info, email):
 
 
 @query.field("qrExists")
+@convert_kwargs_to_snake_case
 def resolve_qr_exists(_, info, qr_code):
     try:
         QRCode.get_id_from_code(qr_code)
@@ -79,6 +82,7 @@ def resolve_qr_exists(_, info, qr_code):
 
 
 @query.field("qrBoxExists")
+@convert_kwargs_to_snake_case
 def resolve_qr_box_exists(_, info, qr_code):
     try:
         qr_id = QRCode.get_id_from_code(qr_code)
@@ -89,6 +93,7 @@ def resolve_qr_box_exists(_, info, qr_code):
 
 
 @query.field("getBoxDetails")
+@convert_kwargs_to_snake_case
 def resolve_get_box_details_by_id(_, info, box_id=None, qr_code=None):
     if bool(box_id) == bool(qr_code):
         # Either both or none of the arguments are given
@@ -104,6 +109,7 @@ def resolve_get_box_details_by_id(_, info, box_id=None, qr_code=None):
 
 
 @query.field("getBoxesByLocation")
+@convert_kwargs_to_snake_case
 def resolve_get_boxes_by_location(_, info, location_id):
     return Box.select().where(Box.location == location_id)
 

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -133,6 +133,12 @@ def resolve_box_id(obj, info):
     return obj.box_id
 
 
+@box.field("state")
+def resolve_box_state(obj, info):
+    # Instead of a BoxState instance return an integer for EnumType conversion
+    return obj.box_state.id
+
+
 @mutation.field("createBox")
 def create_box(_, info, box_creation_input):
     response = Box.create_box(box_creation_input)
@@ -146,8 +152,14 @@ product_gender_type_def = EnumType(
         "UnisexAdult": 3,
     },
 )
+box_state_type_def = EnumType(
+    "BoxState",
+    {
+        "InStock": 1,
+    },
+)
 schema = make_executable_schema(
     gql(type_defs + query_defs + mutation_defs),
-    [query, mutation, box, product_gender_type_def],
+    [query, mutation, box, product_gender_type_def, box_state_type_def],
     snake_case_fallback_resolvers,
 )

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -90,7 +90,7 @@ def resolve_qr_exists(_, info, qr_code):
 def resolve_qr_box_exists(_, info, qr_code):
     try:
         qr_id = QRCode.get_id_from_code(qr_code)
-        Box.get_box_from_qr(qr_id)
+        Box.get(Box.qr_code == qr_id)
     except Box.DoesNotExist:
         return False
     return True

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -94,6 +94,11 @@ def resolve_box(_, info, qr_code):
     return Box.get_box_from_qr(qr_id)
 
 
+@query.field("getBoxDetails")
+def resolve_get_box_details_by_id(_, info, box_id):
+    return Box.get(Box.box_id == box_id)
+
+
 @mutation.field("createBox")
 def create_box(_, info, box_creation_input):
     response = Box.create_box(box_creation_input)

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -104,7 +104,7 @@ def resolve_get_box_details_by_id(_, info, box_id=None, qr_code=None):
         return None
 
     elif box_id is not None:
-        return Box.get(Box.box_id == box_id)
+        return Box.get(Box.box_label_identifier == box_id)
 
     return Box.select().join(QRCode).where(QRCode.code == qr_code).get()
 
@@ -124,13 +124,6 @@ def resolve_get_boxes_by_gender(_, info, gender_id):
         .join(ProductGender)
         .where(ProductGender.id == gender_id)
     )
-
-
-@box.field("ID")
-def resolve_box_id(obj, info):
-    # Custom resolver because the GraphQL Box.ID field refers to the peewee
-    # Box.box_id field (not id)
-    return obj.box_id
 
 
 @box.field("state")

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -99,6 +99,11 @@ def resolve_get_box_details_by_id(_, info, box_id):
     return Box.get(Box.box_id == box_id)
 
 
+@query.field("getBoxesByLocation")
+def resolve_get_boxes_by_location(_, info, location_id):
+    return Box.select().where(Box.location == location_id)
+
+
 @mutation.field("createBox")
 def create_box(_, info, box_creation_input):
     response = Box.create_box(box_creation_input)

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -106,8 +106,7 @@ def resolve_get_box_details_by_id(_, info, box_id=None, qr_code=None):
     elif box_id is not None:
         return Box.get(Box.box_id == box_id)
 
-    qr_id = QRCode.get_id_from_code(qr_code)
-    return Box.select().where(Box.qr_id == qr_id).get()
+    return Box.select().join(QRCode).where(QRCode.code == qr_code).get()
 
 
 @query.field("getBoxesByLocation")

--- a/flask/boxwise_flask/graph_ql/type_defs.py
+++ b/flask/boxwise_flask/graph_ql/type_defs.py
@@ -150,7 +150,7 @@ type_defs = gql(
         size_id: Int #this is a foreign key
         items: Int
         location_id: Int! #this is a foreign key
-        comments: String!
+        comment: String!
         #this will get looked up to turn into qr_id, which is a foreign key
         qr_barcode: String!
         created: Datetime #this is an output, but not an input

--- a/flask/boxwise_flask/graph_ql/type_defs.py
+++ b/flask/boxwise_flask/graph_ql/type_defs.py
@@ -5,7 +5,7 @@ type_defs = gql(
     """
     type Box{
         ID: ID!
-        boxLabelNumber: Int!
+        boxLabelIdentifier: String!
         location: Location!
         items: Int!
         product: Product!

--- a/flask/boxwise_flask/graph_ql/type_defs.py
+++ b/flask/boxwise_flask/graph_ql/type_defs.py
@@ -3,11 +3,132 @@ from ariadne import gql
 
 type_defs = gql(
     """
-    type Base {
-        id: Int
+    type Box{
+        ID: ID!
+        boxLabelNumber: Int!
+        location: Location!
+        items: Int!
+        product: Product!
+        gender: ProductGender
+        # A size from a size range, consider making this enum
+        size: String!
+        state: BoxState!
+        qrCode: QRCode!
+        createdBy: String!
+        createdOn: Datetime!
+        # The user who last changed something about the box
+        lastModifiedBy: String!
+        lastModifiedOn: Datetime!
+        comment: String
+    }
+
+    type QRCode{
+        ID: ID!
+        code: String!
+        box: Box
+        createdOn: Datetime
+        # The user who generated QR code
+        createdBy: String!
+    }
+
+    type Product{
+        ID: ID!
+        name: String!
+        category: ProductCategory!
+        sizeRange: SizeRange!
+        sizes: [String!]!
+        base: Base!
+        price: Float
+        gender: ProductGender
+        createdBy: String!
+        createdOn: Datetime!
+        # The user who last changed something about the box
+        lastModifiedBy: String!
+        lastModifiedOn: Datetime!
+    }
+
+    type ProductCategory{
+        ID: ID!
+        categoryName: String!
+        products: [Product]
+        sizeRanges: [SizeRange]
+        hasGender: Boolean!
+    }
+
+    enum ProductGender{
+        Men
+        Women
+        UnisexAdult
+        UnisexChild
+        UnisexBaby
+        TeenGirl
+        TeenBoy
+        Girl
+        Boy
+    }
+
+    enum BoxState{
+        InStock
+        Lost
+        Ordered
+        Picked
+        Donated
+        Scrap
+    }
+
+    type SizeRange{
+        ID: ID!
+        label: String!
+        sizes: [String!]!
+        productCategory: [ProductCategory!]
+    }
+
+    type Location{
+        ID: ID!
+        base: Base!
         name: String
+        isShop: Boolean!
+        isDeleted: Boolean!
+        # List of all the boxes in the location
+        boxes: [Box!]
+        hasBoxState: BoxState
+        createdOn: Datetime!
+        # The user who generated QR code
+        createdBy: String!
+        lastModifiedBy: String!
+        lastModifiedOn: Datetime!
+    }
+
+    type Base{
+        ID: ID!
+        name: String!
+        parentOrg: Organisation!
+        locations: [Location!]
         currencyName: String
-        organisationId: Int
+    }
+
+    type Organisation{
+        ID: ID!
+        name: String!
+        bases: [Base!]
+    }
+
+    type Order{
+        ID: ID!
+        fromLocation: String!
+        toLocation: String!
+        # If null means internal transfer
+        fromOrg: Int
+        # If null means internal transfer
+        toOrg: Int
+        boxes: Box!
+        # If box state of all ordered boxes have not yet been changed, then it is active
+        isActive: Boolean!
+        createdBy: String!
+        createdOn: Datetime!
+        lastModifiedBy: String
+        # Need to change int to custom scalar for datetime
+        lastModifiedOn: Int
     }
 
     type User {
@@ -21,20 +142,6 @@ type_defs = gql(
         base_id: [Int]
         lastlogin: Datetime
         lastaction: Datetime
-    }
-
-    type Box {
-        id: Int
-        box_id: String!
-        product_id: Int
-        size_id: Int
-        items: Int
-        location_id: Int
-        comments: String
-        qr_id: Int
-        created: Datetime
-        created_by: String
-        box_state_id: Int
     }
 
     input CreateBoxInput {

--- a/flask/boxwise_flask/models/base.py
+++ b/flask/boxwise_flask/models/base.py
@@ -22,6 +22,7 @@ class Base(db.Model):
     adult_age = IntegerField(constraints=[SQL("DEFAULT 15")])
     created = DateTimeField(null=True)
     created_by = ForeignKeyField(
+        column_name="created_by",
         field="id",
         model=User,
         null=True,

--- a/flask/boxwise_flask/models/box.py
+++ b/flask/boxwise_flask/models/box.py
@@ -143,7 +143,3 @@ class Box(db.Model):
     @staticmethod
     def get_box(box_id):
         return Box.get(Box.box_id == box_id)
-
-    @staticmethod
-    def get_box_from_qr(qr_id):
-        return Box.get(Box.qr_id == qr_id)

--- a/flask/boxwise_flask/models/box.py
+++ b/flask/boxwise_flask/models/box.py
@@ -28,7 +28,7 @@ class Box(db.Model):
         model=BoxState,
         on_update="CASCADE",
     )
-    comments = TextField()
+    comment = TextField(column_name="comments")
     created = DateTimeField(null=True)
     created_by = ForeignKeyField(
         column_name="created_by",
@@ -131,7 +131,7 @@ class Box(db.Model):
             location_id=box_creation_input.get(
                 "location_id", None
             ),  # based on the user's allowed bases
-            comments=box_creation_input.get("comments", None),
+            comment=box_creation_input.get("comment", None),
             qr_id=qr_id_from_table,
             created=today,
             # this is consistently NULL in the table, do we want to change that?

--- a/flask/boxwise_flask/models/box.py
+++ b/flask/boxwise_flask/models/box.py
@@ -20,7 +20,9 @@ from .qr_code import QRCode
 
 
 class Box(db.Model):
-    box_id = CharField(constraints=[SQL("DEFAULT ''")], index=True, unique=True)
+    box_label_identifier = CharField(
+        column_name="box_id", constraints=[SQL("DEFAULT ''")], index=True, unique=True
+    )
     box_state = ForeignKeyField(
         column_name="box_state_id",
         constraints=[SQL("DEFAULT 1")],
@@ -105,7 +107,7 @@ class Box(db.Model):
         table_name = "stock"
 
     def __unicode__(self):
-        return self.box_id
+        return self.box_label_identifier
 
     @staticmethod
     def create_box(box_creation_input):
@@ -120,7 +122,7 @@ class Box(db.Model):
 
         new_box = Box.create(
             # surprisingly not primary key, unique non-sequential identifier for a box
-            box_id=box_short_uuid,
+            box_label_identifier=box_short_uuid,
             product_id=box_creation_input.get(
                 "product_id", None
             ),  # will become a fancy dropdown on the FE
@@ -142,4 +144,4 @@ class Box(db.Model):
 
     @staticmethod
     def get_box(box_id):
-        return Box.get(Box.box_id == box_id)
+        return Box.get(Box.box_label_identifier == box_id)

--- a/flask/boxwise_flask/models/location.py
+++ b/flask/boxwise_flask/models/location.py
@@ -14,8 +14,10 @@ class Location(db.Model):
         null=True,
         on_update="CASCADE",
     )
-    base = ForeignKeyField(column_name="base_id", field="id", model=Base)
-    is_stockroom = IntegerField(constraints=[SQL("DEFAULT 0")])
+    base = ForeignKeyField(column_name="camp_id", field="id", model=Base)
+    is_stockroom = IntegerField(
+        column_name="container_stock", constraints=[SQL("DEFAULT 0")]
+    )
     created = DateTimeField(null=True)
     created_by = ForeignKeyField(
         column_name="created_by",

--- a/flask/boxwise_flask/models/qr_code.py
+++ b/flask/boxwise_flask/models/qr_code.py
@@ -4,7 +4,7 @@ from peewee import SQL, CharField, DateTimeField, IntegerField
 
 class QRCode(db.Model):
     code = CharField(null=True)
-    created = DateTimeField(null=True)
+    created_on = DateTimeField(column_name="created", null=True)
     legacy = IntegerField(constraints=[SQL("DEFAULT 0")])
 
     class Meta:

--- a/flask/boxwise_flask/models/size.py
+++ b/flask/boxwise_flask/models/size.py
@@ -40,4 +40,4 @@ class Size(db.Model):
         table_name = "sizes"
 
     def __str__(self):
-        return f"{self.id} {self.organisation_id} {self.name} {self.currency_name}"
+        return f"{self.id} {self.label}"

--- a/flask/test/data/box.py
+++ b/flask/test/data/box.py
@@ -16,7 +16,7 @@ def default_box_data():
         "product": default_product_data()["id"],
         "box_id": "abc",
         "box_state": default_box_state_data()["id"],
-        "comments": "",
+        "comment": "",
         "created": TIME,
         "created_by": None,
         "deleted": TIME,

--- a/flask/test/data/box.py
+++ b/flask/test/data/box.py
@@ -14,7 +14,7 @@ def default_box_data():
     mock_box = {
         "id": 2,
         "product": default_product_data()["id"],
-        "box_id": "abc",
+        "box_label_identifier": "abc",
         "box_state": default_box_state_data()["id"],
         "comment": "",
         "created": TIME,

--- a/flask/test/endpoint_tests/conftest.py
+++ b/flask/test/endpoint_tests/conftest.py
@@ -58,3 +58,18 @@ def client(app):
     """The fixture simulates a client sending requests to the app."""
     client = app.test_client()
     return client
+
+
+@pytest.fixture()
+def mysql_app_client():
+    """Follow the setup-proceduce of the main module. Note that the fixture
+    requires a MySQL database server running locally on port 3306.
+    """
+    app = create_app()
+    app.testing = True
+    # cf. main.py but inserting values from docker-compose.yml
+    app.config["DATABASE"] = "mysql://root:dropapp_root@127.0.0.1:3306/dropapp_dev"
+
+    db.init_app(app)
+    yield app.test_client()
+    db.close_db(None)

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -100,3 +100,26 @@ def test_get_boxes_by_location():
     # There are no comments currently. Verify by creating a set
     assert {box["comment"] for box in queried_boxes} == {""}
     db.close_db(None)
+
+
+@pytest.mark.skipif("CIRCLECI" not in os.environ, reason="only functional in CircleCI")
+def test_get_boxes_by_gender():
+    app = create_app()
+    app.testing = True
+    app.config["DATABASE"] = "mysql://root:dropapp_root@127.0.0.1:3306/dropapp_dev"
+
+    db.init_app(app)
+    client = app.test_client()
+
+    data = {
+        "query": """query BoxesWithUnisexAdultProducts {
+                getBoxesByGender(genderId: UnisexAdult) {
+                    ID
+                }
+            }"""
+    }
+    response = client.post("/graphql", json=data)
+    queried_boxes = response.json["data"]["getBoxesByGender"]
+    assert response.status_code == 200
+    assert len(queried_boxes) == 47
+    db.close_db(None)

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -24,14 +24,14 @@ def test_backend_connection():
 
     data = {
         "query": """query Box {
-                box(qr_code: "ffdd7f7243d74a663b417562df0ebeb") {
+                getBoxDetails(qr_code: "ffdd7f7243d74a663b417562df0ebeb") {
                     ID
                     items
                 }
             }"""
     }
     response = client.post("/graphql", json=data)
-    queried_box = response.json["data"]["box"]
+    queried_box = response.json["data"]["getBoxDetails"]
     assert response.status_code == 200
     assert queried_box == {"ID": "436898", "items": 87}
 

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -24,7 +24,7 @@ def test_backend_connection():
 
     data = {
         "query": """query Box {
-                getBoxDetails(qr_code: "ffdd7f7243d74a663b417562df0ebeb") {
+                getBoxDetails(qrCode: "ffdd7f7243d74a663b417562df0ebeb") {
                     ID
                     items
                 }
@@ -49,7 +49,7 @@ def test_get_box_details():
 
     data = {
         "query": """query Box {
-                getBoxDetails(box_id: 996559) {
+                getBoxDetails(boxId: 996559) {
                     qrCode {
                         ID
                     }
@@ -88,7 +88,7 @@ def test_get_boxes_by_location():
 
     data = {
         "query": """query Box {
-                getBoxesByLocation(location_id: 14) {
+                getBoxesByLocation(locationId: 14) {
                     comment
                 }
             }"""

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -9,6 +9,7 @@ def test_get_box_details(mysql_app_client):
         "query": """query BoxIdAndItems {
                 getBoxDetails(qrCode: "ffdd7f7243d74a663b417562df0ebeb") {
                     ID
+                    boxLabelIdentifier
                     location {
                         ID
                         base {
@@ -26,7 +27,8 @@ def test_get_box_details(mysql_app_client):
     queried_box = response.json["data"]["getBoxDetails"]
     assert response.status_code == 200
     assert queried_box == {
-        "ID": "436898",
+        "ID": "642",
+        "boxLabelIdentifier": "436898",
         "items": 87,
         "location": {
             "ID": "18",
@@ -101,7 +103,7 @@ def test_get_boxes(mysql_app_client):
     data = {
         "query": """query BoxesWithUnisexAdultProducts {
                 getBoxesByGender(genderId: UnisexAdult) {
-                    ID
+                    boxLabelIdentifier
                 }
             }"""
     }
@@ -109,6 +111,6 @@ def test_get_boxes(mysql_app_client):
     queried_boxes = response.json["data"]["getBoxesByGender"]
     assert response.status_code == 200
     assert len(queried_boxes) == 47
-    # IDs are six-digit numbers
+    # boxLabelIds are six-digit numbers
     for box in queried_boxes:
-        assert 99999 < int(box["ID"]) < 1000000
+        assert 99999 < int(box["boxLabelIdentifier"]) < 1000000

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -25,16 +25,15 @@ def test_backend_connection():
     data = {
         "query": """query Box {
                 box(qr_code: "ffdd7f7243d74a663b417562df0ebeb") {
-                    box_id
+                    ID
                     items
-                    created
                 }
             }"""
     }
     response = client.post("/graphql", json=data)
     queried_box = response.json["data"]["box"]
     assert response.status_code == 200
-    assert queried_box == {"box_id": "436898", "items": 87, "created": None}
+    assert queried_box == {"ID": "436898", "items": 87}
 
     db.close_db(None)
 
@@ -51,11 +50,14 @@ def test_get_box_details():
     data = {
         "query": """query Box {
                 getBoxDetails(box_id: 996559) {
-                    qr_id
-                    product_id
-                    size_id
+                    qrCode {
+                        ID
+                    }
+                    product {
+                        ID
+                    }
+                    size
                     items
-                    created
                 }
             }"""
     }
@@ -63,11 +65,14 @@ def test_get_box_details():
     queried_box = response.json["data"]["getBoxDetails"]
     assert response.status_code == 200
     assert queried_box == {
-        "qr_id": 574,
+        "qrCode": {
+            "ID": "574",
+        },
         "items": 84,
-        "created": None,
-        "product_id": 156,
-        "size_id": 53,
+        "product": {
+            "ID": "156",
+        },
+        "size": "53 S",
     }
     db.close_db(None)
 
@@ -84,7 +89,7 @@ def test_get_boxes_by_location():
     data = {
         "query": """query Box {
                 getBoxesByLocation(location_id: 14) {
-                    comments
+                    comment
                 }
             }"""
     }
@@ -93,5 +98,5 @@ def test_get_boxes_by_location():
     assert response.status_code == 200
     assert len(queried_boxes) == 78
     # There are no comments currently. Verify by creating a set
-    assert {box["comments"] for box in queried_boxes} == {""}
+    assert {box["comment"] for box in queried_boxes} == {""}
     db.close_db(None)

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -122,4 +122,7 @@ def test_get_boxes_by_gender():
     queried_boxes = response.json["data"]["getBoxesByGender"]
     assert response.status_code == 200
     assert len(queried_boxes) == 47
+    # IDs are six-digit numbers
+    for box in queried_boxes:
+        assert 99999 < int(box["ID"]) < 1000000
     db.close_db(None)

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -9,20 +9,41 @@ def test_get_box_details(mysql_app_client):
         "query": """query BoxIdAndItems {
                 getBoxDetails(qrCode: "ffdd7f7243d74a663b417562df0ebeb") {
                     ID
+                    location {
+                        ID
+                        base {
+                            ID
+                        }
+                        name
+                    }
                     items
+                    size
+                    state
                 }
             }"""
     }
     response = mysql_app_client.post("/graphql", json=data)
     queried_box = response.json["data"]["getBoxDetails"]
     assert response.status_code == 200
-    assert queried_box == {"ID": "436898", "items": 87}
+    assert queried_box == {
+        "ID": "436898",
+        "items": 87,
+        "location": {
+            "ID": "18",
+            "base": {"ID": "2"},
+            "name": None,
+        },
+        "size": "52 Mixed",
+        "state": "InStock",
+    }
 
     data = {
         "query": """query SomeBoxDetails {
                 getBoxDetails(boxId: 996559) {
                     qrCode {
                         ID
+                        code
+                        createdOn
                     }
                     product {
                         ID
@@ -38,6 +59,8 @@ def test_get_box_details(mysql_app_client):
     assert queried_box == {
         "qrCode": {
             "ID": "574",
+            "code": "224ac643d3b929f99c71c25ccde7dde",
+            "createdOn": None,
         },
         "items": 84,
         "product": {

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -1,54 +1,25 @@
 import os
 
 import pytest
-from boxwise_flask.app import create_app
-from boxwise_flask.db import db
 
 
 @pytest.mark.skipif("CIRCLECI" not in os.environ, reason="only functional in CircleCI")
-def test_backend_connection():
-    """Verify that database connection is established and operational.
-
-    Follow the setup-proceduce of the main module, instantiate a test client,
-    and query a box via the GraphQL endpoint.
-    """
-    app = create_app()
-    app.testing = True
-
-    # cf. main.py but inserting values from docker-compose.yml
-    app.config["DATABASE"] = "mysql://root:dropapp_root@127.0.0.1:3306/dropapp_dev"
-
-    db.init_app(app)
-
-    client = app.test_client()
-
+def test_get_box_details(mysql_app_client):
     data = {
-        "query": """query Box {
+        "query": """query BoxIdAndItems {
                 getBoxDetails(qrCode: "ffdd7f7243d74a663b417562df0ebeb") {
                     ID
                     items
                 }
             }"""
     }
-    response = client.post("/graphql", json=data)
+    response = mysql_app_client.post("/graphql", json=data)
     queried_box = response.json["data"]["getBoxDetails"]
     assert response.status_code == 200
     assert queried_box == {"ID": "436898", "items": 87}
 
-    db.close_db(None)
-
-
-@pytest.mark.skipif("CIRCLECI" not in os.environ, reason="only functional in CircleCI")
-def test_get_box_details():
-    app = create_app()
-    app.testing = True
-    app.config["DATABASE"] = "mysql://root:dropapp_root@127.0.0.1:3306/dropapp_dev"
-
-    db.init_app(app)
-    client = app.test_client()
-
     data = {
-        "query": """query Box {
+        "query": """query SomeBoxDetails {
                 getBoxDetails(boxId: 996559) {
                     qrCode {
                         ID
@@ -61,7 +32,7 @@ def test_get_box_details():
                 }
             }"""
     }
-    response = client.post("/graphql", json=data)
+    response = mysql_app_client.post("/graphql", json=data)
     queried_box = response.json["data"]["getBoxDetails"]
     assert response.status_code == 200
     assert queried_box == {
@@ -74,42 +45,35 @@ def test_get_box_details():
         },
         "size": "53 S",
     }
-    db.close_db(None)
+
+    data = {
+        "query": """query BoxLookupWithTwoParameters {
+                getBoxDetails(boxId: 996559, qrCode: "deadbeef") {
+                    ID
+                }
+            }"""
+    }
+    response = mysql_app_client.post("/graphql", json=data)
+    queried_box = response.json["data"]["getBoxDetails"]
+    assert response.status_code == 200
+    assert queried_box is None
 
 
 @pytest.mark.skipif("CIRCLECI" not in os.environ, reason="only functional in CircleCI")
-def test_get_boxes_by_location():
-    app = create_app()
-    app.testing = True
-    app.config["DATABASE"] = "mysql://root:dropapp_root@127.0.0.1:3306/dropapp_dev"
-
-    db.init_app(app)
-    client = app.test_client()
-
+def test_get_boxes(mysql_app_client):
     data = {
-        "query": """query Box {
+        "query": """query CommentsOfLostBoxes {
                 getBoxesByLocation(locationId: 14) {
                     comment
                 }
             }"""
     }
-    response = client.post("/graphql", json=data)
+    response = mysql_app_client.post("/graphql", json=data)
     queried_boxes = response.json["data"]["getBoxesByLocation"]
     assert response.status_code == 200
     assert len(queried_boxes) == 78
     # There are no comments currently. Verify by creating a set
     assert {box["comment"] for box in queried_boxes} == {""}
-    db.close_db(None)
-
-
-@pytest.mark.skipif("CIRCLECI" not in os.environ, reason="only functional in CircleCI")
-def test_get_boxes_by_gender():
-    app = create_app()
-    app.testing = True
-    app.config["DATABASE"] = "mysql://root:dropapp_root@127.0.0.1:3306/dropapp_dev"
-
-    db.init_app(app)
-    client = app.test_client()
 
     data = {
         "query": """query BoxesWithUnisexAdultProducts {
@@ -118,11 +82,10 @@ def test_get_boxes_by_gender():
                 }
             }"""
     }
-    response = client.post("/graphql", json=data)
+    response = mysql_app_client.post("/graphql", json=data)
     queried_boxes = response.json["data"]["getBoxesByGender"]
     assert response.status_code == 200
     assert len(queried_boxes) == 47
     # IDs are six-digit numbers
     for box in queried_boxes:
         assert 99999 < int(box["ID"]) < 1000000
-    db.close_db(None)

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -47,3 +47,36 @@ def test_backend_connection():
     assert queried_box == {"box_id": "436898", "items": 87, "created": None}
 
     db.close_db(None)
+
+
+@pytest.mark.skipif("CIRCLECI" not in os.environ, reason="only functional in CircleCI")
+def test_get_box_details():
+    app = create_app()
+    app.testing = True
+    app.config["DATABASE"] = "mysql://root:dropapp_root@127.0.0.1:3306/dropapp_dev"
+
+    db.init_app(app)
+    client = app.test_client()
+
+    data = {
+        "query": """query Box {
+                getBoxDetails(box_id: 996559) {
+                    qr_id
+                    product_id
+                    size_id
+                    items
+                    created
+                }
+            }"""
+    }
+    response = client.post("/graphql", json=data)
+    queried_box = response.json["data"]["getBoxDetails"]
+    assert response.status_code == 200
+    assert queried_box == {
+        "qr_id": 574,
+        "items": 84,
+        "created": None,
+        "product_id": 156,
+        "size_id": 53,
+    }
+    db.close_db(None)

--- a/flask/test/endpoint_tests/test_app.py
+++ b/flask/test/endpoint_tests/test_app.py
@@ -5,16 +5,6 @@ from boxwise_flask.app import create_app
 from boxwise_flask.db import db
 
 
-def test_private_endpoint(client):
-    """example test for private endpoint"""
-    response_data = client.get("/api/private")
-    assert response_data.status_code == 200
-    assert (
-        "Hello from a private endpoint! You need to be authenticated to see this."
-        == response_data.json["message"]
-    )
-
-
 @pytest.mark.skipif("CIRCLECI" not in os.environ, reason="only functional in CircleCI")
 def test_backend_connection():
     """Verify that database connection is established and operational.

--- a/flask/test/endpoint_tests/test_bases.py
+++ b/flask/test/endpoint_tests/test_bases.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def get_base_from_graphql(id, base_query):
-    return [x for x in base_query if x["ID"] == id][0]
+    return [x for x in base_query if int(x["ID"]) == id][0]
 
 
 @pytest.mark.usefixtures("default_bases")
@@ -24,7 +24,7 @@ def test_all_bases(client, default_bases):
     all_bases = response_data.json["data"]["allBases"]
     for _, expected_base in default_bases.items():
         created_base = get_base_from_graphql(expected_base["id"], all_bases)
-        assert created_base["ID"] == expected_base["id"]
+        assert int(created_base["ID"]) == expected_base["id"]
         assert created_base["name"] == expected_base["name"]
         assert created_base["currencyName"] == expected_base["currency_name"]
 
@@ -48,6 +48,6 @@ def test_base(client, default_bases):
 
     expected_base = default_bases[test_id]
     created_base = response_data.json["data"]["base"]
-    assert created_base["ID"] == expected_base["id"]
+    assert int(created_base["ID"]) == expected_base["id"]
     assert created_base["name"] == expected_base["name"]
     assert created_base["currencyName"] == expected_base["currency_name"]

--- a/flask/test/endpoint_tests/test_bases.py
+++ b/flask/test/endpoint_tests/test_bases.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def get_base_from_graphql(id, base_query):
-    return [x for x in base_query if x["id"] == id][0]
+    return [x for x in base_query if x["ID"] == id][0]
 
 
 @pytest.mark.usefixtures("default_bases")
@@ -11,7 +11,7 @@ def test_all_bases(client, default_bases):
     """Verify allBases GraphQL query endpoint"""
     graph_ql_query_string = """query {
                 allBases {
-                    id
+                    ID
                     name
                     currencyName
                 }
@@ -24,7 +24,7 @@ def test_all_bases(client, default_bases):
     all_bases = response_data.json["data"]["allBases"]
     for _, expected_base in default_bases.items():
         created_base = get_base_from_graphql(expected_base["id"], all_bases)
-        assert created_base["id"] == expected_base["id"]
+        assert created_base["ID"] == expected_base["id"]
         assert created_base["name"] == expected_base["name"]
         assert created_base["currencyName"] == expected_base["currency_name"]
 
@@ -36,7 +36,7 @@ def test_base(client, default_bases):
     test_id = 1
     graph_ql_query_string = f"""query Base {{
                 base(id: {test_id}) {{
-                    id
+                    ID
                     name
                     currencyName
                 }}
@@ -48,6 +48,6 @@ def test_base(client, default_bases):
 
     expected_base = default_bases[test_id]
     created_base = response_data.json["data"]["base"]
-    assert created_base["id"] == expected_base["id"]
+    assert created_base["ID"] == expected_base["id"]
     assert created_base["name"] == expected_base["name"]
     assert created_base["currencyName"] == expected_base["currency_name"]

--- a/flask/test/endpoint_tests/test_box.py
+++ b/flask/test/endpoint_tests/test_box.py
@@ -7,14 +7,14 @@ def test_get_box_from_code(client, default_box, default_qr_code):
     code = default_qr_code["code"]
     graph_ql_query_string = f"""query Box {{
                 getBoxDetails(qrCode: "{code}") {{
-                    ID
+                    boxLabelIdentifier
                 }}
             }}"""
     data = {"query": graph_ql_query_string}
     response_data = client.post("/graphql", json=data)
     queried_box = response_data.json["data"]["getBoxDetails"]
     assert response_data.status_code == 200
-    assert queried_box["ID"] == default_box["box_id"]
+    assert queried_box["boxLabelIdentifier"] == default_box["box_label_identifier"]
 
 
 @pytest.mark.usefixtures("qr_code_without_box")

--- a/flask/test/endpoint_tests/test_box.py
+++ b/flask/test/endpoint_tests/test_box.py
@@ -45,7 +45,7 @@ def test_code_does_not_exist(client):
     response_data = client.post("/graphql", json=data)
     queried_box = response_data.json["data"]["getBoxDetails"]
     assert (
-        "<Model: QRCode> instance matching query does not exist"
+        "<Model: Box> instance matching query does not exist"
         in response_data.json["errors"][0]["message"]
     )
     assert queried_box is None

--- a/flask/test/endpoint_tests/test_box.py
+++ b/flask/test/endpoint_tests/test_box.py
@@ -4,30 +4,30 @@ import pytest
 @pytest.mark.usefixtures("default_qr_code")
 @pytest.mark.usefixtures("default_box")
 def test_get_box_from_code(client, default_box, default_qr_code):
-    code = '"%s"' % default_qr_code["code"]
+    code = default_qr_code["code"]
     graph_ql_query_string = f"""query Box {{
-                box(qr_code: {code}) {{
+                getBoxDetails(qr_code: "{code}") {{
                     ID
                 }}
             }}"""
     data = {"query": graph_ql_query_string}
     response_data = client.post("/graphql", json=data)
-    queried_box = response_data.json["data"]["box"]
+    queried_box = response_data.json["data"]["getBoxDetails"]
     assert response_data.status_code == 200
     assert queried_box["ID"] == default_box["box_id"]
 
 
 @pytest.mark.usefixtures("qr_code_without_box")
 def test_code_not_associated_with_box(client, qr_code_without_box):
-    code = '"%s"' % qr_code_without_box["code"]
+    code = qr_code_without_box["code"]
     graph_ql_query_string = f"""query Box {{
-                box(qr_code: {code}) {{
+                getBoxDetails(qr_code: "{code}") {{
                     ID
                 }}
             }}"""
     data = {"query": graph_ql_query_string}
     response_data = client.post("/graphql", json=data)
-    queried_box = response_data.json["data"]["box"]
+    queried_box = response_data.json["data"]["getBoxDetails"]
     assert (
         "<Model: Box> instance matching query does not exist"
         in response_data.json["errors"][0]["message"]
@@ -36,15 +36,14 @@ def test_code_not_associated_with_box(client, qr_code_without_box):
 
 
 def test_code_does_not_exist(client):
-    code = '"-1"'
-    graph_ql_query_string = f"""query Box {{
-                box(qr_code: {code}) {{
+    graph_ql_query_string = """query Box {
+                getBoxDetails(qr_code: "-1") {
                     ID
-                }}
-            }}"""
+                }
+            }"""
     data = {"query": graph_ql_query_string}
     response_data = client.post("/graphql", json=data)
-    queried_box = response_data.json["data"]["box"]
+    queried_box = response_data.json["data"]["getBoxDetails"]
     assert (
         "<Model: QRCode> instance matching query does not exist"
         in response_data.json["errors"][0]["message"]

--- a/flask/test/endpoint_tests/test_box.py
+++ b/flask/test/endpoint_tests/test_box.py
@@ -6,7 +6,7 @@ import pytest
 def test_get_box_from_code(client, default_box, default_qr_code):
     code = default_qr_code["code"]
     graph_ql_query_string = f"""query Box {{
-                getBoxDetails(qr_code: "{code}") {{
+                getBoxDetails(qrCode: "{code}") {{
                     ID
                 }}
             }}"""
@@ -21,7 +21,7 @@ def test_get_box_from_code(client, default_box, default_qr_code):
 def test_code_not_associated_with_box(client, qr_code_without_box):
     code = qr_code_without_box["code"]
     graph_ql_query_string = f"""query Box {{
-                getBoxDetails(qr_code: "{code}") {{
+                getBoxDetails(qrCode: "{code}") {{
                     ID
                 }}
             }}"""
@@ -37,7 +37,7 @@ def test_code_not_associated_with_box(client, qr_code_without_box):
 
 def test_code_does_not_exist(client):
     graph_ql_query_string = """query Box {
-                getBoxDetails(qr_code: "-1") {
+                getBoxDetails(qrCode: "-1") {
                     ID
                 }
             }"""
@@ -56,7 +56,7 @@ def test_code_does_not_exist(client):
 def test_qr_box_exists(client, default_qr_code, qr_code_without_box):
     code = default_qr_code["code"]
     graph_ql_query_string = f"""query CheckQrExistence {{
-                qrBoxExists(qr_code: "{code}")
+                qrBoxExists(qrCode: "{code}")
             }}"""
     data = {"query": graph_ql_query_string}
     response = client.post("/graphql", json=data)
@@ -65,7 +65,7 @@ def test_qr_box_exists(client, default_qr_code, qr_code_without_box):
 
     code = qr_code_without_box["code"]
     graph_ql_query_string = f"""query CheckQrExistence {{
-                qrBoxExists(qr_code: "{code}")
+                qrBoxExists(qrCode: "{code}")
             }}"""
     data = {"query": graph_ql_query_string}
     response = client.post("/graphql", json=data)

--- a/flask/test/endpoint_tests/test_box.py
+++ b/flask/test/endpoint_tests/test_box.py
@@ -14,7 +14,7 @@ def test_get_box_from_code(client, default_box, default_qr_code):
     response_data = client.post("/graphql", json=data)
     queried_box = response_data.json["data"]["box"]
     assert response_data.status_code == 200
-    assert int(queried_box["ID"]) == default_box["id"]
+    assert queried_box["ID"] == default_box["box_id"]
 
 
 @pytest.mark.usefixtures("qr_code_without_box")

--- a/flask/test/endpoint_tests/test_box.py
+++ b/flask/test/endpoint_tests/test_box.py
@@ -7,14 +7,14 @@ def test_get_box_from_code(client, default_box, default_qr_code):
     code = '"%s"' % default_qr_code["code"]
     graph_ql_query_string = f"""query Box {{
                 box(qr_code: {code}) {{
-                    box_id
+                    ID
                 }}
             }}"""
     data = {"query": graph_ql_query_string}
     response_data = client.post("/graphql", json=data)
     queried_box = response_data.json["data"]["box"]
     assert response_data.status_code == 200
-    assert queried_box["box_id"] == default_box["box_id"]
+    assert int(queried_box["ID"]) == default_box["id"]
 
 
 @pytest.mark.usefixtures("qr_code_without_box")
@@ -22,7 +22,7 @@ def test_code_not_associated_with_box(client, qr_code_without_box):
     code = '"%s"' % qr_code_without_box["code"]
     graph_ql_query_string = f"""query Box {{
                 box(qr_code: {code}) {{
-                    box_id
+                    ID
                 }}
             }}"""
     data = {"query": graph_ql_query_string}
@@ -39,7 +39,7 @@ def test_code_does_not_exist(client):
     code = '"-1"'
     graph_ql_query_string = f"""query Box {{
                 box(qr_code: {code}) {{
-                    box_id
+                    ID
                 }}
             }}"""
     data = {"query": graph_ql_query_string}

--- a/flask/test/endpoint_tests/test_create_box.py
+++ b/flask/test/endpoint_tests/test_create_box.py
@@ -19,7 +19,7 @@ def test_create_box(client, qr_code_without_box):
             createBox(
                 box_creation_input : {box_creation_input_string}
             ) {{
-                id
+                ID
                 items
             }}
         }}"""

--- a/flask/test/endpoint_tests/test_create_box.py
+++ b/flask/test/endpoint_tests/test_create_box.py
@@ -8,7 +8,7 @@ def test_create_box(client, qr_code_without_box):
                     product_id: 1,
                     items: 9999,
                     location_id: 100000005,
-                    comments: "",
+                    comment: "",
                     size_id: 1,
                     qr_barcode: "{qr_code_without_box["code"]}",
                     created_by: "1"

--- a/flask/test/endpoint_tests/test_qr.py
+++ b/flask/test/endpoint_tests/test_qr.py
@@ -5,7 +5,7 @@ import pytest
 def test_qr_exists(client, default_qr_code):
     code = default_qr_code["code"]
     graph_ql_query_string = f"""query CheckQrExistence {{
-                qrExists(qr_code: "{code}")
+                qrExists(qrCode: "{code}")
             }}"""
     data = {"query": graph_ql_query_string}
     response = client.post("/graphql", json=data)
@@ -13,7 +13,7 @@ def test_qr_exists(client, default_qr_code):
     assert response.json["data"]["qrExists"]
 
     graph_ql_query_string = """query CheckQrExistence {
-                qrExists(qr_code: "111")
+                qrExists(qrCode: "111")
             }"""
     data = {"query": graph_ql_query_string}
     response = client.post("/graphql", json=data)

--- a/flask/test/endpoint_tests/test_simple.py
+++ b/flask/test/endpoint_tests/test_simple.py
@@ -1,0 +1,8 @@
+def test_private_endpoint(client):
+    """example test for private endpoint"""
+    response_data = client.get("/api/private")
+    assert response_data.status_code == 200
+    assert (
+        "Hello from a private endpoint! You need to be authenticated to see this."
+        == response_data.json["message"]
+    )

--- a/flask/test/model_tests/test_box.py
+++ b/flask/test/model_tests/test_box.py
@@ -11,7 +11,7 @@ def test_box_model(
     default_box, default_product, default_product_gender, default_product_category
 ):
 
-    queried_box = Box.get_box(default_box["box_id"])
+    queried_box = Box.get_box(default_box["box_label_identifier"])
 
     queried_box_dict = model_to_dict(queried_box)
     if queried_box_dict != default_box:
@@ -19,7 +19,9 @@ def test_box_model(
         print("created_box ", default_box)
 
     assert queried_box_dict["id"] == default_box["id"]
-    assert queried_box_dict["box_id"] == default_box["box_id"]
+    assert (
+        queried_box_dict["box_label_identifier"] == default_box["box_label_identifier"]
+    )
     assert queried_box_dict["box_state"]["id"] == default_box["box_state"]
     assert queried_box_dict["comment"] == default_box["comment"]
     assert queried_box_dict["created"] == default_box["created"]

--- a/flask/test/model_tests/test_box.py
+++ b/flask/test/model_tests/test_box.py
@@ -21,7 +21,7 @@ def test_box_model(
     assert queried_box_dict["id"] == default_box["id"]
     assert queried_box_dict["box_id"] == default_box["box_id"]
     assert queried_box_dict["box_state"]["id"] == default_box["box_state"]
-    assert queried_box_dict["comments"] == default_box["comments"]
+    assert queried_box_dict["comment"] == default_box["comment"]
     assert queried_box_dict["created"] == default_box["created"]
     assert queried_box_dict["created_by"] == default_box["created_by"]
     assert queried_box_dict["deleted"] == default_box["deleted"]


### PR DESCRIPTION
This PR shows a PoC for box resolvers. I implemented the four resolvers as requested, and learnt a lot about the resolver 'magic' that ariadne provides. It ties together nicely with peewee since the rows returned by DB queries can be directly accessed for their attributes (we should watch out for a 1-to-1 mapping between the GraphQL field names and the Peewee field names. Conversion of camelCase and snake_case happens semi-automatically. For anything else we can have custom resolvers, e.g. below for the ID field).

@aerinsol 
1. you asked me about the query design, I'm not quite decisive yet about the approach. As a BE engineer I'd probably opt for the second approach because it does not require additional handling (number of) of the arguments.
1.1 parametrized query (`GetBoxDetails`): requires caution on client-side to pass only either argument, and/or handling of the exceptional case when passing zero/two arguments. The handling becomes more difficult the more (mutually exclusive) parameters we have. Yet it might be convenient for the client to only have a single query which accepts either argument
1.2 specialized query (`GetBoxesByLocation`, `GetBoxesByGender`): we can use `!` to require the argument being passed in the query. Very simple resolver implementation without additional conditional branches (basically a DB query and overhead from the Python decorators)
2. for the select-boxes-given-a-gender query, is the double join the correct way to go (it's literally the first join query I've written)
3. I applied more camelCase style to the arguments in the query definition, hope that's fine!

If you or @vahidbazzaz have any other questions or suggestions, let me know =)

Still TBD: limiting the query depth using [cost validators](https://ariadnegraphql.org/docs/query-validators#query-cost-validator)