### PR TITLE
GraphQL mutations for shipment flow

### DIFF
--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -44,15 +44,26 @@ class RequestedResourceNotFound(Exception):
     }
 
 
-class InvalidTransferAgreementState(Exception):
-    def __init__(self, expected_states, actual_state, *args, **kwargs):
+class _InvalidResourceState(Exception):
+    def __init__(self, resource_name, *args, expected_states, actual_state, **kwargs):
         self.extensions = {
             "code": "BAD_USER_INPUT",
-            "description": f"The state of the transfer agreement ({actual_state.name}) "
+            "description": f"The state of the {resource_name} ({actual_state.name}) "
             "does not allow the requested action. Expecting state: "
             f"{' or '.join(s.name for s in expected_states)}",
         }
         super().__init__(*args, **kwargs)
+
+
+class InvalidTransferAgreementState(_InvalidResourceState):
+    def __init__(self, *args, expected_states, actual_state, **kwargs):
+        super().__init__(
+            "transfer agreement",
+            expected_states=expected_states,
+            actual_state=actual_state,
+            *args,
+            **kwargs,
+        )
 
 
 class InvalidTransferAgreementOrganisation(Exception):

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -85,6 +85,17 @@ class InvalidTransferAgreementBase(Exception):
         super().__init__(*args, **kwargs)
 
 
+class InvalidShipmentState(_InvalidResourceState):
+    def __init__(self, *args, expected_states, actual_state, **kwargs):
+        super().__init__(
+            "shipment",
+            expected_states=expected_states,
+            actual_state=actual_state,
+            *args,
+            **kwargs,
+        )
+
+
 class InvalidPaginationInput(Exception):
     extensions = {
         "code": "BAD_USER_INPUT",

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -63,6 +63,17 @@ class InvalidTransferAgreementOrganisation(Exception):
     }
 
 
+class InvalidTransferAgreementBase(Exception):
+    def __init__(self, *args, base_id, expected_base_ids, **kwargs):
+        self.extensions = {
+            "code": "BAD_USER_INPUT",
+            "description": f"The specified base (ID: {base_id}) is not part of the "
+            "current transfer agreement (included base IDs: "
+            f"{', '.join(str(i) for i in expected_base_ids)}).",
+        }
+        super().__init__(*args, **kwargs)
+
+
 class InvalidPaginationInput(Exception):
     extensions = {
         "code": "BAD_USER_INPUT",

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -12,6 +12,7 @@ from ..models.crud import (
     create_beneficiary,
     create_box,
     create_qr_code,
+    create_shipment,
     create_transfer_agreement,
     reject_transfer_agreement,
     update_beneficiary,
@@ -347,6 +348,13 @@ def resolve_reject_transfer_agreement(_, info, id):
 @mutation.field("cancelTransferAgreement")
 def resolve_cancel_transfer_agreement(_, info, id):
     return cancel_transfer_agreement(id=id, canceled_by=g.user["id"])
+
+
+@mutation.field("createShipment")
+@convert_kwargs_to_snake_case
+def resolve_create_shipment(_, info, creation_input):
+    creation_input["started_by"] = g.user["id"]
+    return create_shipment(creation_input)
 
 
 @base.field("locations")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -353,8 +353,7 @@ def resolve_cancel_transfer_agreement(_, info, id):
 @mutation.field("createShipment")
 @convert_kwargs_to_snake_case
 def resolve_create_shipment(_, info, creation_input):
-    creation_input["started_by"] = g.user["id"]
-    return create_shipment(creation_input)
+    return create_shipment(creation_input, started_by=g.user)
 
 
 @base.field("locations")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -8,6 +8,7 @@ from ..authz import authorize
 from ..enums import HumanGender, TransferAgreementState
 from ..models.crud import (
     accept_transfer_agreement,
+    cancel_shipment,
     cancel_transfer_agreement,
     create_beneficiary,
     create_box,
@@ -354,6 +355,11 @@ def resolve_cancel_transfer_agreement(_, info, id):
 @convert_kwargs_to_snake_case
 def resolve_create_shipment(_, info, creation_input):
     return create_shipment(creation_input, started_by=g.user)
+
+
+@mutation.field("cancelShipment")
+def resolve_cancel_shipment(_, info, id):
+    return cancel_shipment(id=id, user_id=g.user["id"])
 
 
 @base.field("locations")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -17,6 +17,7 @@ from ..models.crud import (
     create_transfer_agreement,
     reject_transfer_agreement,
     retrieve_transfer_agreement_bases,
+    send_shipment,
     update_beneficiary,
     update_box,
 )
@@ -360,6 +361,11 @@ def resolve_create_shipment(_, info, creation_input):
 @mutation.field("cancelShipment")
 def resolve_cancel_shipment(_, info, id):
     return cancel_shipment(id=id, user_id=g.user["id"])
+
+
+@mutation.field("sendShipment")
+def resolve_send_shipment(_, info, id):
+    return send_shipment(id=id, user_id=g.user["id"])
 
 
 @base.field("locations")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -15,6 +15,7 @@ from ..models.crud import (
     create_shipment,
     create_transfer_agreement,
     reject_transfer_agreement,
+    retrieve_transfer_agreement_bases,
     update_beneficiary,
     update_box,
 )
@@ -31,7 +32,6 @@ from ..models.definitions.shipment_detail import ShipmentDetail
 from ..models.definitions.size import Size
 from ..models.definitions.transaction import Transaction
 from ..models.definitions.transfer_agreement import TransferAgreement
-from ..models.definitions.transfer_agreement_detail import TransferAgreementDetail
 from ..models.definitions.user import User
 from ..models.definitions.x_beneficiary_language import XBeneficiaryLanguage
 from .pagination import load_into_page
@@ -433,25 +433,15 @@ def resolve_shipment_details(shipment_obj, info):
 
 @transfer_agreement.field("sourceBases")
 def resolve_transfer_agreement_source_bases(transfer_agreement_obj, info):
-    # If source base for transfer agreement is None, return all bases for the agreement
-    # source organisation
-    return Base.select().join(
-        TransferAgreementDetail, on=TransferAgreementDetail.source_base
-    ).where(
-        TransferAgreementDetail.transfer_agreement == transfer_agreement_obj.id
-    ) or Base.select().where(
-        Base.organisation == transfer_agreement_obj.source_organisation
+    return retrieve_transfer_agreement_bases(
+        transfer_agreement=transfer_agreement_obj, kind="source"
     )
 
 
 @transfer_agreement.field("targetBases")
 def resolve_transfer_agreement_target_bases(transfer_agreement_obj, info):
-    return Base.select().join(
-        TransferAgreementDetail, on=TransferAgreementDetail.target_base
-    ).where(
-        TransferAgreementDetail.transfer_agreement == transfer_agreement_obj.id
-    ) or Base.select().where(
-        Base.organisation == transfer_agreement_obj.target_organisation
+    return retrieve_transfer_agreement_bases(
+        transfer_agreement=transfer_agreement_obj, kind="target"
     )
 
 

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -378,6 +378,23 @@ def cancel_shipment(*, id, user_id):
     return shipment
 
 
+def send_shipment(*, id, user_id):
+    """Transition state of specified shipment to 'Sent'.
+    Raise InvalidShipmentState exception if shipment state is different from
+    'Preparing'.
+    """
+    shipment = Shipment.get_by_id(id)
+    if shipment.state != ShipmentState.Preparing:
+        raise InvalidShipmentState(
+            expected_states=[ShipmentState.Preparing], actual_state=shipment.state
+        )
+    shipment.state = ShipmentState.Sent
+    shipment.sent_by = user_id
+    shipment.sent_on = utcnow()
+    shipment.save()
+    return shipment
+
+
 def update_shipment(data):
     """Update shipment detail information, such as prepared boxes."""
     prepared_box_label_identifiers = data.pop("prepared_box_label_identifiers", [])

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -7,7 +7,12 @@ import peewee
 from dateutil import tz
 
 from ..db import db
-from ..enums import BoxState, TransferAgreementState, TransferAgreementType
+from ..enums import (
+    BoxState,
+    ShipmentState,
+    TransferAgreementState,
+    TransferAgreementType,
+)
 from ..exceptions import (
     BoxCreationFailed,
     InvalidTransferAgreementBase,
@@ -353,6 +358,16 @@ def create_shipment(data, *, started_by):
         started_by=started_by["id"],
         **data,
     )
+
+
+def cancel_shipment(*, id, user_id):
+    """Transition state of specified shipment to 'Canceled'."""
+    shipment = Shipment.get_by_id(id)
+    shipment.state = ShipmentState.Canceled
+    shipment.canceled_by = user_id
+    shipment.canceled_on = utcnow()
+    shipment.save()
+    return shipment
 
 
 def update_shipment(data):

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -15,6 +15,7 @@ from ..enums import (
 )
 from ..exceptions import (
     BoxCreationFailed,
+    InvalidShipmentState,
     InvalidTransferAgreementBase,
     InvalidTransferAgreementOrganisation,
     InvalidTransferAgreementState,
@@ -361,8 +362,15 @@ def create_shipment(data, *, started_by):
 
 
 def cancel_shipment(*, id, user_id):
-    """Transition state of specified shipment to 'Canceled'."""
+    """Transition state of specified shipment to 'Canceled'.
+    Raise InvalidShipmentState exception if shipment state is different from
+    'Preparing'.
+    """
     shipment = Shipment.get_by_id(id)
+    if shipment.state != ShipmentState.Preparing:
+        raise InvalidShipmentState(
+            expected_states=[ShipmentState.Preparing], actual_state=shipment.state
+        )
     shipment.state = ShipmentState.Canceled
     shipment.canceled_by = user_id
     shipment.canceled_on = utcnow()

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -14,6 +14,7 @@ from ..exceptions import (
     InvalidTransferAgreementState,
     RequestedResourceNotFound,
 )
+from .definitions.base import Base
 from .definitions.beneficiary import Beneficiary
 from .definitions.box import Box
 from .definitions.qr_code import QrCode
@@ -293,6 +294,20 @@ def cancel_transfer_agreement(*, id, canceled_by):
     agreement.terminated_on = utcnow()
     agreement.save()
     return agreement
+
+
+def retrieve_transfer_agreement_bases(*, transfer_agreement, kind):
+    """Return all bases (kind: source or target) involved in the given transfer
+    agreement. If the selection is None, it indicates that all bases of the respective
+    organisation are included.
+    """
+    return Base.select().join(
+        TransferAgreementDetail, on=getattr(TransferAgreementDetail, f"{kind}_base")
+    ).where(
+        TransferAgreementDetail.transfer_agreement == transfer_agreement.id
+    ) or Base.select().where(
+        Base.organisation == getattr(transfer_agreement, f"{kind}_organisation")
+    )
 
 
 def create_shipment(data):

--- a/back/boxtribute_server/models/definitions/shipment.py
+++ b/back/boxtribute_server/models/definitions/shipment.py
@@ -18,6 +18,7 @@ class Shipment(db.Model):
     state = EnumCharField(
         constraints=[SQL(f"DEFAULT '{ShipmentState.Preparing.name}'")],
         choices=ShipmentState,
+        default=ShipmentState.Preparing,
     )
     started_on = DateTimeField(default=utcnow)
     started_by = UIntForeignKeyField(

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -24,6 +24,7 @@ from .transfer_agreement import (
     expired_transfer_agreement,
     reviewed_transfer_agreement,
     transfer_agreements,
+    unidirectional_transfer_agreement,
 )
 from .user import default_user, default_users
 
@@ -55,6 +56,7 @@ __all__ = [
     "qr_code_without_box",
     "reviewed_transfer_agreement",
     "transfer_agreements",
+    "unidirectional_transfer_agreement",
 ]
 
 MODULE_DIRECTORY = pathlib.Path(__file__).resolve().parent

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -16,7 +16,7 @@ from .product import default_product
 from .product_category import default_product_category
 from .product_gender import default_product_gender
 from .qr_code import default_qr_code, qr_code_without_box
-from .shipment import default_shipment
+from .shipment import canceled_shipment, default_shipment
 from .size_range import default_size_range
 from .transaction import default_transaction
 from .transfer_agreement import (
@@ -32,6 +32,7 @@ __all__ = [
     "another_location",
     "another_organisation",
     "box_without_qr_code",
+    "canceled_shipment",
     "default_beneficiary",
     "default_base",
     "default_bases",

--- a/back/test/data/base.py
+++ b/back/test/data/base.py
@@ -26,6 +26,13 @@ def data():
             "seq": 1,
             "organisation": organisation_data()[1]["id"],
         },
+        {
+            "id": 4,
+            "name": "second base",
+            "currency_name": "pounds",
+            "seq": 1,
+            "organisation": organisation_data()[1]["id"],
+        },
     ]
 
 

--- a/back/test/data/shipment.py
+++ b/back/test/data/shipment.py
@@ -11,21 +11,37 @@ TIME = utcnow().replace(tzinfo=None)
 
 
 def data():
-    return {
-        "id": 1,
-        "source_base": base_data()[0]["id"],
-        "target_base": base_data()[2]["id"],
-        "transfer_agreement": transfer_agreement_data()[0]["id"],
-        "state": ShipmentState.Preparing,
-        "started_by": default_user_data()["id"],
-        "started_on": TIME,
-    }
+    return [
+        {
+            "id": 1,
+            "source_base": base_data()[0]["id"],
+            "target_base": base_data()[2]["id"],
+            "transfer_agreement": transfer_agreement_data()[0]["id"],
+            "state": ShipmentState.Preparing,
+            "started_by": default_user_data()["id"],
+            "started_on": TIME,
+        },
+        {
+            "id": 2,
+            "source_base": base_data()[0]["id"],
+            "target_base": base_data()[2]["id"],
+            "transfer_agreement": transfer_agreement_data()[1]["id"],
+            "state": ShipmentState.Canceled,
+            "started_by": default_user_data()["id"],
+            "started_on": TIME,
+        },
+    ]
 
 
 @pytest.fixture
 def default_shipment():
-    return data()
+    return data()[0]
+
+
+@pytest.fixture
+def canceled_shipment():
+    return data()[1]
 
 
 def create():
-    Shipment.create(**data())
+    Shipment.insert_many(data()).execute()

--- a/back/test/data/transfer_agreement.py
+++ b/back/test/data/transfer_agreement.py
@@ -38,6 +38,14 @@ def data():
             "type": TransferAgreementType.Bidirectional,
             "requested_by": default_user_data()["id"],
         },
+        {
+            "id": 4,
+            "source_organisation": organisation_data()[1]["id"],
+            "target_organisation": organisation_data()[0]["id"],
+            "state": TransferAgreementState.Accepted,
+            "type": TransferAgreementType.Unidirectional,
+            "requested_by": default_user_data()["id"],
+        },
     ]
 
 
@@ -54,6 +62,11 @@ def expired_transfer_agreement():
 @pytest.fixture
 def reviewed_transfer_agreement():
     return data()[2]
+
+
+@pytest.fixture
+def unidirectional_transfer_agreement():
+    return data()[3]
 
 
 @pytest.fixture

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -129,3 +129,19 @@ def test_shipment_mutations(client, default_bases, default_transfer_agreement):
         "transferAgreement": {"id": str(agreement_id)},
         "details": [],
     }
+
+
+def test_shipment_mutations_create_with_non_accepted_agreement(
+    read_only_client, expired_transfer_agreement
+):
+    agreement_id = expired_transfer_agreement["id"]
+    creation_input = f"""sourceBaseId: 4,
+                         targetBaseId: 5,
+                         transferAgreementId: {agreement_id}"""
+    mutation = f"""mutation {{ createShipment(creationInput: {{ {creation_input} }} ) {{
+                    id }} }}"""
+    data = {"query": mutation}
+    response = read_only_client.post("/graphql", json=data)
+    assert response.status_code == 200
+    assert len(response.json["errors"]) == 1
+    assert response.json["errors"][0]["extensions"]["code"] == "BAD_USER_INPUT"

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -61,12 +61,14 @@ def test_shipment_query(read_only_client, default_shipment):
     }
 
 
-def test_shipments_query(read_only_client, default_shipment):
+def test_shipments_query(read_only_client, default_shipment, canceled_shipment):
     query = "query { shipments { id } }"
     data = {"query": query}
     response = read_only_client.post("/graphql", json=data)
     shipments = response.json["data"]["shipments"]
-    assert shipments == [{"id": str(default_shipment["id"])}]
+    assert shipments == [
+        {"id": str(s["id"])} for s in [default_shipment, canceled_shipment]
+    ]
 
 
 def test_shipment_mutations(client, default_bases, default_transfer_agreement):

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -163,3 +163,21 @@ def test_shipment_mutations_create_with_invalid_base(
     assert response.status_code == 200
     assert len(response.json["errors"]) == 1
     assert response.json["errors"][0]["extensions"]["code"] == "BAD_USER_INPUT"
+
+
+def test_shipment_mutations_create_as_target_org_member_in_unidirectional_agreement(
+    read_only_client, default_bases, unidirectional_transfer_agreement
+):
+    source_base_id = default_bases[3]["id"]
+    target_base_id = default_bases[2]["id"]
+    agreement_id = unidirectional_transfer_agreement["id"]
+    creation_input = f"""sourceBaseId: {source_base_id},
+                         targetBaseId: {target_base_id},
+                         transferAgreementId: {agreement_id}"""
+    mutation = f"""mutation {{ createShipment(creationInput: {{ {creation_input} }} ) {{
+                    id }} }}"""
+    data = {"query": mutation}
+    response = read_only_client.post("/graphql", json=data)
+    assert response.status_code == 200
+    assert len(response.json["errors"]) == 1
+    assert response.json["errors"][0]["extensions"]["code"] == "BAD_USER_INPUT"

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -206,3 +206,10 @@ def test_shipment_mutations_create_as_target_org_member_in_unidirectional_agreem
         target_base_id=default_bases[2]["id"],
         agreement_id=unidirectional_transfer_agreement["id"],
     )
+
+
+def test_shipment_mutations_cancel_in_non_preparing_state(
+    read_only_client, canceled_shipment
+):
+    mutation = f"mutation {{ cancelShipment(id: {canceled_shipment['id']}) {{ id }} }}"
+    assert_bad_user_input(read_only_client, mutation)

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -1,3 +1,8 @@
+from datetime import date
+
+from boxtribute_server.enums import ShipmentState
+
+
 def test_shipment_query(read_only_client, default_shipment):
     shipment_id = str(default_shipment["id"])
     query = f"""query {{
@@ -62,3 +67,65 @@ def test_shipments_query(read_only_client, default_shipment):
     response = read_only_client.post("/graphql", json=data)
     shipments = response.json["data"]["shipments"]
     assert shipments == [{"id": str(default_shipment["id"])}]
+
+
+def test_shipment_mutations(client, default_bases, default_transfer_agreement):
+    source_base_id = default_bases[2]["id"]
+    target_base_id = default_bases[3]["id"]
+    agreement_id = default_transfer_agreement["id"]
+    creation_input = f"""sourceBaseId: {source_base_id},
+                         targetBaseId: {target_base_id},
+                         transferAgreementId: {agreement_id}"""
+    mutation = f"""mutation {{ createShipment(creationInput: {{ {creation_input} }} ) {{
+                    id
+                    sourceBase {{
+                        id
+                    }}
+                    targetBase {{
+                        id
+                    }}
+                    state
+                    startedBy {{
+                        id
+                    }}
+                    startedOn
+                    sentBy {{
+                        id
+                    }}
+                    sentOn
+                    completedBy {{
+                        id
+                    }}
+                    completedOn
+                    canceledBy {{
+                        id
+                    }}
+                    canceledOn
+                    transferAgreement {{
+                        id
+                    }}
+                    details {{
+                        id
+                    }}
+                }} }}"""
+    data = {"query": mutation}
+    response = client.post("/graphql", json=data)
+    assert response.status_code == 200
+    shipment = response.json["data"]["createShipment"]
+    shipment.pop("id")
+
+    assert shipment.pop("startedOn").startswith(date.today().isoformat())
+    assert shipment == {
+        "sourceBase": {"id": str(source_base_id)},
+        "targetBase": {"id": str(target_base_id)},
+        "state": ShipmentState.Preparing.name,
+        "startedBy": {"id": "8"},
+        "sentBy": None,
+        "sentOn": None,
+        "completedBy": None,
+        "completedOn": None,
+        "canceledBy": None,
+        "canceledOn": None,
+        "transferAgreement": {"id": str(agreement_id)},
+        "details": [],
+    }

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -145,3 +145,21 @@ def test_shipment_mutations_create_with_non_accepted_agreement(
     assert response.status_code == 200
     assert len(response.json["errors"]) == 1
     assert response.json["errors"][0]["extensions"]["code"] == "BAD_USER_INPUT"
+
+
+def test_shipment_mutations_create_with_invalid_base(
+    read_only_client, default_bases, default_transfer_agreement
+):
+    source_base_id = default_bases[2]["id"]
+    target_base_id = default_bases[4]["id"]  # not part of agreement
+    agreement_id = default_transfer_agreement["id"]
+    creation_input = f"""sourceBaseId: {source_base_id},
+                         targetBaseId: {target_base_id},
+                         transferAgreementId: {agreement_id}"""
+    mutation = f"""mutation {{ createShipment(creationInput: {{ {creation_input} }} ) {{
+                    id }} }}"""
+    data = {"query": mutation}
+    response = read_only_client.post("/graphql", json=data)
+    assert response.status_code == 200
+    assert len(response.json["errors"]) == 1
+    assert response.json["errors"][0]["extensions"]["code"] == "BAD_USER_INPUT"

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -159,7 +159,7 @@ def test_transfer_agreement_mutations(
         "requestedBy": {"id": "8"},
         "validUntil": None,
         "sourceBases": [{"id": "1"}, {"id": "2"}],
-        "targetBases": [{"id": "3"}],
+        "targetBases": [{"id": "3"}, {"id": "4"}],
         "shipments": [],
     }
 

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -86,9 +86,9 @@ def state_names(value):
 @pytest.mark.parametrize(
     "filter_input,transfer_agreement_ids",
     (
-        ["", ["1", "2", "3"]],
+        ["", ["1", "2", "3", "4"]],
         ["(states: [UnderReview])", ["3"]],
-        ["(states: [Accepted])", ["1"]],
+        ["(states: [Accepted])", ["1", "4"]],
         ["(states: [Rejected])", []],
         ["(states: [Expired])", ["2"]],
         ["(states: [Rejected, Canceled, Expired])", ["2"]],

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -68,9 +68,14 @@ def test_create_shipment(
         "source_base_id": default_bases[1]["id"],
         "target_base_id": default_bases[3]["id"],
         "transfer_agreement_id": default_transfer_agreement["id"],
-        "started_by": default_user["id"],
     }
-    shipment = create_shipment(data)
+    shipment = create_shipment(
+        data,
+        started_by={
+            "id": default_user["id"],
+            "organisation_id": default_transfer_agreement["source_organisation"],
+        },
+    )
     shipment = Shipment.select().where(Shipment.id == shipment.id).dicts().get()
     assert (
         shipment.items()

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -1,11 +1,7 @@
 import peewee
 import pytest
 from boxtribute_server.enums import BoxState, ShipmentState
-from boxtribute_server.exceptions import (
-    BoxCreationFailed,
-    InvalidTransferAgreementState,
-    RequestedResourceNotFound,
-)
+from boxtribute_server.exceptions import BoxCreationFailed, RequestedResourceNotFound
 from boxtribute_server.models.crud import (
     BOX_LABEL_IDENTIFIER_GENERATION_ATTEMPTS,
     create_box,
@@ -122,19 +118,6 @@ def test_create_shipment(
 
     box = Box.get_by_id(detail["box"])
     assert box.state_id == BoxState.MarkedForShipment.value
-
-
-def test_create_shipment_from_expired_agreement(
-    default_user, default_bases, expired_transfer_agreement
-):
-    data = {
-        "source_base_id": default_bases[1]["id"],
-        "target_base_id": default_bases[3]["id"],
-        "transfer_agreement_id": expired_transfer_agreement["id"],
-        "started_by": default_user["id"],
-    }
-    with pytest.raises(InvalidTransferAgreementState):
-        create_shipment(data)
 
 
 def test_update_beneficiary(default_beneficiary, default_bases):


### PR DESCRIPTION
This PR adds the implementation for the `createShipment`, `cancelShipment`, `sendShipment` mutations, incl. appropriate validations (e.g. for shipment state).

The corresponding test cases are 3.2.1 - 3.2.14 in https://docs.google.com/spreadsheets/d/1sDhSsaVwNxAhGn1VYACDPVepZpvlwTkgy9nmeTaRy2Q/edit#gid=1709672082 (last sheet) with the exception of the cases dealing with non-existent resources (will be handled in generic way).

I have two questions regarding these test cases:
- *3.2.10* Is it correct that only a member of the organisation that originally created the shipment can cancel that shipment?
- *3.2.14* For validating that the confirming user is member of the organisation that created the shipment I first need to retrieve information about the creating organisation. We don't explicitly store that in the Shipment table. Instead I'd have to use the ID of the user who created the shipment, and query Auth0 for the organisation that the user belongs to. This creates some overhead but I don't see another way (without duplicating information about the user's organisation in the User table). Or do you think it's an edge case we don't have to take care of?
