### PR TITLE
Fix GraphQL resolvers and enums

### DIFF
--- a/back/boxtribute_server/graph_ql/enums.py
+++ b/back/boxtribute_server/graph_ql/enums.py
@@ -5,7 +5,15 @@ product_gender_enum = EnumType(
     "ProductGender",
     {
         "Women": 1,
+        "Men": 2,
         "UnisexAdult": 3,
+        "Girl": 4,
+        "Boy": 5,
+        "UnisexKid": 6,
+        "UnisexBaby": 9,
+        "None": 10,
+        "TeenGirl": 12,
+        "TeenBoy": 13,
     },
 )
 
@@ -13,6 +21,11 @@ box_state_enum = EnumType(
     "BoxState",
     {
         "InStock": 1,
+        "Lost": 2,
+        "Ordered": 3,
+        "Picked": 4,
+        "Donated": 5,
+        "Scrap": 6,
     },
 )
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -24,7 +24,7 @@ from ..models.size import Size
 from ..models.transaction import Transaction
 from ..models.user import User
 from ..models.x_beneficiary_language import XBeneficiaryLanguage
-from .pagination import generate_page, pagination_parameters
+from .pagination import load_into_page
 
 query = QueryType()
 mutation = MutationType()
@@ -155,21 +155,12 @@ def resolve_locations(_, info):
 @convert_kwargs_to_snake_case
 def resolve_products(_, info, pagination_input=None):
     authorize(permission="product:read")
-    cursor, limit = pagination_parameters(pagination_input)
     base_filter_condition = Base.id.in_(g.user["base_ids"])
-    pagination_condition = cursor.pagination_condition(Product)
-    selection = Product.select().join(Base)
-    products = (
-        selection.where((base_filter_condition) & (pagination_condition))
-        .order_by(Product.id)
-        .limit(limit + 1)
-    )
-    return generate_page(
+    return load_into_page(
+        Product,
         base_filter_condition,
-        elements=products,
-        cursor=cursor,
-        limit=limit,
-        selection=selection,
+        selection=Product.select().join(Base),
+        pagination_input=pagination_input,
     )
 
 
@@ -177,21 +168,12 @@ def resolve_products(_, info, pagination_input=None):
 @convert_kwargs_to_snake_case
 def resolve_beneficiaries(_, info, pagination_input=None):
     authorize(permission="beneficiary:read")
-    cursor, limit = pagination_parameters(pagination_input)
     base_filter_condition = Base.id.in_(g.user["base_ids"])
-    pagination_condition = cursor.pagination_condition(Beneficiary)
-    selection = Beneficiary.select().join(Base)
-    beneficiaries = (
-        selection.where((base_filter_condition) & (pagination_condition))
-        .order_by(Beneficiary.id)
-        .limit(limit + 1)
-    )
-    return generate_page(
+    return load_into_page(
+        Beneficiary,
         base_filter_condition,
-        elements=beneficiaries,
-        cursor=cursor,
-        limit=limit,
-        selection=selection,
+        selection=Beneficiary.select().join(Base),
+        pagination_input=pagination_input,
     )
 
 
@@ -287,21 +269,9 @@ def resolve_base_locations(base_obj, info):
 @convert_kwargs_to_snake_case
 def resolve_base_beneficiaries(base_obj, info, pagination_input=None):
     authorize(permission="beneficiary:read")
-    cursor, limit = pagination_parameters(pagination_input)
     base_filter_condition = Beneficiary.base == base_obj.id
-    pagination_condition = cursor.pagination_condition(Beneficiary)
-    selection = Beneficiary.select()
-    beneficiaries = (
-        selection.where((base_filter_condition) & (pagination_condition))
-        .order_by(Beneficiary.id)
-        .limit(limit + 1)
-    )
-    return generate_page(
-        base_filter_condition,
-        elements=beneficiaries,
-        cursor=cursor,
-        limit=limit,
-        selection=selection,
+    return load_into_page(
+        Beneficiary, base_filter_condition, pagination_input=pagination_input
     )
 
 
@@ -309,21 +279,9 @@ def resolve_base_beneficiaries(base_obj, info, pagination_input=None):
 @convert_kwargs_to_snake_case
 def resolve_location_boxes(location_obj, info, pagination_input=None):
     authorize(permission="stock:read")
-    cursor, limit = pagination_parameters(pagination_input)
     location_filter_condition = Box.location == location_obj.id
-    pagination_condition = cursor.pagination_condition(Box)
-    selection = Box.select()
-    boxes = (
-        selection.where((location_filter_condition) & (pagination_condition))
-        .order_by(Box.id)
-        .limit(limit + 1)
-    )
-    return generate_page(
-        location_filter_condition,
-        elements=boxes,
-        cursor=cursor,
-        limit=limit,
-        selection=selection,
+    return load_into_page(
+        Box, location_filter_condition, pagination_input=pagination_input
     )
 
 
@@ -357,21 +315,9 @@ def resolve_product_category_products(
     product_category_obj, info, pagination_input=None
 ):
     authorize(permission="product:read")
-    cursor, limit = pagination_parameters(pagination_input)
     category_filter_condition = Product.category == product_category_obj.id
-    pagination_condition = cursor.pagination_condition(Product)
-    selection = Product.select()
-    products = (
-        selection.where((category_filter_condition) & (pagination_condition))
-        .order_by(Product.id)
-        .limit(limit + 1)
-    )
-    return generate_page(
-        category_filter_condition,
-        elements=products,
-        cursor=cursor,
-        limit=limit,
-        selection=selection,
+    return load_into_page(
+        Product, category_filter_condition, pagination_input=pagination_input
     )
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -334,8 +334,14 @@ def resolve_organisation_bases(organisation_obj, info):
 
 
 @product.field("gender")
-def resolve_product_gender(obj, info):
-    return obj.id
+def resolve_product_gender(product_obj, info):
+    # Instead of a ProductGender instance return an integer for EnumType conversion
+    gender_id = product_obj.gender.id
+    if gender_id == 11:  # pragma: no cover
+        # In dropapp, UnisexChild (6) and UnisexKid (11) are merged.
+        # This shall be removed when a recent database dump is added.
+        gender_id = 6
+    return gender_id
 
 
 @product.field("sizes")

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -61,12 +61,13 @@ enum ProductGender {
   Men
   Women
   UnisexAdult
-  UnisexChild
+  UnisexKid
   UnisexBaby
   TeenGirl
   TeenBoy
   Girl
   Boy
+  None
 }
 
 enum BoxState {

--- a/back/boxtribute_server/models/product_gender.py
+++ b/back/boxtribute_server/models/product_gender.py
@@ -33,7 +33,7 @@ class ProductGender(db.Model):
         constraints=[SQL("UNSIGNED")],
     )
     seq = IntegerField(null=True)
-    short_label = CharField(null=True)
+    short_label = CharField(null=True, column_name="shortlabel")
 
     class Meta:
         table_name = "genders"


### PR DESCRIPTION
As a preparation for future FE implementation, I had a look at the [previous](https://github.com/boxwise/boxtribute/blob/36529720613db62176bf3221613369bb0630ce8c/react/src/utils/queries.ts) query definitions, and run them in the playground. Indeed I could find two inconsistencies :)

Further comments on the queries:
- USER: parameter `id` instead of `email`
- ALL_BASES, BASE, ORG_BASES: nested field `organisation { id }` instead of `organisationId`
- BOX_BY_QR: misleading name since it fetches box by `boxLabelIdentifier`. `size` and `state` instead of `size_id` and `box_state_id`
- PRODUCTS: now a paginated query. Accepts PaginationInput argument and returns ProductPage type

@aerinsol @haguesto How does the dropapp handle the ProductGender with ID 10? It does not have any name associated with it. Should it be represented by null?

@spaudanjo I don't expect a complete review, this is rather an FYI =)
Can you think of any other queries/mutations that might be relevant for the FE MVP?
