### PR TITLE
Add base locations resolver

### DIFF
--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -257,6 +257,12 @@ def resolve_update_beneficiary(_, info, beneficiary_update_input):
     return update_beneficiary(beneficiary_update_input)
 
 
+@base.field("locations")
+def resolve_base_locations(base_obj, info):
+    authorize(permission="location:read")
+    return Location.select().where(Location.base == base_obj.id)
+
+
 @base.field("beneficiaries")
 @convert_kwargs_to_snake_case
 def resolve_base_beneficiaries(base_obj, info, pagination_input=None):

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -105,11 +105,10 @@ def resolve_product(_, info, id):
 def resolve_box(_, info, box_label_identifier):
     authorize(permission="stock:read")
     box = (
-        Box.select(Box, Base.id)
+        Box.select(Box, Location.base)
         .join(Location)
         .join(Base)
         .where(Box.box_label_identifier == box_label_identifier)
-        .objects()
         .get()
     )
     authorize(base_id=box.location.base.id)

--- a/flask/test/endpoint_tests/test_base.py
+++ b/flask/test/endpoint_tests/test_base.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.usefixtures("default_bases")
 def test_all_bases(client, default_bases):
-    graph_ql_query_string = """query {
+    query = """query {
                 bases {
                     id
                     name
@@ -11,7 +11,7 @@ def test_all_bases(client, default_bases):
                 }
             }"""
 
-    data = {"query": graph_ql_query_string}
+    data = {"query": query}
     response_data = client.post("/graphql", json=data)
 
     assert response_data.status_code == 200
@@ -30,7 +30,7 @@ def test_all_bases(client, default_bases):
 @pytest.mark.usefixtures("default_bases")
 def test_base(client, default_bases, default_location):
     test_id = 1
-    graph_ql_query_string = f"""query Base {{
+    query = f"""query Base {{
                 base(id: {test_id}) {{
                     id
                     name
@@ -41,16 +41,16 @@ def test_base(client, default_bases, default_location):
                 }}
             }}"""
 
-    data = {"query": graph_ql_query_string}
+    data = {"query": query}
     response_data = client.post("/graphql", json=data)
     assert response_data.status_code == 200
 
     expected_base = default_bases[test_id]
-    created_base = response_data.json["data"]["base"]
-    assert int(created_base["id"]) == expected_base["id"]
-    assert created_base["name"] == expected_base["name"]
-    assert created_base["currencyName"] == expected_base["currency_name"]
+    base = response_data.json["data"]["base"]
+    assert int(base["id"]) == expected_base["id"]
+    assert base["name"] == expected_base["name"]
+    assert base["currencyName"] == expected_base["currency_name"]
 
-    locations = created_base["locations"]
+    locations = base["locations"]
     assert len(locations) == 1
     assert int(locations[0]["id"]) == default_location["id"]

--- a/flask/test/endpoint_tests/test_bases.py
+++ b/flask/test/endpoint_tests/test_bases.py
@@ -28,13 +28,16 @@ def test_all_bases(client, default_bases):
 
 
 @pytest.mark.usefixtures("default_bases")
-def test_base(client, default_bases):
+def test_base(client, default_bases, default_location):
     test_id = 1
     graph_ql_query_string = f"""query Base {{
                 base(id: {test_id}) {{
                     id
                     name
                     currencyName
+                    locations {{
+                        id
+                    }}
                 }}
             }}"""
 
@@ -47,3 +50,7 @@ def test_base(client, default_bases):
     assert int(created_base["id"]) == expected_base["id"]
     assert created_base["name"] == expected_base["name"]
     assert created_base["currencyName"] == expected_base["currency_name"]
+
+    locations = created_base["locations"]
+    assert len(locations) == 1
+    assert int(locations[0]["id"]) == default_location["id"]

--- a/flask/test/endpoint_tests/test_permissions.py
+++ b/flask/test/endpoint_tests/test_permissions.py
@@ -172,3 +172,12 @@ def test_invalid_permission_for_beneficiary_tokens(client, mocker):
     )
     data = {"query": "query { beneficiary(id: 3) { tokens } }"}
     assert_forbidden_request(data, client, field="beneficiary", value={"tokens": None})
+
+
+def test_invalid_permission_for_base_locations(client, mocker):
+    # verify missing location:read permission
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        permissions=["base:read"]
+    )
+    data = {"query": "query { base(id: 1) { locations { id } } }"}
+    assert_forbidden_request(data, client, field="base", value={"locations": None})


### PR DESCRIPTION
This PR adds a resolver that I had previously missed to implement.

On a side-note @vahidbazzaz, I also checked the boxes resolver of the location query. It's not possible to retrieve unauthorized data since the location resolver checks whether the user has access to the location's base, and only if the base can be accessed, the `boxes` will be resolved by filtering w.r.t. the location.
