### PR TITLE
App load testing and profiling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     flask:
         build:
             context: ./flask
+            args:
+                flask_env: ${FLASK_ENV:-development}
         ports:
             - 5000:5000
             # request localhost:5001 to run debugger in vscode (cf. README)
@@ -12,7 +14,6 @@ services:
         volumes:
             - ./flask:/app/flask
         environment:
-            FLASK_ENV: development
             PYTHONUNBUFFERED: 1
             AUTH0_DOMAIN: ${AUTH0_DOMAIN:?auth0 config not set in .env file}
             AUTH0_AUDIENCE: ${AUTH0_AUDIENCE:?auth0 config not set in .env file}

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,11 +1,28 @@
+ARG flask_env
+
 # using alpine for smallest docker image
-FROM python:3.8-alpine
+FROM python:3.8-alpine AS base
+
 WORKDIR /app/flask
 # install packages seperately to use docker build-caching
 # so we don't need to re-fetch these if code has changed
 # but our package.json hasn't
 COPY requirements.txt /app/flask
 RUN pip install -r requirements.txt && rm requirements.txt
+
+# Build two stages for the conditions production/development
+# cf. https://stackoverflow.com/a/60820156/3865876
+FROM base AS production
+# Launch WSGI server, configured by gunicorn.conf.py
+ENV FLASK_ENV production
+CMD gunicorn
+
+FROM base AS development
 # Path of module containing flask app, relative to WORKDIR
 ENV FLASK_APP boxwise_flask/main
+ENV FLASK_ENV development
 CMD flask run -h 0.0.0 -p 5000
+
+# Select final stage depending on flask_env argument
+FROM ${flask_env} AS final
+RUN echo Using $FLASK_ENV

--- a/flask/README.md
+++ b/flask/README.md
@@ -72,7 +72,7 @@ Install the dependencies of the app in the activated virtual environment
 
     pip install -U -r flask/requirements.txt
 
-For the integration tests authentication information is fetched from the [Auth0](https://auth0.com) website. Log in and select `Applications` -> `Applications` from the side bar menu. Select `boxtribute-dev-api`. Copy the `Client ID` and `Client Secret` into the `.env` file as the `AUTH0_CLIENT_TEST_ID` and `AUTH0_CLIENT_SECRET_TEST` variables, resp.
+For the integration tests authentication information is fetched from the [Auth0](https://auth0.com) website. Log in and select `Applications` -> `Applications` from the side bar menu. Select `boxtribute-dev-api`. Copy the `Client Secret` into the `.env` file as the `AUTH0_CLIENT_SECRET_TEST` variables.
 
 We're subject to a rate limit for tokens from Auth0. In order to avoid fetching tokens over and over again for every test run, do the following once before you start your development session:
 
@@ -102,7 +102,7 @@ To access the mysql database, there are now three possibilities:
 
 To figure out the gateway of the docker network `backend` run
 
-        docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' boxtribute_backend
+    docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' boxtribute_backend
 
 #### MySQL workbench or other editors
 
@@ -152,14 +152,12 @@ If you want to break on any other code lines (not endpoints), then you can only 
 
 #### Usage of Logger
 
-To log to the console from inside the docker container, create an instance of app using:
+To log to the console while running the `flask` service, do
 
-    from flask import Flask
-    app = Flask(__name__)
+    from flask import current_app
+    current_app.logger.warn(<whatever you want to log>)
 
-and log with:
-
-    app.logger.warn(<whatever you want to log>)
+Note that in production mode, logging is also subject to the configuration of the WSGI server.
 
 ## Testing
 
@@ -246,8 +244,7 @@ The back-end exposes the GraphQL API at the `/graphql` endpoint. You can experim
 
 1. Start the required services by `docker-compose up flask mysql`
 1. Open `localhost:5000/graphql`.
-1. Simulate being a valid, logged-in user by fetching an authorization token (internally the variables of the `.env` file are used)
-    ./fetch_token
+1. Simulate being a valid, logged-in user by fetching an authorization token (internally the variables of the `.env` file are used): `./fetch_token`
 1. Copy the content of the `access_token` field (alternatively, you can pipe the above command ` | jq -r .access_token | xclip -i -selection c` to copy it to the system clipboard)
 1.  Insert the access token in the following format on the playground in the section on the bottom left of the playground called HTTP Headers.
 
@@ -255,11 +252,11 @@ The back-end exposes the GraphQL API at the `/graphql` endpoint. You can experim
 
 1. A sample query you can try if it works is:
 
-    query {
-        bases {
-            name
+        query {
+            organisations {
+                name
+            }
         }
-    }
 
 ## Production environment
 

--- a/flask/README.md
+++ b/flask/README.md
@@ -261,6 +261,14 @@ The back-end exposes the GraphQL API at the `/graphql` endpoint. You can experim
         }
     }
 
+## Production environment
+
+In production, the web app is run by the WSGI server `gunicorn` which serves as a glue between the web app and the web server (e.g. Apache). `gunicorn` allows for more flexible configuration of request handling (see `flask/gunicorn.conf.py` file).
+
+Launch the production server by
+
+    FLASK_ENV=production docker-compose up --build flask
+
 ## Authentication and Authorization
 
 We use the [Auth0](https://auth0.com) web service to provide the app client with user authentication and authorization data (for short, auth and authz, resp.).

--- a/flask/README.md
+++ b/flask/README.md
@@ -12,6 +12,8 @@
    1. [Debugging](#debugging)
 1. [Testing](#testing)
 1. [GraphQL Playground](#graphql-playground)
+1. [Production environment](#production-environment)
+1. [Performance evaluation](#performance-evaluation)
 1. [Authentication and Authorization on the back-end](#authentication-and-authorization)
 1. [Database Migrations](#database-migrations)
 
@@ -265,6 +267,37 @@ In production, the web app is run by the WSGI server `gunicorn` which serves as 
 Launch the production server by
 
     FLASK_ENV=production docker-compose up --build flask
+
+## Performance evaluation
+
+### Load testing
+
+Used in combination with [k6](https://k6.io/docs/). See the example [script](./scripts/load-test.js) for instructions.
+
+### Profiling
+
+1. Add profiling middleware by extending `main.py`
+
+        import pathlib
+        from werkzeug.middleware.profiler import ProfilerMiddleware
+        # ...
+        # setting up app
+        # ...
+        BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
+        app = ProfilerMiddleware(app, profile_dir=str(BASE_DIR / "stats"))
+
+1. Create output directory for profile files
+
+        mkdir -p flask/stats
+
+1. Launch the production server as mentioned above, and the database service
+1. Run a request, e.g. `dotenv run k6 run flask/scripts/load-test.js`
+1. `pip install` a profile visualization tool, e.g. [tuna](https://github.com/nschloe/tuna) or [snakeviz](https://github.com/jiffyclub/snakeviz) and load the profile
+
+        tuna flask/stats/some.profile
+        snakeviz flask/stats/some.profile
+
+1. Inspect the stack visualization in your web browser.
 
 ## Authentication and Authorization
 

--- a/flask/boxwise_flask/graph_ql/resolvers.py
+++ b/flask/boxwise_flask/graph_ql/resolvers.py
@@ -57,7 +57,7 @@ def resolve_base(_, info, id):
 def resolve_beneficiary(_, info, id):
     authorize(permission="beneficiary:read")
     beneficiary = Beneficiary.get_by_id(id)
-    authorize(base_id=beneficiary.base.id)
+    authorize(base_id=beneficiary.base_id)
     return beneficiary
 
 
@@ -96,7 +96,7 @@ def resolve_qr_code(_, info, qr_code):
 def resolve_product(_, info, id):
     authorize(permission="product:read")
     product = Product.get_by_id(id)
-    authorize(base_id=product.base.id)
+    authorize(base_id=product.base_id)
     return product
 
 
@@ -105,13 +105,12 @@ def resolve_product(_, info, id):
 def resolve_box(_, info, box_label_identifier):
     authorize(permission="stock:read")
     box = (
-        Box.select(Box, Location.base)
+        Box.select(Box, Location.base_id)
         .join(Location)
-        .join(Base)
         .where(Box.box_label_identifier == box_label_identifier)
         .get()
     )
-    authorize(base_id=box.location.base.id)
+    authorize(base_id=box.location.base_id)
     return box
 
 
@@ -119,7 +118,7 @@ def resolve_box(_, info, box_label_identifier):
 def resolve_location(_, info, id):
     authorize(permission="location:read")
     location = Location.get_by_id(id)
-    authorize(base_id=location.base.id)
+    authorize(base_id=location.base_id)
     return location
 
 

--- a/flask/boxwise_flask/models/beneficiary.py
+++ b/flask/boxwise_flask/models/beneficiary.py
@@ -29,6 +29,7 @@ class Beneficiary(db.Model):
         field="id",
         model=Base,
         on_update="CASCADE",
+        object_id_name="base_id",
     )
     comments = TextField(null=True)
     group_identifier = CharField(

--- a/flask/boxwise_flask/models/location.py
+++ b/flask/boxwise_flask/models/location.py
@@ -15,7 +15,12 @@ class Location(db.Model):
         null=True,
         on_update="CASCADE",
     )
-    base = ForeignKeyField(column_name="camp_id", field="id", model=Base)
+    base = ForeignKeyField(
+        column_name="camp_id",
+        field="id",
+        model=Base,
+        object_id_name="base_id",
+    )
     is_stockroom = IntegerField(
         column_name="container_stock", constraints=[SQL("DEFAULT 0")]
     )

--- a/flask/boxwise_flask/models/product.py
+++ b/flask/boxwise_flask/models/product.py
@@ -16,6 +16,7 @@ class Product(db.Model):
         null=True,
         on_update="CASCADE",
         constraints=[SQL("UNSIGNED")],
+        object_id_name="base_id",
     )
     category = ForeignKeyField(
         column_name="category_id",

--- a/flask/gunicorn.conf.py
+++ b/flask/gunicorn.conf.py
@@ -1,0 +1,8 @@
+"""Configuration for gunicorn WSGI server. For possible settings see
+https://docs.gunicorn.org/en/stable/settings.html#
+"""
+workers = 1
+threads = 1
+bind = "0.0.0.0:5000"
+wsgi_app = "boxwise_flask.main:app"
+# loglevel = "debug"

--- a/flask/scripts/load-test.js
+++ b/flask/scripts/load-test.js
@@ -1,0 +1,45 @@
+// Load-testing script for k6
+//
+// Instructions:
+// 1. Install k6
+// 2. Launch the Docker service:
+//    FLASK_ENV=production docker-compose up --build flask
+// 3. Fetch a JWT for authorization
+//    ./fetch_token
+// 4. Store the value of `access_token` as `AUTH0_TEST_JWT` in the .env file
+// 5. Run the script with effective loading of variables from the .env file
+//    dotenv run k6 run flask/scripts/load-test.js
+// 6. Consider k6 options (e.g. number of virtual users via -u)
+// 7. Experiment with GraphQL queries of varying complexity
+// 8. Experiment with different WSGI server settings (gunicorn.conf.py file)
+//    Remember to re-launch the Docker service for changes to take effect
+import http from "k6/http";
+import { check } from "k6";
+
+const url = "http://0.0.0.0:5000/graphql";
+const params = {
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${__ENV.AUTH0_TEST_JWT}`,
+  },
+};
+const payload = JSON.stringify({
+  // A) Request single field of single resource
+  // query: "query { beneficiary(id: 1007) { firstName } }",
+
+  // B) Request single field of multiple resources
+  query: "query { beneficiaries { elements { firstName } } }",
+});
+
+export default function () {
+  const res = http.post(url, payload, params);
+
+  // Use in combination with A/B to assert working auth
+  // check(res, { 'is status 200': (r) => r.status === 200, });
+
+  // Use in combination with A
+  // check(res, { 'has correct firstName': (r) => r.json().data.beneficiary.firstName === "Kailyn", });
+
+  // Use in combination with B
+  // check(res, { 'contains 50 elements': (r) => r.json().data.beneficiaries.elements.length === 50, });
+}


### PR DESCRIPTION
This PR contains some modifications to enable load-testing and profiling of the app.

The goal is to find out whether the app currently already shows severe bottlenecks for data IO, network, memory, and/or CPU usage.

### Experiments

On my local machine I ran two different experiments using the flask/mysql Docker services. For the results I don't put absolute numbers since they'll be different/non-comparable when running the experiments with the app deployed to GAE or similar.

- Load-testing using [k6](https://k6.io/docs/)
- Profiling the app

1. Load-testing
    1. The scenario is a running server running the webapp, and several clients sending **as many requests as possible**. We want to find out about the throughput (requests / sec), and the latency (i.e. request waiting time for client == processing time for server)
    1. I extended our Docker services to use the WSGI server `gunicorn` to resemble a production-level setup. For `gunicorn`, it's most important to [tune its number of worker processes](https://docs.gunicorn.org/en/stable/design.html#how-many-workers) acc. the available CPU resources
    1. I ran the `load-testing.js` script by `k6` for several combinations of virtual users, requests (single beneficiary vs. page of 100 beneficiaries) and gunicorn settings. The duration of the load-test is 15s.
    1. Result:
        - scaling workers in sensible manner improves both latency and throughput by a factor of 4
        - below some threshold (~nr of workers) increasing the number of users does not have an impact on app performance
        - latency for the beneficiaries query (50 DB rows read and returned) already noticeable: data IO plays a role
    1. Follow-up:
        - various smart and performant worker classes (`gevent`, `meinheld`) can be used in combination with gunicorn
        - Flask as a framework already has some overhead when processing requests. More minimalistic frameworks like [falcon](https://falcon.readthedocs.io/en/stable/user/intro.html#how-is-falcon-different) show [better performance](https://gist.github.com/nhymxu/814cf9b3294276629d2231248b709e26) but have a smaller community
1. Profiling
    1. I wanted to find out more about the internal workings in the app during a request. I could hook in the built-in `ProfilerMiddleware` for Flask, and visualize the resulting profile files using `tuna` and `snakeviz` (showing the hierarchy of Python calls and their expense)
    1. Findings:
        - for decoding the user JWT, we retrieve the public key of the boxtribute domain from Auth0. [Like others](https://community.auth0.com/t/where-are-jwks-key-ids-obtained-from-anywhere-in-the-auth0-gui/38890) we should consider **hard-coding the public key in our codebase or providing it via an env variable at least**
        - after having cut the public-key-retrieval overhead about 1/3 of the processing time is due to opening a MySQL connection at the start of processing the request. peewee provides support for [connection pooling](https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#pool) but it has to be evaluated how efficient this is in combination with Flask
        - the remaining processing time is mostly spent processing the actual database query
        - peewee [caches](http://docs.peewee-orm.com/en/latest/peewee/querying.html#iterating-over-large-result-sets) rows returned by select queries. For large queries it is recommended to work-around this behavior
        - a query like `bene = Beneficiary.get_by_id(id)`, followed by `bene.base.id` causes a full select of the Base model. Better be explicit and do `Beneficiary.select(Beneficiary, Base.id).join(Base).where(Beneficiary.id == id).get()`. This can avoid overhead, e.g. due to formatting datetime in peewee.

### Conclusion

The requests used in the experiments are still fairly simply, and don't put the app under concerning pressure. Profiling revealed some overhead that we can easily reduce. I'm not sure how much benefit further optimizations (e.g. using an async framework) would bring (but they would take some effort for sure). On that topic, I found [articles](https://calpaterson.com/async-python-is-not-faster.html) that question the performance of (and benchmarks issued by) async frameworks.

### Follow-up questions:
1. How many (simultaneous) users do we currently have in dropapp?
1. What are the resources (CPU, memory) of the stack we deploy to?

### Tasks

- [x] optimize peewee usage (avoid additional select call when resolving ID for FK field)
