### PR TITLE
GraphQL improvements

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -251,6 +251,7 @@ and inspect the reported output. Open the HTML report via `back/htmlcov/index.ht
 
 The back-end exposes the GraphQL API at the `/graphql` endpoint. You can experiment with the API in the GraphQL playground.
 
+1. Set `export FLASK_ENV=development`
 1. Start the required services by `docker-compose up webapp db`
 1. Open `localhost:5005/graphql`.
 1. Simulate being a valid, logged-in user by fetching an authorization token (internally the variables of the `.env` file are used): `./fetch_token`
@@ -274,6 +275,8 @@ In production, the web app is run by the WSGI server `gunicorn` which serves as 
 Launch the production server by
 
     FLASK_ENV=production docker-compose up --build webapp
+
+In production mode, inspection of the GraphQL server is disabled, i.e. it's not possible to run the GraphQL playground.
 
 ## Performance evaluation
 

--- a/back/boxtribute_server/box_transfer/shipment.py
+++ b/back/boxtribute_server/box_transfer/shipment.py
@@ -360,6 +360,10 @@ def update_shipment(
 def _validate_base_as_part_of_shipment(resource_id, *, detail, model):
     """Validate that the base of the given resource (location or product) is identical
     to the target base of the detail's shipment.
+    Return false if resource does not exist.
     """
-    target_resource = model.get_by_id(resource_id)
-    return target_resource.base_id == detail.shipment.target_base_id
+    try:
+        target_resource = model.get_by_id(resource_id)
+        return target_resource.base_id == detail.shipment.target_base_id
+    except model.DoesNotExist:
+        return False

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -15,6 +15,12 @@ def format_database_errors(error, debug=False):
         # IntegrityError is raised when foreign key ID does not exist.
         error.message = ""  # setting `error.formatted["message"] = ""` has no effect
         error.extensions = RequestedResourceNotFound.extensions
+    elif isinstance(error.original_error, peewee.PeeweeException):
+        error.message = ""
+        error.extensions = {
+            "code": "INTERNAL_SERVER_ERROR",
+            "description": "The database failed to perform the requested action.",
+        }
     return error.formatted
 
 

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -11,9 +11,9 @@ def format_database_errors(error, debug=False):
     if debug:  # pragma: no cover
         return ariadne.format_error(error, debug)
 
-    if isinstance(error.original_error, peewee.DoesNotExist):
-        # setting `error.formatted["message"] = ""` has no effect
-        error.message = ""
+    if isinstance(error.original_error, (peewee.DoesNotExist, peewee.IntegrityError)):
+        # IntegrityError is raised when foreign key ID does not exist.
+        error.message = ""  # setting `error.formatted["message"] = ""` has no effect
         error.extensions = RequestedResourceNotFound.extensions
     return error.formatted
 

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -1,3 +1,23 @@
+import ariadne
+import peewee
+
+
+def format_database_errors(error, debug=False):
+    """Custom formatting of peewee errors (indicating a missing resource) to avoid SQL
+    queries from being exposed to the client.
+    In the resulting response, the corresponding field for `data` will be None, and the
+    `errors` list will have a single entry.
+    """
+    if debug:  # pragma: no cover
+        return ariadne.format_error(error, debug)
+
+    if isinstance(error.original_error, peewee.DoesNotExist):
+        # setting `error.formatted["message"] = ""` has no effect
+        error.message = ""
+        error.extensions = RequestedResourceNotFound.extensions
+    return error.formatted
+
+
 class AuthenticationFailed(Exception):
     """Custom exception for authentication errors on web API level (i.e. when
     hitting a Flask server endpoint).

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -402,10 +402,10 @@ def resolve_update_shipment(_, info, update_input):
         "lost_box_label_identifiers",
     ]
     organisation_id = None
-    if any([update_input.get(f) for f in source_update_fields]):
+    if any([update_input.get(f) is not None for f in source_update_fields]):
         # User must be member of organisation that created the shipment
         organisation_id = shipment.source_base.organisation_id
-    elif any([update_input.get(f) for f in target_update_fields]):
+    elif any([update_input.get(f) is not None for f in target_update_fields]):
         # User must be member of organisation that is supposed to receive the shipment
         organisation_id = shipment.target_base.organisation_id
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -322,20 +322,15 @@ def resolve_update_box(_, info, box_update_input):
 @convert_kwargs_to_snake_case
 def resolve_create_beneficiary(_, info, creation_input):
     authorize(permission="beneficiary:create", base_id=creation_input["base_id"])
-    creation_input["created_by"] = g.user["id"]
-    return create_beneficiary(creation_input)
+    return create_beneficiary(**creation_input, user=g.user)
 
 
 @mutation.field("updateBeneficiary")
 @convert_kwargs_to_snake_case
 def resolve_update_beneficiary(_, info, update_input):
     # Use target base ID if specified, otherwise skip enforcing base-specific authz
-    authorize(
-        permission="beneficiary:edit",
-        base_id=update_input.get("base_id"),
-    )
-    update_input["last_modified_by"] = g.user["id"]
-    return update_beneficiary(update_input)
+    authorize(permission="beneficiary:edit", base_id=update_input.get("base_id"))
+    return update_beneficiary(**update_input, user=g.user)
 
 
 @mutation.field("createTransferAgreement")

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -106,10 +106,12 @@ def create_beneficiary(
         bicycle_ban_comment="",
         workshop_ban_comment="",
     )
-    for language_id in languages or []:
-        XBeneficiaryLanguage.create(
-            language=language_id, beneficiary=new_beneficiary.id
-        )
+
+    language_ids = languages or []
+    XBeneficiaryLanguage.insert_many(
+        [{"language": lid, "beneficiary": new_beneficiary.id} for lid in language_ids]
+    ).execute()
+
     return new_beneficiary
 
 
@@ -150,8 +152,9 @@ def update_beneficiary(
         XBeneficiaryLanguage.delete().where(
             XBeneficiaryLanguage.beneficiary == id
         ).execute()
-        for language_id in language_ids:
-            XBeneficiaryLanguage.create(language=language_id, beneficiary=id)
+        XBeneficiaryLanguage.insert_many(
+            [{"language": lid, "beneficiary": id} for lid in language_ids]
+        ).execute()
 
     # Set first_name, last_name, group_identifier, date_of_birth, comment, is_volunteer,
     # date_of_signature if specified via GraphQL input

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -120,6 +120,7 @@ def update_beneficiary(
     user,
     id,
     base_id=None,
+    gender=None,
     languages=None,
     family_head_id=None,
     is_registered=None,
@@ -135,6 +136,9 @@ def update_beneficiary(
     # Handle any items with keys not matching the Model fields
     if base_id is not None:
         beneficiary.base = base_id
+
+    if gender is not None:
+        beneficiary.gender = gender.value
 
     if family_head_id is not None:
         beneficiary.family_head = family_head_id

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -71,6 +71,7 @@ def graphql_server():
         data,
         context_value=request,
         debug=debug_graphql,
+        introspection=os.getenv("FLASK_ENV") == "development",
         error_formatter=format_database_errors,
     )
 

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -7,7 +7,7 @@ from flask import Blueprint, jsonify, request
 from flask_cors import cross_origin
 
 from .auth import requires_auth
-from .exceptions import AuthenticationFailed
+from .exceptions import AuthenticationFailed, format_database_errors
 from .graph_ql.schema import schema
 
 # Blueprint for API
@@ -67,7 +67,11 @@ def graphql_server():
 
     debug_graphql = bool(os.getenv("DEBUG_GRAPHQL", False))
     success, result = graphql_sync(
-        schema, data, context_value=request, debug=debug_graphql
+        schema,
+        data,
+        context_value=request,
+        debug=debug_graphql,
+        error_formatter=format_database_errors,
     )
 
     status_code = 200 if success else 400

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -66,4 +66,4 @@ def test_invalid_pagination_input(read_only_client):
     query = """query { beneficiaries(paginationInput: {last: 2}) {
         elements { id }
     } }"""
-    assert_bad_user_input(read_only_client, query)
+    assert_bad_user_input(read_only_client, query, none_data=True)

--- a/back/test/endpoint_tests/test_qr.py
+++ b/back/test/endpoint_tests/test_qr.py
@@ -38,26 +38,14 @@ def test_qr_code_query(read_only_client, default_box, default_qr_code):
 def test_code_not_associated_with_box(read_only_client, qr_code_without_box):
     code = qr_code_without_box["code"]
     query = f"""query {{ qrCode(qrCode: "{code}") {{ box {{ id }} }} }}"""
-    data = {"query": query}
-    response = read_only_client.post("/graphql", json=data)
-    assert (
-        "<Model: Box> instance matching query does not exist"
-        in response.json["errors"][0]["message"]
-    )
-    queried_box = response.json["data"]["qrCode"]["box"]
-    assert queried_box is None
+    response = assert_bad_user_input(read_only_client, query, value={"box": None})
+    assert "SQL" not in response.json["errors"][0]["message"]
 
 
 def test_code_does_not_exist(read_only_client):
     query = """query { qrCode(qrCode: "-1") { id } }"""
-    data = {"query": query}
-    response = read_only_client.post("/graphql", json=data)
-    queried_code = response.json["data"]["qrCode"]
-    assert (
-        "<Model: QrCode> instance matching query does not exist"
-        in response.json["errors"][0]["message"]
-    )
-    assert queried_code is None
+    response = assert_bad_user_input(read_only_client, query)
+    assert "SQL" not in response.json["errors"][0]["message"]
 
 
 def test_qr_code_mutation(client, box_without_qr_code):

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -421,28 +421,30 @@ def test_shipment_mutations_on_target_side(
     assert shipment == expected_shipment
 
     # Verify that another_detail_id is not updated (invalid product)
-    # Test case 3.2.39
-    shipment = assert_successful_request(
-        client,
-        _create_mutation(
-            detail_id=another_detail_id,
-            target_product_id=default_product["id"],
-            target_location_id=target_location_id,
-        ),
-    )
-    assert shipment == expected_shipment
+    # Test cases 3.2.39ab
+    for product in [default_product, {"id": 0}]:
+        shipment = assert_successful_request(
+            client,
+            _create_mutation(
+                detail_id=another_detail_id,
+                target_product_id=product["id"],
+                target_location_id=target_location_id,
+            ),
+        )
+        assert shipment == expected_shipment
 
     # Verify that another_detail_id is not updated (invalid location)
-    # Test case 3.2.38
-    shipment = assert_successful_request(
-        client,
-        _create_mutation(
-            detail_id=another_detail_id,
-            target_product_id=target_product_id,
-            target_location_id=default_location["id"],
-        ),
-    )
-    assert shipment == expected_shipment
+    # Test cases 3.2.38ab
+    for location in [default_location, {"id": 0}]:
+        shipment = assert_successful_request(
+            client,
+            _create_mutation(
+                detail_id=another_detail_id,
+                target_product_id=target_product_id,
+                target_location_id=location["id"],
+            ),
+        )
+        assert shipment == expected_shipment
 
     # Test case 3.2.40, 3.2.34b
     box_label_identifier = marked_for_shipment_box["label_identifier"]

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -706,3 +706,15 @@ def test_shipment_mutations_update_checked_in_boxes_when_shipment_in_non_sent_st
         target_location=another_location,
         target_product=another_product,
     )
+
+
+def test_shipment_mutations_create_non_existent_resource(
+    read_only_client, default_bases
+):
+    # Test case 3.2.5
+    mutation = _generate_create_shipment_mutation(
+        source_base=default_bases[1],
+        target_base=default_bases[3],
+        agreement={"id": 0},
+    )
+    assert_bad_user_input(read_only_client, mutation)

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -206,9 +206,11 @@ def test_shipment_mutations_on_source_side(
 
     # Verify that another_box is not added to shipment (not located in source base).
     # Same for lost_box (box state different from InStock) and default_box (already
-    # added to shipment, hence box state MarkedForShipment different from InStock)
-    # Test cases 3.2.27, 3.2.28
-    for box in [another_box, lost_box, default_box]:
+    # added to shipment, hence box state MarkedForShipment different from InStock).
+    # A box with unknown label identifier is not added either
+    # Test cases 3.2.27, 3.2.28, 3.2.29
+    non_existent_box = {"label_identifier": "xxx"}
+    for box in [another_box, lost_box, default_box, non_existent_box]:
         box_label_identifier = box["label_identifier"]
         update_input = f"""{{ id: {shipment_id},
                     preparedBoxLabelIdentifiers: ["{box_label_identifier}"] }}"""
@@ -247,10 +249,10 @@ def test_shipment_mutations_on_source_side(
 
     # Verify that lost_box is not removed from shipment (box state different from
     # MarkedForShipment).
-    # Same for marked_for_shipment_box (not part of shipment)
+    # Same for marked_for_shipment_box (not part of shipment), and non-existent box
     # Test cases 3.2.31, 3.2.32
     boxes = [lost_box, marked_for_shipment_box]
-    for box in boxes:
+    for box in boxes + [non_existent_box]:
         box_label_identifier = box["label_identifier"]
         update_input = f"""{{ id: {shipment_id},
                     removedBoxLabelIdentifiers: ["{box_label_identifier}"] }}"""
@@ -420,7 +422,6 @@ def test_shipment_mutations_on_target_side(
 
     # Verify that another_detail_id is not updated (invalid product)
     # Test case 3.2.39
-
     shipment = assert_successful_request(
         client,
         _create_mutation(

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -264,3 +264,13 @@ def test_transfer_agreement_mutations_create_invalid_source_base(
                     type: Bidirectional
                 }} ) {{ id }} }}"""
     assert_bad_user_input(read_only_client, mutation)
+
+
+def test_transfer_agreement_mutations_create_non_existent_target_org(read_only_client):
+    # Test case 2.2.15
+    creation_input = "targetOrganisationId: 0"
+    mutation = f"""mutation {{ createTransferAgreement( creationInput: {{
+                    {creation_input},
+                    type: Bidirectional
+                }} ) {{ id }} }}"""
+    assert_bad_user_input(read_only_client, mutation)

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -5,7 +5,6 @@ from boxtribute_server.models.crud import (
     BOX_LABEL_IDENTIFIER_GENERATION_ATTEMPTS,
     create_box,
     create_qr_code,
-    update_beneficiary,
 )
 from boxtribute_server.models.definitions.qr_code import QrCode
 
@@ -54,16 +53,3 @@ def test_box_label_identifier_generation(
     new_box = create_box(data)
     assert rng_function.call_count == len(side_effect)
     assert new_box.label_identifier == new_identifier
-
-
-def test_update_beneficiary(default_beneficiary, default_bases, default_user):
-    """Complement anything not yet covered by endpoint tests."""
-    base_id = default_bases[2]["id"]
-    data = {
-        "id": default_beneficiary["id"],
-        "base_id": base_id,
-        "family_head_id": default_beneficiary["id"],
-    }
-    beneficiary = update_beneficiary(**data, user=default_user)
-    assert beneficiary.id == beneficiary.family_head_id
-    assert beneficiary.base_id == base_id

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -56,7 +56,7 @@ def test_box_label_identifier_generation(
     assert new_box.label_identifier == new_identifier
 
 
-def test_update_beneficiary(default_beneficiary, default_bases):
+def test_update_beneficiary(default_beneficiary, default_bases, default_user):
     """Complement anything not yet covered by endpoint tests."""
     base_id = default_bases[2]["id"]
     data = {
@@ -64,6 +64,6 @@ def test_update_beneficiary(default_beneficiary, default_bases):
         "base_id": base_id,
         "family_head_id": default_beneficiary["id"],
     }
-    beneficiary = update_beneficiary(data)
+    beneficiary = update_beneficiary(**data, user=default_user)
     assert beneficiary.id == beneficiary.family_head_id
     assert beneficiary.base_id == base_id

--- a/back/test/utils.py
+++ b/back/test/utils.py
@@ -50,6 +50,15 @@ def assert_forbidden_request(client, query, **kwargs):
     return _assert_erroneous_request(client, query, code="FORBIDDEN", **kwargs)
 
 
+def assert_internal_server_error(client, query, **kwargs):
+    """Send GraphQL request with query using given client.
+    Assert that single INTERNAL_SERVER_ERROR error is returned in response.
+    """
+    return _assert_erroneous_request(
+        client, query, code="INTERNAL_SERVER_ERROR", **kwargs
+    )
+
+
 def assert_successful_request(client, query, field=None):
     """Send GraphQL request with query using given client.
     Assert response HTTP code 200, and return main response JSON data field.

--- a/back/test/utils.py
+++ b/back/test/utils.py
@@ -29,6 +29,7 @@ def assert_bad_user_input(client, query, **kwargs):
     response = _assert_erroneous_request(client, query)
     assert response.json["errors"][0]["extensions"]["code"] == "BAD_USER_INPUT"
     _verify_response_data(query=query, response=response, **kwargs)
+    return response
 
 
 def _extract_field(query):

--- a/example.envrc
+++ b/example.envrc
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 layout virtualenv .venv
+export FLASK_ENV=development


### PR DESCRIPTION
This PR brings
- some improvements for database error handling and how they are reported to the client (hide away potential raw SQL queries)
- covering two more test cases with `updateShipment` mutation
- fix for updating beneficiary gender
- improved function signatures for `crud.create/update_beneficiary`
- disabling GraphQL introspection in non-development mode

Let me know if you have any questions :)
