### PR TITLE
810 use 5005 for host only

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -20,7 +20,7 @@ FROM base AS development
 # Path of module containing Flask app, relative to WORKDIR
 ENV FLASK_APP boxtribute_server/main
 ENV FLASK_ENV development
-CMD flask run -h 0.0.0 -p 5005
+CMD flask run -h 0.0.0 -p 5000
 
 # Select final stage depending on flask_env argument
 FROM ${flask_env} AS final

--- a/back/README.md
+++ b/back/README.md
@@ -243,7 +243,7 @@ and inspect the reported output. Open the HTML report via `back/htmlcov/index.ht
 The back-end exposes the GraphQL API at the `/graphql` endpoint. You can experiment with the API in the GraphQL playground.
 
 1. Start the required services by `docker-compose up webapp db`
-1. Open `localhost:5005/graphql`.
+1. Open `localhost:5000/graphql`.
 1. Simulate being a valid, logged-in user by fetching an authorization token (internally the variables of the `.env` file are used): `./fetch_token`
 1. Copy the content of the `access_token` field (alternatively, you can pipe the above command ` | jq -r .access_token | xclip -i -selection c` to copy it to the system clipboard)
 1.  Insert the access token in the following format on the playground in the section on the bottom left of the playground called HTTP Headers.

--- a/back/README.md
+++ b/back/README.md
@@ -243,7 +243,7 @@ and inspect the reported output. Open the HTML report via `back/htmlcov/index.ht
 The back-end exposes the GraphQL API at the `/graphql` endpoint. You can experiment with the API in the GraphQL playground.
 
 1. Start the required services by `docker-compose up webapp db`
-1. Open `localhost:5000/graphql`.
+1. Open `localhost:5005/graphql`.
 1. Simulate being a valid, logged-in user by fetching an authorization token (internally the variables of the `.env` file are used): `./fetch_token`
 1. Copy the content of the `access_token` field (alternatively, you can pipe the above command ` | jq -r .access_token | xclip -i -selection c` to copy it to the system clipboard)
 1.  Insert the access token in the following format on the playground in the section on the bottom left of the playground called HTTP Headers.

--- a/back/gunicorn.conf.py
+++ b/back/gunicorn.conf.py
@@ -3,6 +3,6 @@ https://docs.gunicorn.org/en/stable/settings.html#
 """
 workers = 1
 threads = 1
-bind = "0.0.0.0:5005"
+bind = "0.0.0.0:5000"
 wsgi_app = "boxtribute_server.main:app"
 # loglevel = "debug"

--- a/back/scripts/load-test.js
+++ b/back/scripts/load-test.js
@@ -16,7 +16,7 @@
 import http from "k6/http";
 import { check } from "k6";
 
-const url = "http://0.0.0.0:5005/graphql";
+const url = "http://0.0.0.0:5000/graphql";
 const params = {
   headers: {
     "Content-Type": "application/json",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
             args:
                 flask_env: ${FLASK_ENV:-development}
         ports:
-            - 5000:5000
+            - 5005:5000
             # request localhost:5001 to run debugger in vscode (cf. README)
             - 5001:5001
         networks:
@@ -33,7 +33,7 @@ services:
             REACT_APP_AUTH0_AUDIENCE:  ${AUTH0_AUDIENCE:?auth0 config not set in .env file}
             REACT_APP_REDIRECT: http://localhost:3000
             REACT_APP_LOGOUT_URL: http://localhost:3000
-            REACT_APP_GRAPHQL_SERVER: http://localhost:5000/graphql
+            REACT_APP_GRAPHQL_SERVER: http://localhost:5005/graphql
         ports:
             - "3000:3000"
         stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
             args:
                 flask_env: ${FLASK_ENV:-development}
         ports:
-            - 5005:5005
+            - 5000:5000
             # request localhost:5001 to run debugger in vscode (cf. README)
             - 5001:5001
         networks:
@@ -33,7 +33,7 @@ services:
             REACT_APP_AUTH0_AUDIENCE:  ${AUTH0_AUDIENCE:?auth0 config not set in .env file}
             REACT_APP_REDIRECT: http://localhost:3000
             REACT_APP_LOGOUT_URL: http://localhost:3000
-            REACT_APP_GRAPHQL_SERVER: http://localhost:5005/graphql
+            REACT_APP_GRAPHQL_SERVER: http://localhost:5000/graphql
         ports:
             - "3000:3000"
         stdin_open: true


### PR DESCRIPTION
Contributes to https://trello.com/c/yZXAchvk/810-fix-docker-app-setup-for-macs
Changed it to: 
* port is 5000 within the container and for the flask configuration 
* just the exposed port/port forwarding from container to host is 5005