### PR TITLE
GraphQL mutations for update-shipment flow

### DIFF
--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -372,7 +372,7 @@ def resolve_cancel_shipment(_, info, id):
 
 @mutation.field("sendShipment")
 def resolve_send_shipment(_, info, id):
-    return send_shipment(id=id, user_id=g.user["id"])
+    return send_shipment(id=id, user=g.user)
 
 
 @base.field("locations")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -446,7 +446,10 @@ def resolve_qr_code_box(qr_code_obj, info):
 
 @shipment.field("details")
 def resolve_shipment_details(shipment_obj, info):
-    return ShipmentDetail.select().where(ShipmentDetail.shipment == shipment_obj.id)
+    return ShipmentDetail.select().where(
+        (ShipmentDetail.shipment == shipment_obj.id)
+        & (ShipmentDetail.deleted_on.is_null())
+    )
 
 
 @transfer_agreement.field("sourceBases")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -20,6 +20,7 @@ from ..models.crud import (
     send_shipment,
     update_beneficiary,
     update_box,
+    update_shipment,
 )
 from ..models.definitions.base import Base
 from ..models.definitions.beneficiary import Beneficiary
@@ -356,6 +357,12 @@ def resolve_cancel_transfer_agreement(_, info, id):
 @convert_kwargs_to_snake_case
 def resolve_create_shipment(_, info, creation_input):
     return create_shipment(creation_input, started_by=g.user)
+
+
+@mutation.field("updateShipment")
+@convert_kwargs_to_snake_case
+def resolve_update_shipment(_, info, update_input):
+    return update_shipment(**update_input, user_id=g.user["id"])
 
 
 @mutation.field("cancelShipment")

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -317,14 +317,14 @@ input ShipmentCreationInput {
 
 input ShipmentUpdateInput {
   id: ID!
-  sourceBaseId: Int!
-  targetBaseId: Int!
+  sourceBaseId: Int
+  targetBaseId: Int
   # IDs of boxes prepared for shipment
-  preparedBoxIds: [Int!]!
+  preparedBoxIds: [Int!]
   # IDs of prepared boxes to be moved back to stock
-  removedBoxIds: [Int!]!
+  removedBoxIds: [Int!]
   # IDs of boxes that went lost during shipment
-  lostBoxIds: [Int!]!
+  lostBoxIds: [Int!]
 }
 
 input ShipmentDetailUpdateInput {

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -319,12 +319,12 @@ input ShipmentUpdateInput {
   id: ID!
   sourceBaseId: Int
   targetBaseId: Int
-  # IDs of boxes prepared for shipment
-  preparedBoxIds: [Int!]
-  # IDs of prepared boxes to be moved back to stock
-  removedBoxIds: [Int!]
-  # IDs of boxes that went lost during shipment
-  lostBoxIds: [Int!]
+  # label identifiers of boxes prepared for shipment
+  preparedBoxLabelIdentifiers: [Int!]
+  # label identifiers of prepared boxes to be moved back to stock
+  removedBoxLabelIdentifiers: [Int!]
+  # label identifiers of boxes that went lost during shipment
+  lostBoxLabelIdentifiers: [Int!]
 }
 
 input ShipmentDetailUpdateInput {

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -431,7 +431,8 @@ def update_shipment(
     Raise an InvalidTransferAgreementBase exception if specified source or target base
     are not included in given agreement.
     If boxes are requested to be updated that are not located in the shipment's source
-    base, they are silently discarded (i.e. not added to the ShipmentDetail model).
+    base, or have a state different from InStock, they are silently discarded (i.e. not
+    added to the ShipmentDetail model).
     """
     shipment = Shipment.get_by_id(id)
     if shipment.state != ShipmentState.Preparing:
@@ -456,6 +457,8 @@ def update_shipment(
             .where(Box.label_identifier.in_(prepared_box_label_identifiers))
         ):
             if box.location.base_id != shipment.source_base_id:
+                continue
+            if box.state_id != BoxState.InStock.value:
                 continue
 
             box.state = BoxState.MarkedForShipment

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -395,10 +395,8 @@ def send_shipment(*, id, user_id):
     return shipment
 
 
-def update_shipment(data):
+def update_shipment(*, id, user_id, prepared_box_label_identifiers):
     """Update shipment detail information, such as prepared boxes."""
-    prepared_box_label_identifiers = data.pop("prepared_box_label_identifiers", [])
-    shipment_id = data.pop("id")
     details = []
 
     with db.database.atomic():
@@ -410,14 +408,14 @@ def update_shipment(data):
             boxes.append(box)
             details.append(
                 {
-                    "shipment": shipment_id,
+                    "shipment": id,
                     "box": box.id,
                     "source_product": box.product_id,
                     "source_location": box.location_id,
-                    **data,
+                    "created_by": user_id,
                 }
             )
 
         Box.bulk_update(boxes, fields=[Box.state])
         ShipmentDetail.insert_many(details).execute()
-    return Shipment.get_by_id(shipment_id)
+    return Shipment.get_by_id(id)

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -422,14 +422,21 @@ def update_shipment(
 ):
     """Update shipment detail information, such as prepared boxes, or source/target
     base.
+    Raise InvalidShipmentState exception if shipment state is different from
+    'Preparing'.
     Raise an InvalidTransferAgreementBase exception if specified source or target base
     are not included in given agreement.
     If boxes are requested to be updated that are not located in the shipment's source
     base, they are silently discarded (i.e. not added to the ShipmentDetail model).
     """
+    shipment = Shipment.get_by_id(id)
+    if shipment.state != ShipmentState.Preparing:
+        raise InvalidShipmentState(
+            expected_states=[ShipmentState.Preparing], actual_state=shipment.state
+        )
+
     details = []
     prepared_box_label_identifiers = prepared_box_label_identifiers or []
-    shipment = Shipment.get_by_id(id)
 
     _validate_bases_as_part_of_transfer_agreement(
         transfer_agreement=TransferAgreement.get_by_id(shipment.transfer_agreement_id),

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -421,10 +421,18 @@ def update_shipment(
 ):
     """Update shipment detail information, such as prepared boxes, or source/target
     base.
+    Raise an InvalidTransferAgreementBase exception if specified source or target base
+    are not included in given agreement.
     """
     details = []
     prepared_box_label_identifiers = prepared_box_label_identifiers or []
     shipment = Shipment.get_by_id(id)
+
+    _validate_bases_as_part_of_transfer_agreement(
+        transfer_agreement=TransferAgreement.get_by_id(shipment.transfer_agreement_id),
+        source_base_id=source_base_id,
+        target_base_id=target_base_id,
+    )
 
     with db.database.atomic():
         boxes = []

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -454,10 +454,15 @@ def _update_shipment_with_prepared_boxes(*, shipment, box_label_identifiers, use
 
 
 def _update_shipment_with_removed_boxes(*, user_id, box_label_identifiers):
-    """Return boxes to stock, and mark corresponding shipment details as deleted."""
+    """Return boxes to stock, and mark corresponding shipment details as deleted.
+    If boxes are requested to be removed that have a state different from
+    MarkedForShipment, they are silently discarded.
+    """
     boxes = []
     box_label_identifiers = box_label_identifiers or []
     for box in Box.select().where(Box.label_identifier << box_label_identifiers):
+        if box.state_id != BoxState.MarkedForShipment.value:
+            continue
         box.state = BoxState.InStock
         boxes.append(box)
     if boxes:

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -6,7 +6,7 @@ from boxtribute_server.db import db
 
 from .base import default_base, default_bases
 from .beneficiary import default_beneficiary
-from .box import box_without_qr_code, default_box, default_boxes
+from .box import another_box, box_without_qr_code, default_box, default_boxes
 from .box_state import default_box_state
 from .history import default_history
 from .location import another_location, default_location
@@ -29,6 +29,7 @@ from .transfer_agreement import (
 from .user import default_user, default_users
 
 __all__ = [
+    "another_box",
     "another_location",
     "another_organisation",
     "box_without_qr_code",

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -16,7 +16,7 @@ from .product import default_product
 from .product_category import default_product_category
 from .product_gender import default_product_gender
 from .qr_code import default_qr_code, qr_code_without_box
-from .shipment import canceled_shipment, default_shipment
+from .shipment import another_shipment, canceled_shipment, default_shipment
 from .size_range import default_size_range
 from .transaction import default_transaction
 from .transfer_agreement import (
@@ -32,6 +32,7 @@ __all__ = [
     "another_box",
     "another_location",
     "another_organisation",
+    "another_shipment",
     "box_without_qr_code",
     "canceled_shipment",
     "default_beneficiary",

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -6,7 +6,7 @@ from boxtribute_server.db import db
 
 from .base import default_base, default_bases
 from .beneficiary import default_beneficiary
-from .box import another_box, box_without_qr_code, default_box, default_boxes
+from .box import another_box, box_without_qr_code, default_box, default_boxes, lost_box
 from .box_state import default_box_state
 from .history import default_history
 from .location import another_location, default_location
@@ -56,6 +56,7 @@ __all__ = [
     "default_user",
     "default_users",
     "expired_transfer_agreement",
+    "lost_box",
     "qr_code_without_box",
     "reviewed_transfer_agreement",
     "transfer_agreements",

--- a/back/test/data/box.py
+++ b/back/test/data/box.py
@@ -1,7 +1,7 @@
 import pytest
 from boxtribute_server.models.definitions.box import Box
 from data.box_state import default_box_state_data
-from data.location import default_location_data
+from data.location import another_location_data, default_location_data
 from data.product import default_product_data
 from data.qr_code import default_qr_code_data
 from data.user import default_user_data
@@ -22,7 +22,7 @@ def default_box_data():
 
 
 def box_without_qr_code_data():
-    data = default_box_data().copy()
+    data = default_box_data()
     data["id"] = 3
     data["label_identifier"] = "23456789"
     data["items"] = 10
@@ -30,25 +30,37 @@ def box_without_qr_code_data():
     return data
 
 
+def another_box_data():
+    data = box_without_qr_code_data()
+    data["id"] = 4
+    data["label_identifier"] = "34567890"
+    data["location"] = another_location_data()["id"]
+    return data
+
+
 def data():
-    return [default_box_data(), box_without_qr_code_data()]
+    return [default_box_data(), box_without_qr_code_data(), another_box_data()]
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_boxes():
     return data()
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_box():
     return default_box_data()
 
 
-@pytest.fixture()
+@pytest.fixture
 def box_without_qr_code():
     return box_without_qr_code_data()
 
 
+@pytest.fixture
+def another_box():
+    return another_box_data()
+
+
 def create():
-    Box.create(**default_box_data())
-    Box.create(**box_without_qr_code_data())
+    Box.insert_many(data()).execute()

--- a/back/test/data/box.py
+++ b/back/test/data/box.py
@@ -1,4 +1,5 @@
 import pytest
+from boxtribute_server.enums import BoxState
 from boxtribute_server.models.definitions.box import Box
 from data.box_state import default_box_state_data
 from data.location import another_location_data, default_location_data
@@ -38,8 +39,21 @@ def another_box_data():
     return data
 
 
+def lost_box_data():
+    data = box_without_qr_code_data()
+    data["id"] = 5
+    data["label_identifier"] = "45678901"
+    data["state"] = BoxState.Lost
+    return data
+
+
 def data():
-    return [default_box_data(), box_without_qr_code_data(), another_box_data()]
+    return [
+        default_box_data(),
+        box_without_qr_code_data(),
+        another_box_data(),
+        lost_box_data(),
+    ]
 
 
 @pytest.fixture
@@ -60,6 +74,11 @@ def box_without_qr_code():
 @pytest.fixture
 def another_box():
     return another_box_data()
+
+
+@pytest.fixture
+def lost_box():
+    return lost_box_data()
 
 
 def create():

--- a/back/test/data/location.py
+++ b/back/test/data/location.py
@@ -29,9 +29,9 @@ def default_location():
 
 
 def another_location_data():
-    data = default_location_data().copy()
+    data = default_location_data()
     data["id"] = 2
-    data["base"] = 3
+    data["base"] = base_data()[2]["id"]
     return data
 
 

--- a/back/test/data/shipment.py
+++ b/back/test/data/shipment.py
@@ -30,6 +30,15 @@ def data():
             "started_by": default_user_data()["id"],
             "started_on": TIME,
         },
+        {
+            "id": 3,
+            "source_base": base_data()[2]["id"],
+            "target_base": base_data()[0]["id"],
+            "transfer_agreement": transfer_agreement_data()[3]["id"],
+            "state": ShipmentState.Preparing,
+            "started_by": default_user_data()["id"],
+            "started_on": TIME,
+        },
     ]
 
 
@@ -41,6 +50,11 @@ def default_shipment():
 @pytest.fixture
 def canceled_shipment():
     return data()[1]
+
+
+@pytest.fixture
+def another_shipment():
+    return data()[2]
 
 
 def create():

--- a/back/test/endpoint_tests/test_location.py
+++ b/back/test/endpoint_tests/test_location.py
@@ -1,7 +1,9 @@
 from boxtribute_server.enums import BoxState
 
 
-def test_location_query(read_only_client, default_boxes, default_location):
+def test_location_query(
+    read_only_client, default_box, box_without_qr_code, default_location
+):
     query = f"""query {{
                 location(id: "{default_location['id']}") {{
                     id
@@ -30,7 +32,11 @@ def test_location_query(read_only_client, default_boxes, default_location):
         "base": {"id": str(default_location["base"])},
         "name": default_location["name"],
         "isShop": default_location["is_shop"],
-        "boxes": {"elements": [{"id": str(b["id"])} for b in default_boxes]},
+        "boxes": {
+            "elements": [
+                {"id": str(b["id"])} for b in [default_box, box_without_qr_code]
+            ]
+        },
         "boxState": BoxState(default_location["box_state"]).name,
         "createdOn": None,
         "createdBy": {"id": str(default_location["created_by"])},

--- a/back/test/endpoint_tests/test_location.py
+++ b/back/test/endpoint_tests/test_location.py
@@ -2,7 +2,7 @@ from boxtribute_server.enums import BoxState
 
 
 def test_location_query(
-    read_only_client, default_box, box_without_qr_code, default_location
+    read_only_client, default_box, box_without_qr_code, lost_box, default_location
 ):
     query = f"""query {{
                 location(id: "{default_location['id']}") {{
@@ -34,7 +34,8 @@ def test_location_query(
         "isShop": default_location["is_shop"],
         "boxes": {
             "elements": [
-                {"id": str(b["id"])} for b in [default_box, box_without_qr_code]
+                {"id": str(b["id"])}
+                for b in [default_box, box_without_qr_code, lost_box]
             ]
         },
         "boxState": BoxState(default_location["box_state"]).name,

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -353,6 +353,13 @@ def test_shipment_mutations_create_as_target_org_member_in_unidirectional_agreem
     )
 
 
+def test_shipment_mutations_send_as_member_of_non_creating_org(
+    read_only_client, another_shipment
+):
+    mutation = f"mutation {{ sendShipment(id: {another_shipment['id']}) {{ id }} }}"
+    assert_bad_user_input(read_only_client, mutation)
+
+
 @pytest.mark.parametrize("act", ["cancel", "send"])
 def test_shipment_mutations_in_non_preparing_state(
     read_only_client, canceled_shipment, act

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -366,3 +366,11 @@ def test_shipment_mutations_update_with_invalid_base(
         target_base_id=default_bases[4]["id"],  # not part of agreement
         shipment_id=default_shipment["id"],
     )
+
+
+def test_shipment_mutations_update_in_non_preparing_state(
+    read_only_client, canceled_shipment
+):
+    assert_bad_user_input_when_updating_shipment(
+        read_only_client, shipment_id=canceled_shipment["id"]
+    )

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -62,13 +62,16 @@ def test_shipment_query(read_only_client, default_shipment):
     }
 
 
-def test_shipments_query(read_only_client, default_shipment, canceled_shipment):
+def test_shipments_query(
+    read_only_client, default_shipment, canceled_shipment, another_shipment
+):
     query = "query { shipments { id } }"
     data = {"query": query}
     response = read_only_client.post("/graphql", json=data)
     shipments = response.json["data"]["shipments"]
     assert shipments == [
-        {"id": str(s["id"])} for s in [default_shipment, canceled_shipment]
+        {"id": str(s["id"])}
+        for s in [default_shipment, canceled_shipment, another_shipment]
     ]
 
 

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -261,3 +261,14 @@ def test_shipment_mutations_in_non_preparing_state(
 ):
     mutation = f"mutation {{ {act}Shipment(id: {canceled_shipment['id']}) {{ id }} }}"
     assert_bad_user_input(read_only_client, mutation)
+
+
+def test_shipment_mutations_update_with_invalid_base(
+    read_only_client, default_bases, default_shipment
+):
+    # Base 4 not part of agreement
+    update_input = f"""targetBaseId: {default_bases[4]['id']},
+                       id: {default_shipment['id']}"""
+    mutation = f"""mutation {{ updateShipment(updateInput: {{ {update_input} }} ) {{
+                    id }} }}"""
+    assert_bad_user_input(read_only_client, mutation)

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -273,6 +273,17 @@ def assert_bad_user_input_when_creating_shipment(
     assert_bad_user_input(client, mutation)
 
 
+def assert_bad_user_input_when_updating_shipment(
+    client, *, target_base_id=None, shipment_id
+):
+    update_input = f"id: {shipment_id}"
+    if target_base_id is not None:
+        update_input += f", targetBaseId: {target_base_id}"
+    mutation = f"""mutation {{ updateShipment(updateInput: {{ {update_input} }} ) {{
+                    id }} }}"""
+    assert_bad_user_input(client, mutation)
+
+
 def assert_bad_user_input(client, mutation):
     data = {"query": mutation}
     response = client.post("/graphql", json=data)
@@ -328,9 +339,8 @@ def test_shipment_mutations_in_non_preparing_state(
 def test_shipment_mutations_update_with_invalid_base(
     read_only_client, default_bases, default_shipment
 ):
-    # Base 4 not part of agreement
-    update_input = f"""targetBaseId: {default_bases[4]['id']},
-                       id: {default_shipment['id']}"""
-    mutation = f"""mutation {{ updateShipment(updateInput: {{ {update_input} }} ) {{
-                    id }} }}"""
-    assert_bad_user_input(read_only_client, mutation)
+    assert_bad_user_input_when_updating_shipment(
+        read_only_client,
+        target_base_id=default_bases[4]["id"],  # not part of agreement
+        shipment_id=default_shipment["id"],
+    )

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -97,9 +97,9 @@ def test_create_shipment(
     data = {
         "prepared_box_label_identifiers": [default_box["label_identifier"]],
         "id": shipment["id"],
-        "created_by": default_user["id"],
+        "user_id": default_user["id"],
     }
-    shipment = update_shipment(data)
+    shipment = update_shipment(**data)
     details = list(
         ShipmentDetail.select().where(ShipmentDetail.shipment == shipment.id).dicts()
     )


### PR DESCRIPTION
This PR implements part II of the GraphQL mutations for the box-transfer feature.

The corresponding test cases are 3.2.20 - 3.2.32.

One question (cf. test case 3.2.25): can members of both organisations update the bases of an existing shipment?

Note that in the implementation for test cases 3.2.27, .28, .31, no errors are indicated in the GraphQL response (I didn't see any way to return a partial response because only one resolver (for `updateShipment` mutation is involved. It would be possible to return a custom `ShipmentUpdateResponse` type holding successful and erroneous updates. I don't how much benefit it brings since that part of the API won't be public).
