### PR TITLE
Integrate new permission format

### DIFF
--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -126,17 +126,19 @@ def requires_auth(f):
         prefix = "https://www.boxtribute.com"
         g.user["organisation_id"] = payload[f"{prefix}/organisation_id"]
         g.user["id"] = int(payload["sub"].replace("auth0|", ""))
+        g.user["is_god"] = payload[f"{prefix}/permissions"] == ["*"]
 
         g.user["permissions"] = {}
-        for raw_permission in payload[f"{prefix}/permissions"]:
-            try:
-                base_prefix, permission = raw_permission.split("/")
-                base_ids = [int(b) for b in base_prefix[5:].split("-")]
-            except ValueError:
-                # No base_ prefix, permission granted for all bases
-                permission = raw_permission
-                base_ids = None
-            g.user["permissions"][permission] = base_ids
+        if not g.user["is_god"]:
+            for raw_permission in payload[f"{prefix}/permissions"]:
+                try:
+                    base_prefix, permission = raw_permission.split("/")
+                    base_ids = [int(b) for b in base_prefix[5:].split("-")]
+                except ValueError:
+                    # No base_ prefix, permission granted for all bases
+                    permission = raw_permission
+                    base_ids = None
+                g.user["permissions"][permission] = base_ids
 
         return f(*args, **kwargs)
 

--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -11,6 +11,7 @@ from .exceptions import AuthenticationFailed
 
 AUTH0_DOMAIN = os.getenv("AUTH0_DOMAIN")
 ALGORITHMS = ["RS256"]
+JWT_CLAIM_PREFIX = "https://www.boxtribute.com"
 
 
 def get_auth_string_from_header():
@@ -124,14 +125,13 @@ def requires_auth(f):
         # by a rule in Auth0):
         #     'https://www.boxtribute.com/organisation_id'
         g.user = {}
-        prefix = "https://www.boxtribute.com"
-        g.user["organisation_id"] = payload[f"{prefix}/organisation_id"]
+        g.user["organisation_id"] = payload[f"{JWT_CLAIM_PREFIX}/organisation_id"]
         g.user["id"] = int(payload["sub"].replace("auth0|", ""))
-        g.user["is_god"] = payload[f"{prefix}/permissions"] == ["*"]
+        g.user["is_god"] = payload[f"{JWT_CLAIM_PREFIX}/permissions"] == ["*"]
 
         g.user["permissions"] = {}
         if not g.user["is_god"]:
-            for raw_permission in payload[f"{prefix}/permissions"]:
+            for raw_permission in payload[f"{JWT_CLAIM_PREFIX}/permissions"]:
                 try:
                     base_prefix, permission = raw_permission.split("/")
                     base_ids = [int(b) for b in base_prefix[5:].split("-")]

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -23,21 +23,13 @@ def authorize(
     if current_user is None:
         current_user = g.user
 
-    if permission == "qr:write":
-        # For the front-end, base-specific distinction when creating QR codes is
-        # relevant but not for the back-end (there is no data relationship between
-        # QR code and base). The permission is of form 'base_x:qr:write'.
-        authorized = any("qr:write" in p for p in current_user["permissions"])
-
-    elif permission is not None:
+    if permission is not None:
         authorized = permission in current_user["permissions"]
 
-        if not authorized and base_id is not None:
-            # Handle base-specific permission of form 'base_x:...'
-            permission = f"base_{base_id}:{permission}"
-            authorized = permission in current_user["permissions"]
-    elif base_id is not None:
-        authorized = base_id in current_user["base_ids"]
+        if authorized and base_id is not None:
+            # Enforce base-specific permission
+            base_ids = current_user["permissions"][permission]
+            authorized = True if base_ids is None else base_id in base_ids
     elif organisation_id is not None:
         authorized = organisation_id == current_user["organisation_id"]
     elif user_id is not None:

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -14,6 +14,7 @@ def authorize(
 ):
     """Check whether the current user (default: `g.user`) is authorized to access the
     specified resource.
+    The god user is authorized to access anything.
     This function is supposed to be used in resolver functions. It may raise an
     UnknownResource or Forbidden exception which ariadne handles by extending the
     'errors' field of the response.
@@ -22,6 +23,8 @@ def authorize(
     """
     if current_user is None:
         current_user = g.user
+    if current_user["is_god"]:
+        return True
 
     if permission is not None:
         authorized = permission in current_user["permissions"]

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -2,6 +2,8 @@ import json
 import os
 import urllib
 
+from boxtribute_server.auth import JWT_CLAIM_PREFIX
+
 
 def memoize(function):
     """Wraps a function so the data is cached.
@@ -81,13 +83,12 @@ def create_jwt_payload(
     If no arguments are passed, the payload for the default user is returned. Any
     argument specified overrides the corresponding field of the default payload.
     """
-    prefix = "https://www.boxtribute.com"
     payload = {
-        f"{prefix}/email": "dev_coordinator@boxaid.org",
-        f"{prefix}/organisation_id": 1,
-        f"{prefix}/roles": ["Coordinator"],
+        f"{JWT_CLAIM_PREFIX}/email": "dev_coordinator@boxaid.org",
+        f"{JWT_CLAIM_PREFIX}/organisation_id": 1,
+        f"{JWT_CLAIM_PREFIX}/roles": ["Coordinator"],
         "sub": "auth0|8",
-        f"{prefix}/permissions": [
+        f"{JWT_CLAIM_PREFIX}/permissions": [
             "base_1/base:read",
             "base_1/beneficiary:read",
             "base_1/category:read",
@@ -107,7 +108,7 @@ def create_jwt_payload(
     for name in ["email", "base_ids", "organisation_id", "roles", "permissions"]:
         value = locals()[name]
         if value is not None:
-            payload[f"{prefix}/{name}"] = value
+            payload[f"{JWT_CLAIM_PREFIX}/{name}"] = value
     if user_id is not None:
         payload["sub"] = f"auth0|{user_id}"
 

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -74,40 +74,41 @@ def create_jwt_payload(
 ):
     """Create payload containing authorization information of the user requesting from
     the app in the context of testing. The payload field names are identical to the
-    actual ones in the JWT returned by Auth0. Irrelevant fields (issues, audience, issue
-    time, expiration time, client ID, grant type) are skipped.
+    actual ones in the JWT returned by Auth0 (taking the prefix for custom claims into
+    account). Irrelevant fields (issues, audience, issue time, expiration time, client
+    ID, grant type) are skipped.
 
     If no arguments are passed, the payload for the default user is returned. Any
     argument specified overrides the corresponding field of the default payload.
     """
+    prefix = "https://www.boxtribute.com"
     payload = {
-        "https://www.boxtribute.com/email": "dev_coordinator@boxaid.org",
-        "https://www.boxtribute.com/base_ids": [1],
-        "https://www.boxtribute.com/organisation_id": 1,
-        "https://www.boxtribute.com/roles": ["Coordinator"],
+        f"{prefix}/email": "dev_coordinator@boxaid.org",
+        f"{prefix}/organisation_id": 1,
+        f"{prefix}/roles": ["Coordinator"],
         "sub": "auth0|8",
-        "permissions": [
-            "base:read",
-            "category:read",
-            "location:read",
-            "product:read",
-            "transaction:read",
-            "user:read",
-            "beneficiary:write",
-            "qr:write",
-            "stock:write",
-            "transaction:write",
+        f"{prefix}/permissions": [
+            "base_1/base:read",
+            "base_1/beneficiary:read",
+            "base_1/category:read",
+            "base_1/location:read",
+            "base_1/product:read",
+            "base_1/qr:read",
+            "base_1/stock:read",
+            "base_1/transaction:read",
+            "base_1/user:read",
+            "base_1/beneficiary:write",
+            "base_1/qr:write",
+            "base_1/stock:write",
+            "base_1/transaction:write",
         ],
     }
 
-    prefix = "https://www.boxtribute.com"
-    for name in ["email", "base_ids", "organisation_id", "roles"]:
+    for name in ["email", "base_ids", "organisation_id", "roles", "permissions"]:
         value = locals()[name]
         if value is not None:
             payload[f"{prefix}/{name}"] = value
     if user_id is not None:
         payload["sub"] = f"auth0|{user_id}"
-    if permissions is not None:
-        payload["permissions"] = permissions
 
     return payload

--- a/back/test/auth_tests/test_authz.py
+++ b/back/test/auth_tests/test_authz.py
@@ -19,11 +19,11 @@ ALL_PERMISSIONS = [
 
 
 def test_authorized_user():
-    user = {"organisation_id": 2, "id": 3}
+    user = {"organisation_id": 2, "id": 3, "is_god": False}
     assert authorize(user, organisation_id=2)
     assert authorize(user, user_id=3)
 
-    user = {"permissions": ALL_PERMISSIONS}
+    user = {"permissions": ALL_PERMISSIONS, "is_god": False}
     assert authorize(user, permission="base:read")
     assert authorize(user, permission="beneficiary:read")
     assert authorize(user, permission="category:read")
@@ -42,7 +42,8 @@ def test_authorized_user():
             "qr:write": [1, 3],
             "stock:write": [2],
             "location:write": None,
-        }
+        },
+        "is_god": False,
     }
     assert authorize(user, permission="qr:write")
     assert authorize(user, permission="qr:write", base_id=3)
@@ -52,28 +53,34 @@ def test_authorized_user():
 
 
 def test_user_with_insufficient_permissions():
-    user = {"permissions": []}
+    user = {"permissions": [], "is_god": False}
     for permission in ALL_PERMISSIONS:
         with pytest.raises(Forbidden):
             authorize(user, permission=permission)
 
-    user = {"permissions": {"beneficiary:write": [2]}}
+    user = {"permissions": {"beneficiary:write": [2]}, "is_god": False}
     with pytest.raises(Forbidden):
         authorize(user, permission="beneficiary:write", base_id=1)
 
 
 def test_user_unauthorized_for_organisation():
-    user = {"organisation_id": 1}
+    user = {"organisation_id": 1, "is_god": False}
     with pytest.raises(Forbidden):
         authorize(user, organisation_id=2)
 
 
 def test_user_unauthorized_for_user():
-    user = {"id": 1}
+    user = {"id": 1, "is_god": False}
     with pytest.raises(Forbidden):
         authorize(user, user_id=2)
 
 
 def test_invalid_authorization_resource():
     with pytest.raises(UnknownResource):
-        authorize(current_user={})
+        authorize(current_user={"is_god": False})
+
+
+def test_god_user():
+    user = {"is_god": True}
+    for permission in ALL_PERMISSIONS:
+        assert authorize(user, permission=permission)

--- a/back/test/data/beneficiary.py
+++ b/back/test/data/beneficiary.py
@@ -5,7 +5,7 @@ from data.base import data as base_data
 
 def default_beneficiary_data():
     return {
-        "id": 3,
+        "id": 1,
         "base": base_data()[0]["id"],
         "comment": "",
         "created_by": None,
@@ -20,7 +20,7 @@ def default_beneficiary_data():
 
 def another_beneficiary_data():
     data = default_beneficiary_data().copy()
-    data["id"] = 4
+    data["id"] = 2
     return data
 
 

--- a/back/test/data/product.py
+++ b/back/test/data/product.py
@@ -21,6 +21,13 @@ def default_product_data():
     }
 
 
+def another_product_data():
+    data = default_product_data()
+    data["id"] = 2
+    data["name"] = "another product"
+    return data
+
+
 @pytest.fixture()
 def default_product():
     return default_product_data()
@@ -28,3 +35,4 @@ def default_product():
 
 def create():
     Product.create(**default_product_data())
+    Product.create(**another_product_data())

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -180,9 +180,9 @@ def test_base_specific_permissions(client, mocker):
         roles=["base_2_coordinator", "base_3_coordinator"],
         user_id=1,
         permissions=[
-            "base_2:qr:write",
+            "base_2/qr:write",
             "stock:write",
-            "base_3:beneficiary:write",
+            "base_3/beneficiary:write",
         ],
     )
 

--- a/back/test/endpoint_tests/test_beneficiary.py
+++ b/back/test/endpoint_tests/test_beneficiary.py
@@ -151,17 +151,17 @@ def test_beneficiary_mutations(client):
     "input,size,has_next_page,has_previous_page",
     (
         ["", 2, False, False],
-        #                             ID=2
-        ["""(paginationInput: {after: "MDAwMDAwMDI="})""", 2, False, False],
+        #                             ID=0
+        ["""(paginationInput: {after: "MDAwMDAwMDA="})""", 2, False, False],
         ["""(paginationInput: {first: 1})""", 1, True, False],
-        #                             ID=4; previous page exists but can't be determined
-        ["""(paginationInput: {after: "MDAwMDAwMDQ="})""", 0, False, False],
-        #                             ID=3
-        ["""(paginationInput: {after: "MDAwMDAwMDM=", first: 1})""", 1, False, True],
+        #                             ID=2; previous page exists but can't be determined
+        ["""(paginationInput: {after: "MDAwMDAwMDI="})""", 0, False, False],
+        #                             ID=1
+        ["""(paginationInput: {after: "MDAwMDAwMDE=", first: 1})""", 1, False, True],
         # next page exists but can't be determined
-        ["""(paginationInput: {before: "MDAwMDAwMDM="})""", 0, False, False],
-        #                              ID=5
-        ["""(paginationInput: {before: "MDAwMDAwMDU=", last: 1})""", 1, False, True],
+        ["""(paginationInput: {before: "MDAwMDAwMDE="})""", 0, False, False],
+        #                              ID=3
+        ["""(paginationInput: {before: "MDAwMDAwMDM=", last: 1})""", 1, False, True],
     ),
     ids=[
         "no input",

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -79,7 +79,7 @@ def test_invalid_permission_for_given_resource_id(read_only_client, mocker, quer
     specified resource (base or organisation).
     """
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
-        permissions=["base:read"], base_ids=[1], organisation_id=1
+        permissions=["base_1/base:read"], organisation_id=1
     )
     data = {"query": f"query {{ {query} }}"}
     assert_forbidden_request(data, read_only_client, field=operation_name(query))
@@ -208,3 +208,15 @@ def test_invalid_permission_for_box_location(read_only_client, mocker, default_b
     assert_forbidden_request(
         data, read_only_client, field="box", value={"location": None}
     )
+
+
+def test_permission_for_all_bases(read_only_client, mocker, default_bases):
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        permissions=["base:read"]
+    )
+    data = {"query": """query { bases { id } }"""}
+    response = read_only_client.post("/graphql", json=data)
+
+    assert response.status_code == 200
+    bases = response.json["data"]["bases"]
+    assert len(bases) == len(default_bases)

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -220,3 +220,11 @@ def test_permission_for_all_bases(read_only_client, mocker, default_bases):
     assert response.status_code == 200
     bases = response.json["data"]["bases"]
     assert len(bases) == len(default_bases)
+
+
+def test_permission_for_god_user(read_only_client, mocker, default_users):
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(permissions=["*"])
+    data = {"query": """query { users { id } }"""}
+    response = read_only_client.post("/graphql", json=data)
+    assert response.status_code == 200
+    assert len(response.json["data"]["users"]) == len(default_users)

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -210,9 +210,14 @@ def test_invalid_permission_for_box_location(read_only_client, mocker, default_b
     )
 
 
-def test_permission_for_all_bases(read_only_client, mocker, default_bases):
+@pytest.mark.parametrize(
+    "method",
+    ["read", "write", "edit"],
+    ids=["all-bases", "write-implies-read", "edit-implies-read"],
+)
+def test_permission_scope(read_only_client, mocker, default_bases, method):
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
-        permissions=["base:read"]
+        permissions=[f"base:{method}"]
     )
     data = {"query": """query { bases { id } }"""}
     response = read_only_client.post("/graphql", json=data)

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -39,7 +39,7 @@ def test_invalid_read_permissions(unauthorized, read_only_client, resource):
         data = {"query": "query { products { elements { id } } }"}
     assert_forbidden_request(data, read_only_client)
 
-    data = {"query": f"""query {{ {resource}(id: 3) {{ id }} }}"""}
+    data = {"query": f"""query {{ {resource}(id: 2) {{ id }} }}"""}
     assert_forbidden_request(data, read_only_client, field=resource)
 
 
@@ -53,7 +53,7 @@ def operation_name(operation):
 @pytest.mark.parametrize(
     "query",
     [
-        """box( labelIdentifier: "c0ffee") { id }""",
+        """box( labelIdentifier: "12345678") { id }""",
         """qrCode( qrCode: "1337beef" ) { id }""",
         """qrExists( qrCode: "1337beef" )""",
     ],
@@ -70,7 +70,7 @@ def test_invalid_permission(unauthorized, read_only_client, query):
     [
         """base( id: 0 ) { id }""",
         """organisation( id: 0 ) { id }""",
-        """location( id: 3 ) { id }""",  # ID of another_location fixture
+        """location( id: 2 ) { id }""",  # ID of another_location fixture
     ],
     ids=operation_name,
 )
@@ -171,12 +171,15 @@ def test_invalid_permission_for_organisation_bases(
     )
 
 
-def test_invalid_permission_for_beneficiary_tokens(read_only_client, mocker):
+def test_invalid_permission_for_beneficiary_tokens(
+    read_only_client, mocker, default_beneficiary
+):
     # verify missing transaction:read permission
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         permissions=["beneficiary:read"]
     )
-    data = {"query": "query { beneficiary(id: 3) { tokens } }"}
+    id = default_beneficiary["id"]
+    data = {"query": f"query {{ beneficiary(id: {id}) {{ tokens }} }}"}
     assert_forbidden_request(
         data, read_only_client, field="beneficiary", value={"tokens": None}
     )


### PR DESCRIPTION
- Make test data and its usage more consistent
- Integrate new Auth0 permissions format

Some ideas to decrease the JWT payload size for @vahidbazzaz
- only send `:write` or `:edit` permission (I can derive the corresponding `:read` permission)
- do we need `box_state:read`, `category:read`, `gender:read`, `language:read`, `sizegroup:read`? The underlying data is not user-specific. Even if the permissions were part of the payload, I would not enforce them in the BE for simplicity.

What do you think?
