### PR TITLE
Enforce DB-based permissions for box-transfer

### DIFF
--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -9,6 +9,7 @@ def authorize(
     *,
     user_id=None,
     organisation_id=None,
+    organisation_ids=None,
     base_id=None,
     permission=None,
 ):
@@ -35,6 +36,8 @@ def authorize(
             authorized = True if base_ids is None else base_id in base_ids
     elif organisation_id is not None:
         authorized = organisation_id == current_user["organisation_id"]
+    elif organisation_ids is not None:
+        authorized = current_user["organisation_id"] in organisation_ids
     elif user_id is not None:
         authorized = user_id == current_user["id"]
     else:

--- a/back/boxtribute_server/box_transfer/agreement.py
+++ b/back/boxtribute_server/box_transfer/agreement.py
@@ -109,7 +109,7 @@ def create_transfer_agreement(
         return transfer_agreement
 
 
-def accept_transfer_agreement(*, id, accepted_by):
+def accept_transfer_agreement(*, id, user):
     """Transition state of specified transfer agreement to 'Accepted'.
     Raise error if agreement state different from 'UnderReview', or if requesting user
     not a member of the agreement's target_organisation.
@@ -120,16 +120,16 @@ def accept_transfer_agreement(*, id, accepted_by):
             expected_states=[TransferAgreementState.UnderReview],
             actual_state=agreement.state,
         )
-    if agreement.target_organisation_id != accepted_by["organisation_id"]:
+    if agreement.target_organisation_id != user["organisation_id"]:
         raise InvalidTransferAgreementOrganisation()
     agreement.state = TransferAgreementState.Accepted
-    agreement.accepted_by = accepted_by["id"]
+    agreement.accepted_by = user["id"]
     agreement.accepted_on = utcnow()
     agreement.save()
     return agreement
 
 
-def reject_transfer_agreement(*, id, rejected_by):
+def reject_transfer_agreement(*, id, user):
     """Transition state of specified transfer agreement to 'Rejected'.
     Raise error if agreement state different from 'UnderReview', or if requesting user
     not a member of the agreement's target_organisation.
@@ -140,16 +140,16 @@ def reject_transfer_agreement(*, id, rejected_by):
             expected_states=[TransferAgreementState.UnderReview],
             actual_state=agreement.state,
         )
-    if agreement.target_organisation_id != rejected_by["organisation_id"]:
+    if agreement.target_organisation_id != user["organisation_id"]:
         raise InvalidTransferAgreementOrganisation()
     agreement.state = TransferAgreementState.Rejected
-    agreement.terminated_by = rejected_by["id"]
+    agreement.terminated_by = user["id"]
     agreement.terminated_on = utcnow()
     agreement.save()
     return agreement
 
 
-def cancel_transfer_agreement(*, id, canceled_by):
+def cancel_transfer_agreement(*, id, user_id):
     """Transition state of specified transfer agreement to 'Canceled'.
     Raise error if agreement state different from 'UnderReview'/'Accepted'.
     """
@@ -166,7 +166,7 @@ def cancel_transfer_agreement(*, id, canceled_by):
             actual_state=agreement.state,
         )
     agreement.state = TransferAgreementState.Canceled
-    agreement.terminated_by = canceled_by
+    agreement.terminated_by = user_id
     agreement.terminated_on = utcnow()
     agreement.save()
     return agreement

--- a/back/boxtribute_server/box_transfer/agreement.py
+++ b/back/boxtribute_server/box_transfer/agreement.py
@@ -111,8 +111,8 @@ def create_transfer_agreement(
 
 def accept_transfer_agreement(*, id, user):
     """Transition state of specified transfer agreement to 'Accepted'.
-    Raise error if agreement state different from 'UnderReview', or if requesting user
-    not a member of the agreement's target_organisation.
+    Raise an InvalidTransferAgreementState exception if agreement state different from
+    'UnderReview'.
     """
     agreement = TransferAgreement.get_by_id(id)
     if agreement.state != TransferAgreementState.UnderReview:
@@ -120,8 +120,6 @@ def accept_transfer_agreement(*, id, user):
             expected_states=[TransferAgreementState.UnderReview],
             actual_state=agreement.state,
         )
-    if agreement.target_organisation_id != user["organisation_id"]:
-        raise InvalidTransferAgreementOrganisation()
     agreement.state = TransferAgreementState.Accepted
     agreement.accepted_by = user["id"]
     agreement.accepted_on = utcnow()
@@ -131,8 +129,8 @@ def accept_transfer_agreement(*, id, user):
 
 def reject_transfer_agreement(*, id, user):
     """Transition state of specified transfer agreement to 'Rejected'.
-    Raise error if agreement state different from 'UnderReview', or if requesting user
-    not a member of the agreement's target_organisation.
+    Raise an InvalidTransferAgreementState exception if agreement state different from
+    'UnderReview'.
     """
     agreement = TransferAgreement.get_by_id(id)
     if agreement.state != TransferAgreementState.UnderReview:
@@ -140,8 +138,6 @@ def reject_transfer_agreement(*, id, user):
             expected_states=[TransferAgreementState.UnderReview],
             actual_state=agreement.state,
         )
-    if agreement.target_organisation_id != user["organisation_id"]:
-        raise InvalidTransferAgreementOrganisation()
     agreement.state = TransferAgreementState.Rejected
     agreement.terminated_by = user["id"]
     agreement.terminated_on = utcnow()

--- a/back/boxtribute_server/box_transfer/shipment.py
+++ b/back/boxtribute_server/box_transfer/shipment.py
@@ -57,11 +57,9 @@ def _validate_bases_as_part_of_transfer_agreement(
 def create_shipment(*, source_base_id, target_base_id, transfer_agreement_id, user):
     """Insert information for a new Shipment in the database.
     Raise an InvalidTransferAgreementState exception if specified agreement has a state
-    different from 'ACCEPTED'.
+    different from 'Accepted'.
     Raise an InvalidTransferAgreementBase exception if specified source or target base
     are not included in given agreement.
-    Raise an InvalidTransferAgreementOrganisation exception if the current user is not
-    member of the agreement source organisation in a unidirectional agreement.
     """
     agreement = TransferAgreement.get_by_id(transfer_agreement_id)
     if agreement.state != TransferAgreementState.Accepted:
@@ -75,11 +73,6 @@ def create_shipment(*, source_base_id, target_base_id, transfer_agreement_id, us
         source_base_id=source_base_id,
         target_base_id=target_base_id,
     )
-
-    if (agreement.type == TransferAgreementType.Unidirectional) and (
-        user["organisation_id"] != agreement.source_organisation_id
-    ):
-        raise InvalidTransferAgreementOrganisation()
 
     return Shipment.create(
         source_base=source_base_id,

--- a/back/boxtribute_server/box_transfer/shipment.py
+++ b/back/boxtribute_server/box_transfer/shipment.py
@@ -98,19 +98,12 @@ def cancel_shipment(*, id, user):
     corresponding shipment details.
     Raise InvalidShipmentState exception if shipment state is different from
     'Preparing'.
-    Raise an InvalidTransferAgreementOrganisation exception if the current user is not
-    member of either organisation that is part of the underlying transfer agreement.
     """
     shipment = Shipment.get_by_id(id)
     if shipment.state != ShipmentState.Preparing:
         raise InvalidShipmentState(
             expected_states=[ShipmentState.Preparing], actual_state=shipment.state
         )
-    if user["organisation_id"] not in [
-        shipment.transfer_agreement.source_organisation_id,
-        shipment.transfer_agreement.target_organisation_id,
-    ]:
-        raise InvalidTransferAgreementOrganisation()
 
     now = utcnow()
     shipment.state = ShipmentState.Canceled
@@ -136,14 +129,10 @@ def cancel_shipment(*, id, user):
 
 def send_shipment(*, id, user):
     """Transition state of specified shipment to 'Sent'.
-    Raise an InvalidTransferAgreementOrganisation exception if the current user is not
-    member of the organisation that originally created the shipment.
     Raise InvalidShipmentState exception if shipment state is different from
     'Preparing'.
     """
     shipment = Shipment.get_by_id(id)
-    if shipment.source_base.organisation_id != user["organisation_id"]:
-        raise InvalidTransferAgreementOrganisation()
     if shipment.state != ShipmentState.Preparing:
         raise InvalidShipmentState(
             expected_states=[ShipmentState.Preparing], actual_state=shipment.state

--- a/back/boxtribute_server/graph_ql/operations.graphql
+++ b/back/boxtribute_server/graph_ql/operations.graphql
@@ -30,8 +30,8 @@ type Mutation {
   createQrCode(boxLabelIdentifier: String): QrCode
   createBox(boxCreationInput: CreateBoxInput): Box
   updateBox(boxUpdateInput: UpdateBoxInput): Box
-  createBeneficiary(beneficiaryCreationInput: CreateBeneficiaryInput): Beneficiary
-  updateBeneficiary(beneficiaryUpdateInput: UpdateBeneficiaryInput): Beneficiary
+  createBeneficiary(creationInput: CreateBeneficiaryInput): Beneficiary
+  updateBeneficiary(updateInput: UpdateBeneficiaryInput): Beneficiary
 
   createTransferAgreement(creationInput: TransferAgreementCreationInput): TransferAgreement
   acceptTransferAgreement(id: ID!): TransferAgreement

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -18,7 +18,7 @@ from ..box_transfer.shipment import (
     send_shipment,
     update_shipment,
 )
-from ..enums import HumanGender, TransferAgreementState
+from ..enums import HumanGender, TransferAgreementState, TransferAgreementType
 from ..models.crud import (
     create_beneficiary,
     create_box,
@@ -380,6 +380,9 @@ def resolve_cancel_transfer_agreement(_, info, id):
 @convert_kwargs_to_snake_case
 def resolve_create_shipment(_, info, creation_input):
     authorize(permission="shipment:write")
+    agreement = TransferAgreement.get_by_id(creation_input["transfer_agreement_id"])
+    if agreement.type == TransferAgreementType.Unidirectional:
+        authorize(organisation_id=agreement.source_organisation_id)
     return create_shipment(**creation_input, user=g.user)
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -401,12 +401,16 @@ def resolve_update_shipment(_, info, update_input):
         "received_shipment_detail_update_inputs",
         "lost_box_label_identifiers",
     ]
+    organisation_id = None
     if any([update_input.get(f) for f in source_update_fields]):
         # User must be member of organisation that created the shipment
         organisation_id = shipment.source_base.organisation_id
     elif any([update_input.get(f) for f in target_update_fields]):
         # User must be member of organisation that is supposed to receive the shipment
         organisation_id = shipment.target_base.organisation_id
+
+    if organisation_id is None:
+        return shipment  # no update arguments provided
     authorize(organisation_id=organisation_id)
 
     return update_shipment(**update_input, user=g.user)

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -350,19 +350,19 @@ def resolve_create_transfer_agreement(_, info, creation_input):
 @mutation.field("acceptTransferAgreement")
 def resolve_accept_transfer_agreement(_, info, id):
     authorize(permission="transfer_agreement:write")
-    return accept_transfer_agreement(id=id, accepted_by=g.user)
+    return accept_transfer_agreement(id=id, user=g.user)
 
 
 @mutation.field("rejectTransferAgreement")
 def resolve_reject_transfer_agreement(_, info, id):
     authorize(permission="transfer_agreement:write")
-    return reject_transfer_agreement(id=id, rejected_by=g.user)
+    return reject_transfer_agreement(id=id, user=g.user)
 
 
 @mutation.field("cancelTransferAgreement")
 def resolve_cancel_transfer_agreement(_, info, id):
     authorize(permission="transfer_agreement:write")
-    return cancel_transfer_agreement(id=id, canceled_by=g.user["id"])
+    return cancel_transfer_agreement(id=id, user_id=g.user["id"])
 
 
 @mutation.field("createShipment")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -350,12 +350,16 @@ def resolve_create_transfer_agreement(_, info, creation_input):
 @mutation.field("acceptTransferAgreement")
 def resolve_accept_transfer_agreement(_, info, id):
     authorize(permission="transfer_agreement:write")
+    agreement = TransferAgreement.get_by_id(id)
+    authorize(organisation_id=agreement.target_organisation_id)
     return accept_transfer_agreement(id=id, user=g.user)
 
 
 @mutation.field("rejectTransferAgreement")
 def resolve_reject_transfer_agreement(_, info, id):
     authorize(permission="transfer_agreement:write")
+    agreement = TransferAgreement.get_by_id(id)
+    authorize(organisation_id=agreement.target_organisation_id)
     return reject_transfer_agreement(id=id, user=g.user)
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -320,24 +320,22 @@ def resolve_update_box(_, info, box_update_input):
 
 @mutation.field("createBeneficiary")
 @convert_kwargs_to_snake_case
-def resolve_create_beneficiary(_, info, beneficiary_creation_input):
-    authorize(
-        permission="beneficiary:write", base_id=beneficiary_creation_input["base_id"]
-    )
-    beneficiary_creation_input["created_by"] = g.user["id"]
-    return create_beneficiary(beneficiary_creation_input)
+def resolve_create_beneficiary(_, info, creation_input):
+    authorize(permission="beneficiary:write", base_id=creation_input["base_id"])
+    creation_input["created_by"] = g.user["id"]
+    return create_beneficiary(creation_input)
 
 
 @mutation.field("updateBeneficiary")
 @convert_kwargs_to_snake_case
-def resolve_update_beneficiary(_, info, beneficiary_update_input):
+def resolve_update_beneficiary(_, info, update_input):
     # Use target base ID if specified, otherwise skip enforcing base-specific authz
     authorize(
         permission="beneficiary:write",
-        base_id=beneficiary_update_input.get("base_id"),
+        base_id=update_input.get("base_id"),
     )
-    beneficiary_update_input["last_modified_by"] = g.user["id"]
-    return update_beneficiary(beneficiary_update_input)
+    update_input["last_modified_by"] = g.user["id"]
+    return update_beneficiary(update_input)
 
 
 @mutation.field("createTransferAgreement")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -171,11 +171,13 @@ def resolve_product_category(_, info, id):
 
 @query.field("transferAgreement")
 def resolve_transfer_agreement(_, info, id):
+    authorize(permission="transfer_agreement:read")
     return TransferAgreement.get_by_id(id)
 
 
 @query.field("shipment")
 def resolve_shipment(_, info, id):
+    authorize(permission="shipment:read")
     return Shipment.get_by_id(id)
 
 
@@ -222,6 +224,7 @@ def resolve_beneficiaries(_, info, pagination_input=None):
 
 @query.field("transferAgreements")
 def resolve_transfer_agreements(_, info, states=None):
+    authorize(permission="transfer_agreement:read")
     user_organisation_id = g.user["organisation_id"]
     states = states or list(TransferAgreementState)
     return TransferAgreement.select().where(
@@ -235,6 +238,7 @@ def resolve_transfer_agreements(_, info, states=None):
 
 @query.field("shipments")
 def resolve_shipments(_, info):
+    authorize(permission="shipment:read")
     user_organisation_id = g.user["organisation_id"]
     return (
         Shipment.select()
@@ -339,43 +343,51 @@ def resolve_update_beneficiary(_, info, beneficiary_update_input):
 @mutation.field("createTransferAgreement")
 @convert_kwargs_to_snake_case
 def resolve_create_transfer_agreement(_, info, creation_input):
+    authorize(permission="transfer_agreement:write")
     return create_transfer_agreement(**creation_input, user=g.user)
 
 
 @mutation.field("acceptTransferAgreement")
 def resolve_accept_transfer_agreement(_, info, id):
+    authorize(permission="transfer_agreement:write")
     return accept_transfer_agreement(id=id, accepted_by=g.user)
 
 
 @mutation.field("rejectTransferAgreement")
 def resolve_reject_transfer_agreement(_, info, id):
+    authorize(permission="transfer_agreement:write")
     return reject_transfer_agreement(id=id, rejected_by=g.user)
 
 
 @mutation.field("cancelTransferAgreement")
 def resolve_cancel_transfer_agreement(_, info, id):
+    authorize(permission="transfer_agreement:write")
     return cancel_transfer_agreement(id=id, canceled_by=g.user["id"])
 
 
 @mutation.field("createShipment")
 @convert_kwargs_to_snake_case
 def resolve_create_shipment(_, info, creation_input):
+    authorize(permission="shipment:write")
     return create_shipment(**creation_input, user=g.user)
 
 
 @mutation.field("updateShipment")
 @convert_kwargs_to_snake_case
 def resolve_update_shipment(_, info, update_input):
+    authorize(permission="shipment:write")
     return update_shipment(**update_input, user=g.user)
 
 
 @mutation.field("cancelShipment")
 def resolve_cancel_shipment(_, info, id):
+    authorize(permission="shipment:write")
     return cancel_shipment(id=id, user=g.user)
 
 
 @mutation.field("sendShipment")
 def resolve_send_shipment(_, info, id):
+    authorize(permission="shipment:write")
     return send_shipment(id=id, user=g.user)
 
 
@@ -472,6 +484,7 @@ def resolve_transfer_agreement_target_bases(transfer_agreement_obj, info):
 
 @transfer_agreement.field("shipments")
 def resolve_transfer_agreement_shipments(transfer_agreement_obj, info):
+    authorize(permission="shipment:read")
     return Shipment.select().where(
         Shipment.transfer_agreement == transfer_agreement_obj.id
     )

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -366,6 +366,13 @@ def resolve_reject_transfer_agreement(_, info, id):
 @mutation.field("cancelTransferAgreement")
 def resolve_cancel_transfer_agreement(_, info, id):
     authorize(permission="transfer_agreement:write")
+    agreement = TransferAgreement.get_by_id(id)
+    authorize(
+        organisation_ids=[
+            agreement.source_organisation_id,
+            agreement.target_organisation_id,
+        ]
+    )
     return cancel_transfer_agreement(id=id, user_id=g.user["id"])
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -398,12 +398,21 @@ def resolve_update_shipment(_, info, update_input):
 @mutation.field("cancelShipment")
 def resolve_cancel_shipment(_, info, id):
     authorize(permission="shipment:write")
+    shipment = Shipment.get_by_id(id)
+    authorize(
+        organisation_ids=[
+            shipment.transfer_agreement.source_organisation_id,
+            shipment.transfer_agreement.target_organisation_id,
+        ]
+    )
     return cancel_shipment(id=id, user=g.user)
 
 
 @mutation.field("sendShipment")
 def resolve_send_shipment(_, info, id):
     authorize(permission="shipment:write")
+    shipment = Shipment.get_by_id(id)
+    authorize(organisation_id=shipment.source_base.organisation_id)
     return send_shipment(id=id, user=g.user)
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -381,8 +381,10 @@ def resolve_cancel_transfer_agreement(_, info, id):
 def resolve_create_shipment(_, info, creation_input):
     authorize(permission="shipment:write")
     agreement = TransferAgreement.get_by_id(creation_input["transfer_agreement_id"])
-    if agreement.type == TransferAgreementType.Unidirectional:
-        authorize(organisation_id=agreement.source_organisation_id)
+    organisation_ids = [agreement.source_organisation_id]
+    if agreement.type == TransferAgreementType.Bidirectional:
+        organisation_ids.append(agreement.target_organisation_id)
+    authorize(organisation_ids=organisation_ids)
     return create_shipment(**creation_input, user=g.user)
 
 

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -109,6 +109,8 @@ def create_jwt_payload(
             f"{base_prefix}/qr:write",
             f"{base_prefix}/stock:write",
             f"{base_prefix}/transaction:write",
+            "shipment:write",
+            "transfer_agreement:write",
         ]
     else:
         payload[f"{JWT_CLAIM_PREFIX}/permissions"] = permissions

--- a/back/test/auth_tests/test_authz.py
+++ b/back/test/auth_tests/test_authz.py
@@ -8,12 +8,16 @@ ALL_PERMISSIONS = [
     "category:read",
     "location:read",
     "product:read",
+    "shipment:read",
     "stock:read",
     "transaction:read",
+    "transfer_agreement:read",
     "user:read",
     "qr:read",
     "beneficiary:write",
+    "shipment:write",
     "stock:write",
+    "transfer_agreement:write",
     "qr:write",
 ]
 
@@ -29,12 +33,16 @@ def test_authorized_user():
     assert authorize(user, permission="category:read")
     assert authorize(user, permission="location:read")
     assert authorize(user, permission="product:read")
+    assert authorize(user, permission="shipment:read")
     assert authorize(user, permission="stock:read")
     assert authorize(user, permission="transaction:read")
+    assert authorize(user, permission="transfer_agreement:read")
     assert authorize(user, permission="user:read")
     assert authorize(user, permission="qr:read")
     assert authorize(user, permission="beneficiary:write")
+    assert authorize(user, permission="shipment:write")
     assert authorize(user, permission="stock:write")
+    assert authorize(user, permission="transfer_agreement:write")
     assert authorize(user, permission="qr:write")
 
     user = {

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -186,7 +186,7 @@ def test_base_specific_permissions(client, mocker):
     )
 
     create_beneficiary_for_base2_mutation = """createBeneficiary(
-                beneficiaryCreationInput : {
+                creationInput : {
                     firstName: "First",
                     lastName: "Last",
                     dateOfBirth: "1990-09-01",

--- a/back/test/endpoint_tests/test_beneficiary.py
+++ b/back/test/endpoint_tests/test_beneficiary.py
@@ -26,7 +26,7 @@ def test_beneficiary_mutations(client):
                 }}"""
     mutation = f"""mutation {{
             createBeneficiary(
-                beneficiaryCreationInput : {beneficiary_creation_input_string}
+                creationInput : {beneficiary_creation_input_string}
             ) {{
                 id
                 firstName
@@ -74,7 +74,7 @@ def test_beneficiary_mutations(client):
     language = "nl"
     mutation = f"""mutation {{
             updateBeneficiary(
-                beneficiaryUpdateInput : {{
+                updateInput : {{
                     id: {beneficiary_id},
                     lastName: "{last_name}",
                     signature: "{first_name}",

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -24,7 +24,16 @@ def assert_forbidden_request(data, client_fixture=None, field=None, value=None):
 
 @pytest.mark.parametrize(
     "resource",
-    ["base", "beneficiary", "location", "product", "productCategory", "user"],
+    [
+        "base",
+        "beneficiary",
+        "location",
+        "product",
+        "productCategory",
+        "shipment",
+        "transferAgreement",
+        "user",
+    ],
 )
 def test_invalid_read_permissions(unauthorized, read_only_client, resource):
     """Verify missing resource:read permission when executing query."""
@@ -127,6 +136,23 @@ def test_invalid_permission_for_given_resource_id(read_only_client, mocker, quer
             id
         }""",
         "createQrCode { id }",
+        """createTransferAgreement(
+            creationInput : {
+                targetOrganisationId: 2,
+                type: Bidirectional
+            }) { id }""",
+        "acceptTransferAgreement( id: 1 ) { id }",
+        "rejectTransferAgreement( id: 1 ) { id }",
+        "cancelTransferAgreement( id: 1 ) { id }",
+        """createShipment(
+            creationInput : {
+                sourceBaseId: 1,
+                targetBaseId: 3,
+                transferAgreementId: 1
+            }) { id }""",
+        "updateShipment( updateInput : { id: 1 }) { id }",
+        "cancelShipment( id : 1 ) { id }",
+        "sendShipment( id : 1 ) { id }",
     ],
     ids=operation_name,
 )

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -78,7 +78,7 @@ def test_invalid_permission_for_given_resource_id(read_only_client, mocker, quer
     "mutation",
     [
         """createBeneficiary(
-            beneficiaryCreationInput : {
+            creationInput : {
                 firstName: "First",
                 lastName: "Last",
                 dateOfBirth: "1990-09-01",
@@ -92,7 +92,7 @@ def test_invalid_permission_for_given_resource_id(read_only_client, mocker, quer
             id
         }""",
         """updateBeneficiary(
-            beneficiaryUpdateInput : {
+            updateInput : {
                 id: 3,
                 firstName: "First"
             }) {

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -1,25 +1,6 @@
 import pytest
 from auth import create_jwt_payload
-from utils import assert_successful_request
-
-
-def assert_forbidden_request(data, client_fixture=None, field=None, value=None):
-    """Assertion utility that posts the given data via a client fixture.
-    Afterwards verifies response field containing error information. If specified, the
-    response data field named `field` is verified against an expected `value` (default
-    None).
-    """
-    response = client_fixture.post("/graphql", json=data)
-    assert response.status_code == 200
-    assert len(response.json["errors"]) == 1
-    assert response.json["errors"][0]["extensions"]["code"] == "FORBIDDEN"
-    if field is None:
-        assert response.json["data"] is None
-    else:
-        if value is None:
-            assert response.json["data"][field] is None
-        else:
-            assert response.json["data"][field] == value
+from utils import assert_forbidden_request, assert_successful_request
 
 
 @pytest.mark.parametrize(
@@ -42,15 +23,15 @@ def test_invalid_read_permissions(unauthorized, read_only_client, resource):
     if resource.endswith("y"):
         resources = f"{resource[:-1]}ies"
 
-    data = {"query": f"""query {{ {resources} {{ id }} }}"""}
+    query = f"""query {{ {resources} {{ id }} }}"""
     if resources == "beneficiaries":
-        data = {"query": "query { beneficiaries { elements { id } } }"}
+        query = "query { beneficiaries { elements { id } } }"
     elif resources == "products":
-        data = {"query": "query { products { elements { id } } }"}
-    assert_forbidden_request(data, read_only_client)
+        query = "query { products { elements { id } } }"
+    assert_forbidden_request(read_only_client, query, none_data=True)
 
-    data = {"query": f"""query {{ {resource}(id: 2) {{ id }} }}"""}
-    assert_forbidden_request(data, read_only_client, field=resource)
+    query = f"""query {{ {resource}(id: 2) {{ id }} }}"""
+    assert_forbidden_request(read_only_client, query)
 
 
 def operation_name(operation):
@@ -71,8 +52,7 @@ def operation_name(operation):
 )
 def test_invalid_permission(unauthorized, read_only_client, query):
     """Verify missing resource:read permission."""
-    data = {"query": f"query {{ {query} }}"}
-    assert_forbidden_request(data, read_only_client, field=operation_name(query))
+    assert_forbidden_request(read_only_client, f"query {{ {query} }}")
 
 
 @pytest.mark.parametrize(
@@ -91,8 +71,7 @@ def test_invalid_permission_for_given_resource_id(read_only_client, mocker, quer
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         permissions=["base_1/base:read"], organisation_id=1
     )
-    data = {"query": f"query {{ {query} }}"}
-    assert_forbidden_request(data, read_only_client, field=operation_name(query))
+    assert_forbidden_request(read_only_client, f"query {{ {query} }}")
 
 
 @pytest.mark.parametrize(
@@ -158,8 +137,9 @@ def test_invalid_permission_for_given_resource_id(read_only_client, mocker, quer
 )
 def test_invalid_write_permission(unauthorized, read_only_client, mutation):
     """Verify missing resource:write permission when executing mutation."""
-    data = {"query": f"mutation {{ {mutation} }}"}
-    assert_forbidden_request(data, read_only_client, field=operation_name(mutation))
+    assert_forbidden_request(
+        read_only_client, f"mutation {{ {mutation} }}", field=operation_name(mutation)
+    )
 
 
 def test_invalid_permission_for_location_boxes(read_only_client, mocker):
@@ -167,10 +147,8 @@ def test_invalid_permission_for_location_boxes(read_only_client, mocker):
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         permissions=["location:read"]
     )
-    data = {"query": "query { location(id: 1) { boxes { elements { id } } } }"}
-    assert_forbidden_request(
-        data, read_only_client, field="location", value={"boxes": None}
-    )
+    query = "query { location(id: 1) { boxes { elements { id } } } }"
+    assert_forbidden_request(read_only_client, query, value={"boxes": None})
 
 
 def test_invalid_permission_for_qr_code_box(read_only_client, mocker, default_qr_code):
@@ -179,10 +157,8 @@ def test_invalid_permission_for_qr_code_box(read_only_client, mocker, default_qr
         permissions=["qr:read"]
     )
     code = default_qr_code["code"]
-    data = {"query": f"""query {{ qrCode(qrCode: "{code}") {{ box {{ id }} }} }}"""}
-    assert_forbidden_request(
-        data, read_only_client, field="qrCode", value={"box": None}
-    )
+    query = f"""query {{ qrCode(qrCode: "{code}") {{ box {{ id }} }} }}"""
+    assert_forbidden_request(read_only_client, query, value={"box": None})
 
 
 def test_invalid_permission_for_organisation_bases(
@@ -190,12 +166,8 @@ def test_invalid_permission_for_organisation_bases(
 ):
     # verify missing base:read permission
     org_id = default_organisation["id"]
-    data = {
-        "query": f"""query {{ organisation(id: "{org_id}") {{ bases {{ id }} }} }}"""
-    }
-    assert_forbidden_request(
-        data, read_only_client, field="organisation", value={"bases": None}
-    )
+    query = f"""query {{ organisation(id: "{org_id}") {{ bases {{ id }} }} }}"""
+    assert_forbidden_request(read_only_client, query, value={"bases": None})
 
 
 def test_invalid_permission_for_beneficiary_tokens(
@@ -206,10 +178,8 @@ def test_invalid_permission_for_beneficiary_tokens(
         permissions=["beneficiary:read"]
     )
     id = default_beneficiary["id"]
-    data = {"query": f"query {{ beneficiary(id: {id}) {{ tokens }} }}"}
-    assert_forbidden_request(
-        data, read_only_client, field="beneficiary", value={"tokens": None}
-    )
+    query = f"query {{ beneficiary(id: {id}) {{ tokens }} }}"
+    assert_forbidden_request(read_only_client, query, value={"tokens": None})
 
 
 def test_invalid_permission_for_base_locations(read_only_client, mocker):
@@ -217,10 +187,8 @@ def test_invalid_permission_for_base_locations(read_only_client, mocker):
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         permissions=["base:read"]
     )
-    data = {"query": "query { base(id: 1) { locations { id } } }"}
-    assert_forbidden_request(
-        data, read_only_client, field="base", value={"locations": None}
-    )
+    query = "query { base(id: 1) { locations { id } } }"
+    assert_forbidden_request(read_only_client, query, value={"locations": None})
 
 
 def test_invalid_permission_for_box_location(read_only_client, mocker, default_box):
@@ -228,13 +196,9 @@ def test_invalid_permission_for_box_location(read_only_client, mocker, default_b
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         permissions=["stock:read"]
     )
-    data = {
-        "query": f"""query {{ box(labelIdentifier: "{default_box["label_identifier"]}")
-            {{ location {{ id }} }} }}"""
-    }
-    assert_forbidden_request(
-        data, read_only_client, field="box", value={"location": None}
-    )
+    query = f"""query {{ box(labelIdentifier: "{default_box["label_identifier"]}")
+                {{ location {{ id }} }} }}"""
+    assert_forbidden_request(read_only_client, query, value={"location": None})
 
 
 @pytest.mark.parametrize(

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -638,11 +638,11 @@ def test_shipment_mutations_update_as_member_of_non_creating_org(
     # Test case 3.2.25
     # The default user (see auth_service fixture) is member of organisation 1 but
     # organisation 2 is the one that created another_shipment
-    assert_bad_user_input_when_updating_shipment(
-        read_only_client,
+    mutation = _generate_update_shipment_mutation(
         shipment=another_shipment,
         target_base=default_bases[2],
     )
+    assert_forbidden_request(read_only_client, mutation)
 
 
 def test_shipment_mutations_update_checked_in_boxes_as_member_of_creating_org(
@@ -653,13 +653,13 @@ def test_shipment_mutations_update_checked_in_boxes_as_member_of_creating_org(
     another_product,
 ):
     # Test case 3.2.35
-    assert_bad_user_input_when_updating_shipment(
-        read_only_client,
+    mutation = _generate_update_shipment_mutation(
         shipment=sent_shipment,
         received_details=[default_shipment_detail],
         target_location=another_location,
         target_product=another_product,
     )
+    assert_forbidden_request(read_only_client, mutation)
 
 
 def test_shipment_mutations_update_mark_lost_boxes_as_member_of_creating_org(
@@ -668,11 +668,11 @@ def test_shipment_mutations_update_mark_lost_boxes_as_member_of_creating_org(
     marked_for_shipment_box,
 ):
     # Test case 3.2.41
-    assert_bad_user_input_when_updating_shipment(
-        read_only_client,
+    mutation = _generate_update_shipment_mutation(
         shipment=sent_shipment,
         lost_boxes=[marked_for_shipment_box],
     )
+    assert_forbidden_request(read_only_client, mutation)
 
 
 def test_shipment_mutations_update_checked_in_boxes_when_shipment_in_non_sent_state(

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -675,6 +675,15 @@ def test_shipment_mutations_update_mark_lost_boxes_as_member_of_creating_org(
     assert_forbidden_request(read_only_client, mutation)
 
 
+def test_shipment_mutations_update_without_arguments(
+    read_only_client, default_shipment
+):
+    # Test case 3.2.33
+    mutation = _generate_update_shipment_mutation(shipment=default_shipment)
+    shipment = assert_successful_request(read_only_client, mutation)
+    assert shipment == {"id": str(default_shipment["id"])}
+
+
 def test_shipment_mutations_update_checked_in_boxes_when_shipment_in_non_sent_state(
     read_only_client,
     mocker,

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -584,7 +584,7 @@ def test_shipment_mutations_send_as_member_of_non_creating_org(
 ):
     # Test case 3.2.14
     mutation = f"mutation {{ sendShipment(id: {another_shipment['id']}) {{ id }} }}"
-    assert_bad_user_input(read_only_client, mutation)
+    assert_forbidden_request(read_only_client, mutation)
 
 
 @pytest.mark.parametrize("act", ["cancel", "send"])
@@ -604,7 +604,7 @@ def test_shipment_mutations_cancel_as_member_of_neither_org(
         organisation_id=3, user_id=2
     )
     mutation = f"mutation {{ cancelShipment(id: {default_shipment['id']}) {{ id }} }}"
-    assert_bad_user_input(read_only_client, mutation)
+    assert_forbidden_request(read_only_client, mutation)
 
 
 def test_shipment_mutations_update_with_invalid_target_base(

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -496,8 +496,7 @@ def assert_bad_user_input_when_creating_shipment(client, **kwargs):
     assert_bad_user_input(client, mutation)
 
 
-def assert_bad_user_input_when_updating_shipment(
-    client,
+def _generate_update_shipment_mutation(
     *,
     shipment,
     target_base=None,
@@ -520,8 +519,12 @@ def assert_bad_user_input_when_updating_shipment(
             for detail in received_details
         )
         update_input += f", receivedShipmentDetailUpdateInputs: [{inputs}]"
-    mutation = f"""mutation {{ updateShipment(updateInput: {{ {update_input} }} ) {{
+    return f"""mutation {{ updateShipment(updateInput: {{ {update_input} }} ) {{
                     id }} }}"""
+
+
+def assert_bad_user_input_when_updating_shipment(client, **kwargs):
+    mutation = _generate_update_shipment_mutation(**kwargs)
     assert_bad_user_input(client, mutation)
 
 

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -553,13 +553,28 @@ def test_shipment_mutations_create_with_invalid_base(
 def test_shipment_mutations_create_as_target_org_member_in_unidirectional_agreement(
     read_only_client, default_bases, unidirectional_transfer_agreement
 ):
-    # Test case 3.2.4
+    # Test case 3.2.4a
     # The default user (see auth_service fixture) is member of organisation 1 which is
     # the target organisation in the unidirectional_transfer_agreement fixture
     mutation = _generate_create_shipment_mutation(
         source_base=default_bases[3],
         target_base=default_bases[2],
         agreement=unidirectional_transfer_agreement,
+    )
+    assert_forbidden_request(read_only_client, mutation)
+
+
+def test_shipment_mutations_create_as_member_of_neither_org(
+    read_only_client, mocker, default_transfer_agreement
+):
+    # Test case 3.2.4b
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        organisation_id=3, user_id=2
+    )
+    mutation = _generate_create_shipment_mutation(
+        source_base={"id": 0},
+        target_base={"id": 0},
+        agreement=default_transfer_agreement,
     )
     assert_forbidden_request(read_only_client, mutation)
 

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -479,14 +479,16 @@ def test_shipment_mutations_on_target_side(
     assert box == {"state": BoxState.Lost.name}
 
 
-def assert_bad_user_input_when_creating_shipment(
-    client, *, source_base, target_base, agreement
-):
+def _generate_create_shipment_mutation(*, source_base, target_base, agreement):
     creation_input = f"""sourceBaseId: {source_base["id"]},
                          targetBaseId: {target_base["id"]},
                          transferAgreementId: {agreement["id"]}"""
-    mutation = f"""mutation {{ createShipment(creationInput: {{ {creation_input} }} ) {{
+    return f"""mutation {{ createShipment(creationInput: {{ {creation_input} }} ) {{
                     id }} }}"""
+
+
+def assert_bad_user_input_when_creating_shipment(client, **kwargs):
+    mutation = _generate_create_shipment_mutation(**kwargs)
     assert_bad_user_input(client, mutation)
 
 

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -3,7 +3,11 @@ from datetime import date
 import pytest
 from auth import create_jwt_payload
 from boxtribute_server.enums import BoxState, ShipmentState
-from utils import assert_bad_user_input, assert_successful_request
+from utils import (
+    assert_bad_user_input,
+    assert_forbidden_request,
+    assert_successful_request,
+)
 
 
 def test_shipment_query(read_only_client, default_shipment, prepared_shipment_detail):
@@ -552,12 +556,12 @@ def test_shipment_mutations_create_as_target_org_member_in_unidirectional_agreem
     # Test case 3.2.4
     # The default user (see auth_service fixture) is member of organisation 1 which is
     # the target organisation in the unidirectional_transfer_agreement fixture
-    assert_bad_user_input_when_creating_shipment(
-        read_only_client,
+    mutation = _generate_create_shipment_mutation(
         source_base=default_bases[3],
         target_base=default_bases[2],
         agreement=unidirectional_transfer_agreement,
     )
+    assert_forbidden_request(read_only_client, mutation)
 
 
 def test_shipment_mutations_send_as_member_of_non_creating_org(

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -3,7 +3,11 @@ from datetime import date
 import pytest
 from auth import create_jwt_payload
 from boxtribute_server.enums import TransferAgreementState, TransferAgreementType
-from utils import assert_bad_user_input, assert_successful_request
+from utils import (
+    assert_bad_user_input,
+    assert_forbidden_request,
+    assert_successful_request,
+)
 
 
 def test_transfer_agreement_query(
@@ -204,8 +208,12 @@ def test_transfer_agreement_mutations(
 
 @pytest.mark.parametrize("action", ["accept", "reject", "cancel"])
 def test_transfer_agreement_mutations_invalid_state(
-    read_only_client, expired_transfer_agreement, action
+    read_only_client, mocker, expired_transfer_agreement, action
 ):
+    # The client has to be permitted to perform the action in general
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        organisation_id=expired_transfer_agreement["target_organisation"], user_id=2
+    )
     # Test cases 2.2.11, 2.2.12, 2.2.13
     agreement_id = expired_transfer_agreement["id"]
     mutation = f"mutation {{ {action}TransferAgreement(id: {agreement_id}) {{ id }} }}"
@@ -219,7 +227,7 @@ def test_transfer_agreement_mutations_as_member_of_source_org(
     # Test cases 2.2.9, 2.2.10
     agreement_id = reviewed_transfer_agreement["id"]
     mutation = f"mutation {{ {action}TransferAgreement(id: {agreement_id}) {{ id }} }}"
-    assert_bad_user_input(read_only_client, mutation)
+    assert_forbidden_request(read_only_client, mutation)
 
 
 def test_transfer_agreement_mutations_identical_source_org_for_creation(

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -230,6 +230,18 @@ def test_transfer_agreement_mutations_as_member_of_source_org(
     assert_forbidden_request(read_only_client, mutation)
 
 
+def test_transfer_agreement_mutations_cancel_as_member_of_neither_org(
+    read_only_client, mocker, default_transfer_agreement
+):
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        organisation_id=3, user_id=2
+    )
+    # Test case 2.2.20
+    agreement_id = default_transfer_agreement["id"]
+    mutation = f"mutation {{ cancelTransferAgreement(id: {agreement_id}) {{ id }} }}"
+    assert_forbidden_request(read_only_client, mutation)
+
+
 def test_transfer_agreement_mutations_identical_source_org_for_creation(
     read_only_client,
 ):

--- a/back/test/utils.py
+++ b/back/test/utils.py
@@ -1,12 +1,44 @@
-def assert_bad_user_input(client, mutation):
-    """Send mutation GraphQL request using given client.
-    Assert that single BAD_USER_INPUT error is returned in response.
-    """
-    data = {"query": mutation}
+def _assert_erroneous_request(client, query):
+    data = {"query": query}
     response = client.post("/graphql", json=data)
     assert response.status_code == 200
     assert len(response.json["errors"]) == 1
+    return response
+
+
+def assert_bad_user_input(client, query):
+    """Send GraphQL request with query using given client.
+    Assert that single BAD_USER_INPUT error is returned in response.
+    """
+    response = _assert_erroneous_request(client, query)
     assert response.json["errors"][0]["extensions"]["code"] == "BAD_USER_INPUT"
+
+
+def _extract_field(query):
+    """Extract field name, e.g. 'updateShipment' from a query like
+       mutation { updateShipment(id: 1) { state } }
+    Only works for queries that have arguments (and hence a '(' right after the
+    operation name).
+    """
+    return query.split("{")[1].split("(")[0].strip()
+
+
+def assert_forbidden_request(client, query, *, field=None, none_data=False, value=None):
+    """Assertion utility that posts the given data via a client fixture.
+    Afterwards verifies response field containing error information. If specified, the
+    response data field named `field` is verified against an expected `value` (default
+    None). By default, `field` is extracted as given query's operation name.
+    """
+    response = _assert_erroneous_request(client, query)
+    assert response.json["errors"][0]["extensions"]["code"] == "FORBIDDEN"
+    if none_data:
+        assert response.json["data"] is None
+    else:
+        field = field or _extract_field(query)
+        if value is None:
+            assert response.json["data"][field] is None
+        else:
+            assert response.json["data"][field] == value
 
 
 def assert_successful_request(client, query):
@@ -17,7 +49,5 @@ def assert_successful_request(client, query):
     response = client.post("/graphql", json=data)
     assert response.status_code == 200
 
-    # Extract field name, e.g. 'updateShipment' from a query like
-    #   mutation { updateShipment(id: 1) { state } }
-    field = query.split("{")[1].split("(")[0].strip()
+    field = _extract_field(query)
     return response.json["data"][field]


### PR DESCRIPTION
This PR brings these updates:
- Enforce basic DB-based permissions for transfer agreement and shipment (`shipment:read`/`:write`, same for `transfer_agreement`)
- previously, unauthorized actions for modifying agreements or shipments were consider bad user input (i.e. validation failed) whereas actually they are examples of forbidden actions. The respective implementations are moved to the resolvers level for clear distinction
- two more edge test cases to verify authorized user for creating shipment/canceling agreement

@vahidbazzaz Once the discussion about the corresponding action name, and which users to grant the action is finished, you can extend the Auth0 scripts such that users with the respective permissions in their JWT can actually access shipments/agreements.
