### PR TITLE
Implement GraphQL queries for box-transfer

### DIFF
--- a/back/boxtribute_server/enums.py
+++ b/back/boxtribute_server/enums.py
@@ -18,7 +18,7 @@ class TransferAgreementType(enum.IntEnum):
 class ShipmentState(enum.IntEnum):
     Preparing = 1
     Sent = enum.auto()
-    Received = enum.auto()
+    Completed = enum.auto()
     Canceled = enum.auto()
     Lost = enum.auto()
 

--- a/back/boxtribute_server/graph_ql/enums.py
+++ b/back/boxtribute_server/graph_ql/enums.py
@@ -5,6 +5,7 @@ from ..enums import (
     HumanGender,
     Language,
     ProductGender,
+    ShipmentState,
     TransferAgreementState,
     TransferAgreementType,
 )
@@ -14,6 +15,7 @@ enum_types = [
     EnumType("BoxState", BoxState),
     EnumType("HumanGender", HumanGender),
     EnumType("Language", Language),
+    EnumType("ShipmentState", ShipmentState),
     EnumType("TransferAgreementState", TransferAgreementState),
     EnumType("TransferAgreementType", TransferAgreementType),
 ]

--- a/back/boxtribute_server/graph_ql/enums.py
+++ b/back/boxtribute_server/graph_ql/enums.py
@@ -1,10 +1,19 @@
 from ariadne import EnumType
 
-from ..enums import BoxState, HumanGender, Language, ProductGender
+from ..enums import (
+    BoxState,
+    HumanGender,
+    Language,
+    ProductGender,
+    TransferAgreementState,
+    TransferAgreementType,
+)
 
 enum_types = [
     EnumType("ProductGender", ProductGender),
     EnumType("BoxState", BoxState),
     EnumType("HumanGender", HumanGender),
     EnumType("Language", Language),
+    EnumType("TransferAgreementState", TransferAgreementState),
+    EnumType("TransferAgreementType", TransferAgreementType),
 ]

--- a/back/boxtribute_server/graph_ql/operations.graphql
+++ b/back/boxtribute_server/graph_ql/operations.graphql
@@ -17,6 +17,10 @@ type Query {
   beneficiary(id: ID!): Beneficiary
   beneficiaries(paginationInput: PaginationInput): BeneficiaryPage!
   transferAgreement(id: ID!): TransferAgreement
+  """
+  Without any arguments, return transfer agreements that involve client's organisation,
+  regardless of agreement state. Optionally filter for agreements of certain state(s).
+  """
   transferAgreements(states: [TransferAgreementState!]): [TransferAgreement!]!
   shipment(id: ID!): Shipment
   shipments(filterInput: ShipmentFilterInput): [Shipment!]!

--- a/back/boxtribute_server/graph_ql/operations.graphql
+++ b/back/boxtribute_server/graph_ql/operations.graphql
@@ -23,7 +23,7 @@ type Query {
   """
   transferAgreements(states: [TransferAgreementState!]): [TransferAgreement!]!
   shipment(id: ID!): Shipment
-  shipments(filterInput: ShipmentFilterInput): [Shipment!]!
+  shipments: [Shipment!]!
 }
 
 type Mutation {

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -5,7 +5,7 @@ from peewee import fn
 from flask import g
 
 from ..authz import authorize
-from ..enums import HumanGender
+from ..enums import HumanGender, TransferAgreementState
 from ..models.crud import (
     create_beneficiary,
     create_box,
@@ -198,11 +198,15 @@ def resolve_beneficiaries(_, info, pagination_input=None):
 
 
 @query.field("transferAgreements")
-def resolve_transfer_agreements(_, info):
+def resolve_transfer_agreements(_, info, states=None):
     user_organisation_id = g.user["organisation_id"]
+    states = states or list(TransferAgreementState)
     return TransferAgreement.select().where(
-        (TransferAgreement.source_organisation == user_organisation_id)
-        | (TransferAgreement.target_organisation == user_organisation_id)
+        (
+            (TransferAgreement.source_organisation == user_organisation_id)
+            | (TransferAgreement.target_organisation == user_organisation_id)
+        )
+        & (TransferAgreement.state << states)
     )
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -32,16 +32,25 @@ from .pagination import load_into_page
 
 query = QueryType()
 mutation = MutationType()
-base = ObjectType("Base")
-beneficiary = ObjectType("Beneficiary")
-box = ObjectType("Box")
-location = ObjectType("Location")
-organisation = ObjectType("Organisation")
-product = ObjectType("Product")
-product_category = ObjectType("ProductCategory")
-qr_code = ObjectType("QrCode")
-transfer_agreement = ObjectType("TransferAgreement")
-user = ObjectType("User")
+object_types = []
+
+
+def _register_object_type(name):
+    object_type = ObjectType(name)
+    object_types.append(object_type)
+    return object_type
+
+
+base = _register_object_type("Base")
+beneficiary = _register_object_type("Beneficiary")
+box = _register_object_type("Box")
+location = _register_object_type("Location")
+organisation = _register_object_type("Organisation")
+product = _register_object_type("Product")
+product_category = _register_object_type("ProductCategory")
+qr_code = _register_object_type("QrCode")
+transfer_agreement = _register_object_type("TransferAgreement")
+user = _register_object_type("User")
 
 
 @user.field("bases")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -217,6 +217,19 @@ def resolve_transfer_agreements(_, info, states=None):
     )
 
 
+@query.field("shipments")
+def resolve_shipments(_, info):
+    user_organisation_id = g.user["organisation_id"]
+    return (
+        Shipment.select()
+        .join(TransferAgreement)
+        .where(
+            (TransferAgreement.source_organisation == user_organisation_id)
+            | (TransferAgreement.target_organisation == user_organisation_id)
+        )
+    )
+
+
 @beneficiary.field("tokens")
 def resolve_beneficiary_tokens(beneficiary_obj, info):
     authorize(permission="transaction:read")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -197,6 +197,15 @@ def resolve_beneficiaries(_, info, pagination_input=None):
     )
 
 
+@query.field("transferAgreements")
+def resolve_transfer_agreements(_, info):
+    user_organisation_id = g.user["organisation_id"]
+    return TransferAgreement.select().where(
+        (TransferAgreement.source_organisation == user_organisation_id)
+        | (TransferAgreement.target_organisation == user_organisation_id)
+    )
+
+
 @beneficiary.field("tokens")
 def resolve_beneficiary_tokens(beneficiary_obj, info):
     authorize(permission="transaction:read")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -22,6 +22,7 @@ from ..models.definitions.product import Product
 from ..models.definitions.product_category import ProductCategory
 from ..models.definitions.qr_code import QrCode
 from ..models.definitions.shipment import Shipment
+from ..models.definitions.shipment_detail import ShipmentDetail
 from ..models.definitions.size import Size
 from ..models.definitions.transaction import Transaction
 from ..models.definitions.transfer_agreement import TransferAgreement
@@ -49,6 +50,7 @@ organisation = _register_object_type("Organisation")
 product = _register_object_type("Product")
 product_category = _register_object_type("ProductCategory")
 qr_code = _register_object_type("QrCode")
+shipment = _register_object_type("Shipment")
 transfer_agreement = _register_object_type("TransferAgreement")
 user = _register_object_type("User")
 
@@ -152,6 +154,11 @@ def resolve_product_category(_, info, id):
 @query.field("transferAgreement")
 def resolve_transfer_agreement(_, info, id):
     return TransferAgreement.get_by_id(id)
+
+
+@query.field("shipment")
+def resolve_shipment(_, info, id):
+    return Shipment.get_by_id(id)
 
 
 @query.field("productCategories")
@@ -374,6 +381,11 @@ def resolve_product_category_products(
 def resolve_qr_code_box(qr_code_obj, info):
     authorize(permission="stock:read")
     return Box.get(Box.qr_code == qr_code_obj.id)
+
+
+@shipment.field("details")
+def resolve_shipment_details(shipment_obj, info):
+    return ShipmentDetail.select().where(ShipmentDetail.shipment == shipment_obj.id)
 
 
 @transfer_agreement.field("sourceBases")

--- a/back/boxtribute_server/graph_ql/schema.py
+++ b/back/boxtribute_server/graph_ql/schema.py
@@ -2,20 +2,7 @@ from ariadne import make_executable_schema, snake_case_fallback_resolvers
 
 from .definitions import definitions
 from .enums import enum_types
-from .resolvers import (
-    base,
-    beneficiary,
-    box,
-    location,
-    mutation,
-    organisation,
-    product,
-    product_category,
-    qr_code,
-    query,
-    transfer_agreement,
-    user,
-)
+from .resolvers import mutation, object_types, query
 from .scalars import date_scalar, datetime_scalar
 
 schema = make_executable_schema(
@@ -25,16 +12,7 @@ schema = make_executable_schema(
         mutation,
         date_scalar,
         datetime_scalar,
-        base,
-        beneficiary,
-        box,
-        location,
-        organisation,
-        product,
-        product_category,
-        qr_code,
-        transfer_agreement,
-        user,
+        *object_types,
         *enum_types,
     ],
     snake_case_fallback_resolvers,

--- a/back/boxtribute_server/graph_ql/schema.py
+++ b/back/boxtribute_server/graph_ql/schema.py
@@ -13,6 +13,7 @@ from .resolvers import (
     product_category,
     qr_code,
     query,
+    transfer_agreement,
     user,
 )
 from .scalars import date_scalar, datetime_scalar
@@ -32,6 +33,7 @@ schema = make_executable_schema(
         product,
         product_category,
         qr_code,
+        transfer_agreement,
         user,
         *enum_types,
     ],

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -332,11 +332,6 @@ input ShipmentDetailUpdateInput {
   targetLocationId: Int!
 }
 
-input ShipmentFilterInput {
-  sourceOrganisationId: Int
-  targetOrganisationId: Int
-}
-
 enum TransferAgreementState {
   UnderReview
   Accepted

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -354,6 +354,6 @@ enum ShipmentState {
   Preparing
   Sent
   Completed
-  Lost
   Canceled
+  Lost
 }

--- a/back/boxtribute_server/models/definitions/transfer_agreement.py
+++ b/back/boxtribute_server/models/definitions/transfer_agreement.py
@@ -43,4 +43,4 @@ class TransferAgreement(db.Model):
     )
     valid_from = DateTimeField(default=utcnow)
     valid_until = DateTimeField(null=True)
-    comment = TextField(constraints=[SQL("DEFAULT ''")])
+    comment = TextField(constraints=[SQL("DEFAULT ''")], default="")

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -19,7 +19,11 @@ from .qr_code import default_qr_code, qr_code_without_box
 from .shipment import default_shipment
 from .size_range import default_size_range
 from .transaction import default_transaction
-from .transfer_agreement import default_transfer_agreement, expired_transfer_agreement
+from .transfer_agreement import (
+    default_transfer_agreement,
+    expired_transfer_agreement,
+    transfer_agreements,
+)
 from .user import default_user, default_users
 
 __all__ = [
@@ -48,6 +52,7 @@ __all__ = [
     "default_users",
     "expired_transfer_agreement",
     "qr_code_without_box",
+    "transfer_agreements",
 ]
 
 MODULE_DIRECTORY = pathlib.Path(__file__).resolve().parent

--- a/back/test/data/shipment.py
+++ b/back/test/data/shipment.py
@@ -1,10 +1,13 @@
 import pytest
 from boxtribute_server.enums import ShipmentState
 from boxtribute_server.models.definitions.shipment import Shipment
+from boxtribute_server.models.utils import utcnow
 
 from .base import data as base_data
 from .transfer_agreement import data as transfer_agreement_data
 from .user import default_user_data
+
+TIME = utcnow().replace(tzinfo=None)
 
 
 def data():
@@ -15,6 +18,7 @@ def data():
         "transfer_agreement": transfer_agreement_data()[0]["id"],
         "state": ShipmentState.Preparing.value,
         "started_by": default_user_data()["id"],
+        "started_on": TIME,
     }
 
 

--- a/back/test/data/shipment.py
+++ b/back/test/data/shipment.py
@@ -12,7 +12,7 @@ def data():
         "id": 1,
         "source_base": base_data()[0]["id"],
         "target_base": base_data()[2]["id"],
-        "transfer_agreement": transfer_agreement_data()["id"],
+        "transfer_agreement": transfer_agreement_data()[0]["id"],
         "state": ShipmentState.Preparing.value,
         "started_by": default_user_data()["id"],
     }

--- a/back/test/data/transfer_agreement.py
+++ b/back/test/data/transfer_agreement.py
@@ -1,9 +1,12 @@
 import pytest
 from boxtribute_server.enums import TransferAgreementState, TransferAgreementType
 from boxtribute_server.models.definitions.transfer_agreement import TransferAgreement
+from boxtribute_server.models.utils import utcnow
 
 from .organisation import data as organisation_data
 from .user import default_user_data
+
+TIME = utcnow().replace(tzinfo=None)
 
 
 def data():
@@ -14,6 +17,8 @@ def data():
         "state": TransferAgreementState.Accepted.value,
         "type": TransferAgreementType.Bidirectional.value,
         "requested_by": default_user_data()["id"],
+        "requested_on": TIME,
+        "valid_from": TIME,
         "comment": "looks good to me",
     }
 

--- a/back/test/data/transfer_agreement.py
+++ b/back/test/data/transfer_agreement.py
@@ -10,36 +10,43 @@ TIME = utcnow().replace(tzinfo=None)
 
 
 def data():
-    return {
-        "id": 1,
-        "source_organisation": organisation_data()[0]["id"],
-        "target_organisation": organisation_data()[1]["id"],
-        "state": TransferAgreementState.Accepted.value,
-        "type": TransferAgreementType.Bidirectional.value,
-        "requested_by": default_user_data()["id"],
-        "requested_on": TIME,
-        "valid_from": TIME,
-        "comment": "looks good to me",
-    }
-
-
-def expired_transfer_agreement_data():
-    agreement = data()
-    agreement["id"] = 2
-    agreement["state"] = TransferAgreementState.Expired.value
-    return agreement
+    return [
+        {
+            "id": 1,
+            "source_organisation": organisation_data()[0]["id"],
+            "target_organisation": organisation_data()[1]["id"],
+            "state": TransferAgreementState.Accepted.value,
+            "type": TransferAgreementType.Bidirectional.value,
+            "requested_by": default_user_data()["id"],
+            "requested_on": TIME,
+            "valid_from": TIME,
+            "comment": "looks good to me",
+        },
+        {
+            "id": 2,
+            "source_organisation": organisation_data()[0]["id"],
+            "target_organisation": organisation_data()[1]["id"],
+            "state": TransferAgreementState.Expired.value,
+            "type": TransferAgreementType.Bidirectional.value,
+            "requested_by": default_user_data()["id"],
+        },
+    ]
 
 
 @pytest.fixture
 def default_transfer_agreement():
-    return data()
+    return data()[0]
 
 
 @pytest.fixture
 def expired_transfer_agreement():
-    return expired_transfer_agreement_data()
+    return data()[1]
+
+
+@pytest.fixture
+def transfer_agreements():
+    return data()
 
 
 def create():
-    TransferAgreement.create(**data())
-    TransferAgreement.create(**expired_transfer_agreement_data())
+    TransferAgreement.insert_many(data()).execute()

--- a/back/test/data/transfer_agreement_detail.py
+++ b/back/test/data/transfer_agreement_detail.py
@@ -11,7 +11,7 @@ def data():
     return [
         {
             "id": 1,
-            "transfer_agreement": transfer_agreement_data()["id"],
+            "transfer_agreement": transfer_agreement_data()[0]["id"],
             "source_base": None,
             "target_base": base_data()[2]["id"],
         }

--- a/back/test/data/transfer_agreement_detail.py
+++ b/back/test/data/transfer_agreement_detail.py
@@ -1,0 +1,27 @@
+import pytest
+from boxtribute_server.models.definitions.transfer_agreement_detail import (
+    TransferAgreementDetail,
+)
+
+from .base import data as base_data
+from .transfer_agreement import data as transfer_agreement_data
+
+
+def data():
+    return [
+        {
+            "id": 1,
+            "transfer_agreement": transfer_agreement_data()["id"],
+            "source_base": None,
+            "target_base": base_data()[2]["id"],
+        }
+    ]
+
+
+@pytest.fixture
+def default_transfer_agreement_detail():
+    return data()[0]
+
+
+def create():
+    TransferAgreementDetail.insert_many(data()).execute()

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -1,0 +1,59 @@
+from boxtribute_server.enums import ShipmentState
+
+
+def test_shipment_query(read_only_client, default_shipment):
+    shipment_id = str(default_shipment["id"])
+    query = f"""query {{
+                shipment(id: {shipment_id}) {{
+                    id
+                    sourceBase {{
+                        id
+                    }}
+                    targetBase {{
+                        id
+                    }}
+                    state
+                    startedBy {{
+                        id
+                    }}
+                    startedOn
+                    sentBy {{
+                        id
+                    }}
+                    sentOn
+                    completedBy {{
+                        id
+                    }}
+                    completedOn
+                    canceledBy {{
+                        id
+                    }}
+                    canceledOn
+                    transferAgreement {{
+                        id
+                    }}
+                    details {{
+                        id
+                    }}
+                }}
+            }}"""
+    data = {"query": query}
+    response = read_only_client.post("/graphql", json=data)
+    shipment = response.json["data"]["shipment"]
+
+    assert shipment == {
+        "id": shipment_id,
+        "sourceBase": {"id": str(default_shipment["source_base"])},
+        "targetBase": {"id": str(default_shipment["target_base"])},
+        "state": ShipmentState(default_shipment["state"]).name,
+        "startedBy": {"id": str(default_shipment["started_by"])},
+        "startedOn": default_shipment["started_on"].isoformat() + "+00:00",
+        "sentBy": None,
+        "sentOn": None,
+        "completedBy": None,
+        "completedOn": None,
+        "canceledBy": None,
+        "canceledOn": None,
+        "transferAgreement": {"id": str(default_shipment["transfer_agreement"])},
+        "details": [],
+    }

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -57,3 +57,11 @@ def test_shipment_query(read_only_client, default_shipment):
         "transferAgreement": {"id": str(default_shipment["transfer_agreement"])},
         "details": [],
     }
+
+
+def test_shipments_query(read_only_client, default_shipment):
+    query = "query { shipments { id } }"
+    data = {"query": query}
+    response = read_only_client.post("/graphql", json=data)
+    shipments = response.json["data"]["shipments"]
+    assert shipments == [{"id": str(default_shipment["id"])}]

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -1,0 +1,72 @@
+from boxtribute_server.enums import TransferAgreementState, TransferAgreementType
+
+
+def test_transfer_agreement_query(
+    read_only_client, default_transfer_agreement, default_shipment
+):
+    agreement_id = str(default_transfer_agreement["id"])
+    query = f"""query {{
+                transferAgreement(id: {agreement_id}) {{
+                    id
+                    sourceOrganisation {{
+                        id
+                    }}
+                    targetOrganisation {{
+                        id
+                    }}
+                    state
+                    type
+                    requestedBy {{
+                        id
+                    }}
+                    requestedOn
+                    acceptedBy {{
+                        id
+                    }}
+                    acceptedOn
+                    terminatedBy {{
+                        id
+                    }}
+                    terminatedOn
+                    validFrom
+                    validUntil
+                    comment
+                    sourceBases {{
+                        id
+                    }}
+                    targetBases {{
+                        id
+                    }}
+                    shipments {{
+                        id
+                    }}
+                }}
+            }}"""
+    data = {"query": query}
+    response = read_only_client.post("/graphql", json=data)
+    agreement = response.json["data"]["transferAgreement"]
+
+    assert agreement == {
+        "id": agreement_id,
+        "sourceOrganisation": {
+            "id": str(default_transfer_agreement["source_organisation"])
+        },
+        "targetOrganisation": {
+            "id": str(default_transfer_agreement["target_organisation"])
+        },
+        "state": TransferAgreementState(default_transfer_agreement["state"]).name,
+        "type": TransferAgreementType(default_transfer_agreement["type"]).name,
+        "requestedBy": {"id": str(default_transfer_agreement["requested_by"])},
+        "requestedOn": default_transfer_agreement["requested_on"].isoformat()
+        + "+00:00",
+        "acceptedBy": None,
+        "acceptedOn": None,
+        "terminatedBy": None,
+        "terminatedOn": None,
+        "comment": default_transfer_agreement["comment"],
+        "validFrom": default_transfer_agreement["valid_from"].isoformat() + "+00:00",
+        "validUntil": None,
+        "sourceBases": [{"id": "1"}, {"id": "2"}],
+        "targetBases": [{"id": "3"}],
+        "shipments": [{"id": str(default_shipment["id"])}],
+    }

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -70,3 +70,11 @@ def test_transfer_agreement_query(
         "targetBases": [{"id": "3"}],
         "shipments": [{"id": str(default_shipment["id"])}],
     }
+
+
+def test_transfer_agreements_query(read_only_client, transfer_agreements):
+    query = """query { transferAgreements { id } }"""
+    data = {"query": query}
+    response = read_only_client.post("/graphql", json=data)
+    agreements = response.json["data"]["transferAgreements"]
+    assert agreements == [{"id": str(t["id"])} for t in transfer_agreements]


### PR DESCRIPTION
That worked well...setting up the queries to fetch transfer agreements and shipments via GraphQL

For filtering, the following applies:
- filtering by organisation happens implicitly by only returning agreements/shipments that the current client's organisation is involved in (as either source or target)
- agreements can be filtered by state
- shipments cannot be further filtered

Do you agree with these decisions?
Anyways we can always extend the filtering logic in the process of developing the MVP and beyond =)

https://trello.com/c/e7vZrQAP/804-implement-graphql-queries-for-box-transfer
