### PR TITLE
Update GraphQL types and operations for box-transfer

### DIFF
--- a/back/boxtribute_server/enums.py
+++ b/back/boxtribute_server/enums.py
@@ -3,24 +3,24 @@ import enum
 
 
 class TransferAgreementState(enum.IntEnum):
-    UNDER_REVIEW = 1
-    ACCEPTED = enum.auto()
-    REJECTED = enum.auto()
-    CANCELED = enum.auto()
-    EXPIRED = enum.auto()
+    UnderReview = 1
+    Accepted = enum.auto()
+    Rejected = enum.auto()
+    Canceled = enum.auto()
+    Expired = enum.auto()
 
 
 class TransferAgreementType(enum.IntEnum):
-    UNIDIRECTIONAL = 1
-    BIDIRECTIONAL = enum.auto()
+    Unidirectional = 1
+    Bidirectional = enum.auto()
 
 
 class ShipmentState(enum.IntEnum):
-    PREPARING = 1
-    SENT = enum.auto()
-    RECEIVED = enum.auto()
-    CANCELED = enum.auto()
-    LOST = enum.auto()
+    Preparing = 1
+    Sent = enum.auto()
+    Received = enum.auto()
+    Canceled = enum.auto()
+    Lost = enum.auto()
 
 
 class BoxState(enum.IntEnum):

--- a/back/boxtribute_server/enums.py
+++ b/back/boxtribute_server/enums.py
@@ -28,8 +28,8 @@ class BoxState(enum.IntEnum):
 
     InStock = 1
     Lost = enum.auto()
-    Ordered = enum.auto()
-    Picked = enum.auto()
+    MarkedForShipment = enum.auto()
+    Received = enum.auto()
     Donated = enum.auto()
     Scrap = enum.auto()
 

--- a/back/boxtribute_server/graph_ql/operations.graphql
+++ b/back/boxtribute_server/graph_ql/operations.graphql
@@ -17,9 +17,9 @@ type Query {
   beneficiary(id: ID!): Beneficiary
   beneficiaries(paginationInput: PaginationInput): BeneficiaryPage!
   transferAgreement(id: ID!): TransferAgreement
-  transferAgreements: [TransferAgreement!]!
+  transferAgreements(states: [TransferAgreementState!]): [TransferAgreement!]!
   shipment(id: ID!): Shipment
-  shipments: [Shipment!]!
+  shipments(filterInput: ShipmentFilterInput): [Shipment!]!
 }
 
 type Mutation {
@@ -30,14 +30,14 @@ type Mutation {
   updateBeneficiary(beneficiaryUpdateInput: UpdateBeneficiaryInput): Beneficiary
 
   createTransferAgreement(creationInput: TransferAgreementCreationInput): TransferAgreement
-  updateTransferAgreement(updateInput: TransferAgreementUpdateInput): TransferAgreement
   acceptTransferAgreement(id: ID!): TransferAgreement
   rejectTransferAgreement(id: ID!): TransferAgreement
+  cancelTransferAgreement(id: ID!): TransferAgreement
 
   createShipment(creationInput: ShipmentCreationInput): Shipment
   updateShipment(updateInput: ShipmentUpdateInput): Shipment
+  cancelShipment(id: ID!): Shipment
   sendShipment(id: ID!): Shipment
-  completeShipment(id: ID!, lost: Boolean): Shipment
 
   updateShipmentDetail(updateInput: ShipmentDetailUpdateInput): ShipmentDetail
 }

--- a/back/boxtribute_server/graph_ql/operations.graphql
+++ b/back/boxtribute_server/graph_ql/operations.graphql
@@ -16,6 +16,10 @@ type Query {
   productCategories: [ProductCategory!]!
   beneficiary(id: ID!): Beneficiary
   beneficiaries(paginationInput: PaginationInput): BeneficiaryPage!
+  transferAgreement(id: ID!): TransferAgreement
+  transferAgreements: [TransferAgreement!]!
+  shipment(id: ID!): Shipment
+  shipments: [Shipment!]!
 }
 
 type Mutation {
@@ -24,4 +28,16 @@ type Mutation {
   updateBox(boxUpdateInput: UpdateBoxInput): Box
   createBeneficiary(beneficiaryCreationInput: CreateBeneficiaryInput): Beneficiary
   updateBeneficiary(beneficiaryUpdateInput: UpdateBeneficiaryInput): Beneficiary
+
+  createTransferAgreement(creationInput: TransferAgreementCreationInput): TransferAgreement
+  updateTransferAgreement(updateInput: TransferAgreementUpdateInput): TransferAgreement
+  acceptTransferAgreement(id: ID!): TransferAgreement
+  rejectTransferAgreement(id: ID!): TransferAgreement
+
+  createShipment(creationInput: ShipmentCreationInput): Shipment
+  updateShipment(updateInput: ShipmentUpdateInput): Shipment
+  sendShipment(id: ID!): Shipment
+  completeShipment(id: ID!, lost: Boolean): Shipment
+
+  updateShipmentDetail(updateInput: ShipmentDetailUpdateInput): ShipmentDetail
 }

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -275,12 +275,11 @@ type TransferAgreement {
   requestedOn: Datetime!
   acceptedBy: User
   acceptedOn: Datetime
-  rejectedBy: User
-  rejectedOn: Datetime
-  canceledBy: User
-  canceledOn: Datetime
+  terminatedBy: User
+  terminatedOn: Datetime
   validFrom: Datetime!
   validUntil: Datetime
+  comment: String
   sourceBases: [Base!]!
   targetBases: [Base!]
   shipments: [Shipment!]!
@@ -291,16 +290,16 @@ type Shipment {
   sourceBase: Base
   targetBase: Base
   state: ShipmentState
-  createdBy: User!
-  createdOn: Datetime!
+  startedBy: User!
+  startedOn: Datetime!
   sentBy: User
   sentOn: Datetime
-  receivedBy: User
-  receivedOn: User
+  completedBy: User
+  completedOn: Datetime
+  canceledBy: User
+  canceledOn: Datetime
   transferAgreement: TransferAgreement!
   details: [ShipmentDetail!]!
-  lastModifiedBy: User!
-  lastModifiedOn: Datetime!
 }
 
 type ShipmentDetail {
@@ -311,19 +310,14 @@ type ShipmentDetail {
   targetLocation: Location
   box: Box!
   shipment: Shipment!
-  lastModifiedBy: User!
-  lastModifiedOn: Datetime!
+  createdBy: User!
+  createdOn: Datetime!
+  deletedBy: User
+  deletedOn: Datetime
 }
 
 input TransferAgreementCreationInput {
   targetOrganisationId: Int!
-  validFrom: Datetime
-  validUntil: Datetime
-  sourceBaseIds: [Int!]
-}
-
-input TransferAgreementUpdateInput {
-  id: ID!
   validFrom: Datetime
   validUntil: Datetime
   sourceBaseIds: [Int!]
@@ -352,6 +346,11 @@ input ShipmentDetailUpdateInput {
   id: ID!
   targetProductId: Int!
   targetLocationId: Int!
+}
+
+input ShipmentFilterInput {
+  sourceOrganisationId: Int
+  targetOrganisationId: Int
 }
 
 enum TransferAgreementState {

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -319,8 +319,10 @@ type ShipmentDetail {
 
 input TransferAgreementCreationInput {
   targetOrganisationId: Int!
-  validFrom: Datetime
-  validUntil: Datetime
+  # pass local date and timezone information (e.g. 'Europe/Berlin')
+  validFrom: Date
+  validUntil: Date
+  timezone: String
   sourceBaseIds: [Int!]
   targetBaseIds: [Int!]
 }

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -247,25 +247,6 @@ enum Language {
 scalar Datetime
 scalar Date
 
-# all below is speculative #
-type Order {
-  id: ID!
-  fromLocation: String!
-  toLocation: String!
-  # If null means internal transfer
-  fromOrg: Int
-  # If null means internal transfer
-  toOrg: Int
-  boxes: Box!
-  # If box state of all ordered boxes have not yet been changed, then it is active
-  isActive: Boolean!
-  createdBy: User!
-  createdOn: Datetime!
-  lastModifiedBy: User
-  # Need to change int to custom scalar for datetime
-  lastModifiedOn: Int
-}
-
 type TransferAgreement {
   id: ID!
   sourceOrganisation: Organisation!

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -271,6 +271,7 @@ type TransferAgreement {
   sourceOrganisation: Organisation!
   targetOrganisation: Organisation!
   state: TransferAgreementState
+  type: TransferAgreementType!
   requestedBy: User!
   requestedOn: Datetime!
   acceptedBy: User
@@ -359,6 +360,11 @@ enum TransferAgreementState {
   Rejected
   Canceled
   Expired
+}
+
+enum TransferAgreementType {
+  unidirectional
+  bidirectional
 }
 
 enum ShipmentState {

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -70,8 +70,8 @@ enum ProductGender {
 enum BoxState {
   InStock
   Lost
-  Ordered
-  Picked
+  MarkedForShipment
+  Received
   Donated
   Scrap
 }
@@ -264,4 +264,108 @@ type Order {
   lastModifiedBy: User
   # Need to change int to custom scalar for datetime
   lastModifiedOn: Int
+}
+
+type TransferAgreement {
+  id: ID!
+  sourceOrganisation: Organisation!
+  targetOrganisation: Organisation!
+  state: TransferAgreementState
+  requestedBy: User!
+  requestedOn: Datetime!
+  acceptedBy: User
+  acceptedOn: Datetime
+  rejectedBy: User
+  rejectedOn: Datetime
+  canceledBy: User
+  canceledOn: Datetime
+  validFrom: Datetime!
+  validUntil: Datetime
+  sourceBases: [Base!]!
+  targetBases: [Base!]
+  shipments: [Shipment!]!
+}
+
+type Shipment {
+  id: ID!
+  sourceBase: Base
+  targetBase: Base
+  state: ShipmentState
+  createdBy: User!
+  createdOn: Datetime!
+  sentBy: User
+  sentOn: Datetime
+  receivedBy: User
+  receivedOn: User
+  transferAgreement: TransferAgreement!
+  details: [ShipmentDetail!]!
+  lastModifiedBy: User!
+  lastModifiedOn: Datetime!
+}
+
+type ShipmentDetail {
+  id: ID!
+  sourceProduct: Product!
+  targetProduct: Product
+  sourceLocation: Location!
+  targetLocation: Location
+  box: Box!
+  shipment: Shipment!
+  lastModifiedBy: User!
+  lastModifiedOn: Datetime!
+}
+
+input TransferAgreementCreationInput {
+  targetOrganisationId: Int!
+  validFrom: Datetime
+  validUntil: Datetime
+  sourceBaseIds: [Int!]
+}
+
+input TransferAgreementUpdateInput {
+  id: ID!
+  validFrom: Datetime
+  validUntil: Datetime
+  sourceBaseIds: [Int!]
+  targetBaseIds: [Int!]
+}
+
+input ShipmentCreationInput {
+  sourceBaseId: Int!
+  targetBaseId: Int!
+  transferAgreementId: Int!
+}
+
+input ShipmentUpdateInput {
+  id: ID!
+  sourceBaseId: Int!
+  targetBaseId: Int!
+  # IDs of boxes prepared for shipment
+  preparedBoxIds: [Int!]!
+  # IDs of prepared boxes to be moved back to stock
+  removedBoxIds: [Int!]!
+  # IDs of boxes that went lost during shipment
+  lostBoxIds: [Int!]!
+}
+
+input ShipmentDetailUpdateInput {
+  id: ID!
+  targetProductId: Int!
+  targetLocationId: Int!
+}
+
+enum TransferAgreementState {
+  UnderReview
+  Accepted
+  Rejected
+  Canceled
+  Expired
+}
+
+enum ShipmentState {
+  Preparing
+  Sent
+  Completed
+  Lost
+  Canceled
 }

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -346,8 +346,8 @@ enum TransferAgreementState {
 }
 
 enum TransferAgreementType {
-  unidirectional
-  bidirectional
+  Unidirectional
+  Bidirectional
 }
 
 enum ShipmentState {

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -261,7 +261,7 @@ def update_shipment(data):
         for box in Box.select().where(
             Box.label_identifier.in_(prepared_box_label_identifiers)
         ):
-            box.state = BoxState.Ordered.value  # MarkedForShipment
+            box.state = BoxState.MarkedForShipment.value
             boxes.append(box)
             details.append(
                 {

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -239,7 +239,7 @@ def create_shipment(data):
     """
     transfer_agreement_id = data.pop("transfer_agreement_id")
     agreement = TransferAgreement.get_by_id(transfer_agreement_id)
-    if agreement.state != TransferAgreementState.ACCEPTED.value:
+    if agreement.state != TransferAgreementState.Accepted.value:
         raise InvalidTransferAgreement()
 
     return Shipment.create(

--- a/back/boxtribute_server/models/definitions/shipment.py
+++ b/back/boxtribute_server/models/definitions/shipment.py
@@ -16,7 +16,7 @@ class Shipment(db.Model):
         model=TransferAgreement, on_update="CASCADE"
     )
     state = EnumCharField(
-        constraints=[SQL(f"DEFAULT '{ShipmentState.PREPARING.name}'")],
+        constraints=[SQL(f"DEFAULT '{ShipmentState.Preparing.name}'")],
         choices=ShipmentState,
     )
     started_on = DateTimeField(default=utcnow)

--- a/back/boxtribute_server/models/definitions/transfer_agreement.py
+++ b/back/boxtribute_server/models/definitions/transfer_agreement.py
@@ -13,7 +13,7 @@ class TransferAgreement(db.Model):
     target_organisation = UIntForeignKeyField(model=Organisation, on_update="CASCADE")
     state = EnumCharField(
         choices=TransferAgreementState,
-        constraints=[SQL(f"DEFAULT '{TransferAgreementState.UNDER_REVIEW.name}'")],
+        constraints=[SQL(f"DEFAULT '{TransferAgreementState.UnderReview.name}'")],
     )
     type = EnumCharField(choices=TransferAgreementType)
     requested_on = DateTimeField(default=utcnow)

--- a/back/test/data/shipment.py
+++ b/back/test/data/shipment.py
@@ -13,7 +13,7 @@ def data():
         "source_base": base_data()[0]["id"],
         "target_base": base_data()[2]["id"],
         "transfer_agreement": transfer_agreement_data()["id"],
-        "state": ShipmentState.PREPARING.value,
+        "state": ShipmentState.Preparing.value,
         "started_by": default_user_data()["id"],
     }
 

--- a/back/test/data/transfer_agreement.py
+++ b/back/test/data/transfer_agreement.py
@@ -11,8 +11,8 @@ def data():
         "id": 1,
         "source_organisation": organisation_data()[0]["id"],
         "target_organisation": organisation_data()[1]["id"],
-        "state": TransferAgreementState.ACCEPTED.value,
-        "type": TransferAgreementType.BIDIRECTIONAL.value,
+        "state": TransferAgreementState.Accepted.value,
+        "type": TransferAgreementType.Bidirectional.value,
         "requested_by": default_user_data()["id"],
         "comment": "looks good to me",
     }
@@ -21,7 +21,7 @@ def data():
 def expired_transfer_agreement_data():
     agreement = data()
     agreement["id"] = 2
-    agreement["state"] = TransferAgreementState.EXPIRED.value
+    agreement["state"] = TransferAgreementState.Expired.value
     return agreement
 
 

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -217,7 +217,7 @@ def test_create_shipment(
     assert detail["created_on"] is not None
 
     box = Box.get_by_id(detail["box"])
-    assert box.state_id == BoxState.Ordered.value
+    assert box.state_id == BoxState.MarkedForShipment.value
 
 
 def test_create_shipment_from_expired_agreement(

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -86,7 +86,7 @@ def test_create_transfer_agreement(
         "valid_from": None,
         "valid_until": None,
         "requested_by": default_user["id"],
-        "type": TransferAgreementType.UNIDIRECTIONAL.value,
+        "type": TransferAgreementType.Unidirectional.value,
         "source_base_ids": None,
     }
     agreement = create_transfer_agreement(data.copy())
@@ -112,8 +112,8 @@ def test_create_transfer_agreement(
         >= {
             "source_organisation": default_organisation["id"],
             "target_organisation": another_organisation["id"],
-            "state": TransferAgreementState.UNDER_REVIEW.value,
-            "type": TransferAgreementType.UNIDIRECTIONAL.value,
+            "state": TransferAgreementState.UnderReview.value,
+            "type": TransferAgreementType.Unidirectional.value,
             "requested_by": default_user["id"],
             "accepted_by": None,
             "accepted_on": None,
@@ -178,7 +178,7 @@ def test_create_shipment(
             "source_base": default_bases[1]["id"],
             "target_base": default_bases[3]["id"],
             "transfer_agreement": default_transfer_agreement["id"],
-            "state": ShipmentState.PREPARING.value,
+            "state": ShipmentState.Preparing.value,
             "canceled_on": None,
             "canceled_by": None,
             "sent_on": None,


### PR DESCRIPTION
To be reviewed in combination with the database ERD and the user action list linked in the Trello ticket below.

This is a first version, feel free to comment/review if anything is of major concern. I likely change things a little bit during implementation.

- the types represent the hierarchy of the data layer: agreement -> shipment -> shipment detail
- the agreement details are available as TransferAgreement.sourceBases and .targetBases
- updateShipment can be used for three different actions
- sendShipment and completeShipment serve as trigger for Shipment state transitions
- accept/rejectTransferAgreement serve as trigger for TransferAgreement state transitions
