### PR TITLE
GraphQL filters and fixes

### DIFF
--- a/back/boxtribute_server/graph_ql/filtering.py
+++ b/back/boxtribute_server/graph_ql/filtering.py
@@ -33,10 +33,10 @@ def derive_beneficiary_filter(filter_input):
             Beneficiary.is_volunteer if is_volunteer else ~Beneficiary.is_volunteer
         )
 
-    is_registered = filter_input.get("is_registered")
-    if is_registered is not None:
+    registered = filter_input.get("registered")
+    if registered is not None:
         condition &= (
-            ~Beneficiary.not_registered if is_registered else Beneficiary.not_registered
+            ~Beneficiary.not_registered if registered else Beneficiary.not_registered
         )
 
     pattern = filter_input.get("pattern")

--- a/back/boxtribute_server/graph_ql/filtering.py
+++ b/back/boxtribute_server/graph_ql/filtering.py
@@ -1,4 +1,5 @@
 from ..models.definitions.beneficiary import Beneficiary
+from ..models.definitions.box import Box
 
 
 def derive_beneficiary_filter(filter_input):
@@ -46,4 +47,35 @@ def derive_beneficiary_filter(filter_input):
             | (Beneficiary.comment.contains(pattern))
             | (Beneficiary.group_identifier == pattern)
         )
+    return condition
+
+
+def derive_box_filter(filter_input):
+    """Derive filter condition for select-query from given filter parameters. If no
+    parameters given, return True (i.e. no filtering applied).
+    """
+    if not filter_input:
+        return True
+
+    condition = True
+    states = filter_input.get("states")
+    if states:
+        condition &= Box.state << states
+
+    last_modified_from = filter_input.get("last_modified_from")
+    if last_modified_from is not None:
+        condition &= Box.last_modified_on >= last_modified_from
+
+    last_modified_until = filter_input.get("last_modified_until")
+    if last_modified_until is not None:
+        condition &= Box.last_modified_on <= last_modified_until
+
+    product_gender = filter_input.get("product_gender")
+    if product_gender is not None:
+        condition &= Box.product.gender == product_gender
+
+    product_category_id = filter_input.get("product_category_id")
+    if product_category_id is not None:
+        condition &= Box.product.category == product_category_id
+
     return condition

--- a/back/boxtribute_server/graph_ql/filtering.py
+++ b/back/boxtribute_server/graph_ql/filtering.py
@@ -1,0 +1,49 @@
+from ..models.definitions.beneficiary import Beneficiary
+
+
+def derive_beneficiary_filter(filter_input):
+    """Derive filter condition for select-query from given filter parameters. If no
+    parameters given, return True (i.e. no filtering applied).
+    """
+    if not filter_input:
+        return True
+
+    condition = True
+    created_from = filter_input.get("created_from")
+    if created_from is not None:
+        condition &= Beneficiary.created_on >= created_from
+
+    created_until = filter_input.get("created_until")
+    if created_until is not None:
+        condition &= Beneficiary.created_on <= created_until
+
+    active = filter_input.get("active")
+    if active is not None:
+        # By default, the 'deleted' DateTimeField is '0000-00-00 00:00:00' which
+        # evaluates to both NULL and NOT NULL. Hence in order to find actual dates
+        # (indicating inactive beneficiaries) use >0 instead of IS NOT NULL
+        condition &= (
+            Beneficiary.deleted.is_null() if active else Beneficiary.deleted > 0
+        )
+
+    is_volunteer = filter_input.get("is_volunteer")
+    if is_volunteer is not None:
+        condition &= (
+            Beneficiary.is_volunteer if is_volunteer else ~Beneficiary.is_volunteer
+        )
+
+    is_registered = filter_input.get("is_registered")
+    if is_registered is not None:
+        condition &= (
+            ~Beneficiary.not_registered if is_registered else Beneficiary.not_registered
+        )
+
+    pattern = filter_input.get("pattern")
+    if pattern is not None:
+        condition &= (
+            (Beneficiary.last_name.contains(pattern))
+            | (Beneficiary.first_name.contains(pattern))
+            | (Beneficiary.comment.contains(pattern))
+            | (Beneficiary.group_identifier == pattern)
+        )
+    return condition

--- a/back/boxtribute_server/graph_ql/operations.graphql
+++ b/back/boxtribute_server/graph_ql/operations.graphql
@@ -15,7 +15,7 @@ type Query {
   productCategory(id: ID!): ProductCategory
   productCategories: [ProductCategory!]!
   beneficiary(id: ID!): Beneficiary
-  beneficiaries(paginationInput: PaginationInput): BeneficiaryPage!
+  beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage!
   transferAgreement(id: ID!): TransferAgreement
   """
   Without any arguments, return transfer agreements that involve client's organisation,

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -295,8 +295,10 @@ def resolve_beneficiary_gender(beneficiary_obj, info):
 
 @beneficiary.field("age")
 def resolve_beneficiary_age(beneficiary_obj, info):
-    today = date.today()
     dob = beneficiary_obj.date_of_birth
+    if dob is None:
+        return
+    today = date.today()
     # Subtract 1 if current day is before birthday in current year
     return today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -303,7 +303,7 @@ def resolve_beneficiary_age(beneficiary_obj, info):
 
 @beneficiary.field("active")
 def resolve_beneficiary_active(beneficiary_obj, info):
-    return beneficiary_obj.deleted == "0000-00-00 00:00:00"
+    return beneficiary_obj.deleted is None  # ZeroDateTimeField
 
 
 @box.field("state")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -20,7 +20,7 @@ from ..box_transfer.shipment import (
     send_shipment,
     update_shipment,
 )
-from ..enums import HumanGender, TransferAgreementState, TransferAgreementType
+from ..enums import HumanGender, TransferAgreementType
 from ..models.crud import (
     create_beneficiary,
     create_box,
@@ -228,13 +228,14 @@ def resolve_beneficiaries(_, info, pagination_input=None):
 def resolve_transfer_agreements(_, info, states=None):
     authorize(permission="transfer_agreement:read")
     user_organisation_id = g.user["organisation_id"]
-    states = states or list(TransferAgreementState)
+    # No state filter by default
+    state_filter = TransferAgreement.state << states if states else True
     return TransferAgreement.select().where(
         (
             (TransferAgreement.source_organisation == user_organisation_id)
             | (TransferAgreement.target_organisation == user_organisation_id)
         )
-        & (TransferAgreement.state << states)
+        & (state_filter)
     )
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -1,4 +1,6 @@
 """GraphQL resolver functionality"""
+from datetime import date
+
 from ariadne import MutationType, ObjectType, QueryType, convert_kwargs_to_snake_case
 from peewee import fn
 
@@ -280,6 +282,14 @@ def resolve_beneficiary_languages(beneficiary_obj, info):
 @beneficiary.field("gender")
 def resolve_beneficiary_gender(beneficiary_obj, info):
     return HumanGender(beneficiary_obj.gender)
+
+
+@beneficiary.field("age")
+def resolve_beneficiary_age(beneficiary_obj, info):
+    today = date.today()
+    dob = beneficiary_obj.date_of_birth
+    # Subtract 1 if current day is before birthday in current year
+    return today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
 
 
 @box.field("state")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -267,6 +267,12 @@ def resolve_beneficiary_tokens(beneficiary_obj, info):
     )
 
 
+@beneficiary.field("transactions")
+def resolve_beneficiary_transactions(beneficiary_obj, info):
+    authorize(permission="transaction:read")
+    return Transaction.select().where(Transaction.beneficiary == beneficiary_obj.id)
+
+
 @beneficiary.field("isRegistered")
 def resolve_beneficiary_is_registered(beneficiary_obj, info):
     return not beneficiary_obj.not_registered

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -257,7 +257,7 @@ def resolve_beneficiary_tokens(beneficiary_obj, info):
     authorize(permission="transaction:read")
     # If the beneficiary has no transactions yet, the select query returns None
     return (
-        Transaction.select(fn.sum(Transaction.count))
+        Transaction.select(fn.sum(Transaction.tokens))
         .where(Transaction.beneficiary == beneficiary_obj.id)
         .scalar()
         or 0

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -273,8 +273,8 @@ def resolve_beneficiary_transactions(beneficiary_obj, info):
     return Transaction.select().where(Transaction.beneficiary == beneficiary_obj.id)
 
 
-@beneficiary.field("isRegistered")
-def resolve_beneficiary_is_registered(beneficiary_obj, info):
+@beneficiary.field("registered")
+def resolve_beneficiary_registered(beneficiary_obj, info):
     return not beneficiary_obj.not_registered
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -293,6 +293,11 @@ def resolve_beneficiary_age(beneficiary_obj, info):
     return today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
 
 
+@beneficiary.field("active")
+def resolve_beneficiary_active(beneficiary_obj, info):
+    return beneficiary_obj.deleted == "0000-00-00 00:00:00"
+
+
 @box.field("state")
 def resolve_box_state(box_obj, info):
     # Instead of a BoxState instance return an integer for EnumType conversion

--- a/back/boxtribute_server/graph_ql/scalars.py
+++ b/back/boxtribute_server/graph_ql/scalars.py
@@ -14,10 +14,6 @@ def serialize_datetime(value):
 
 @date_scalar.serializer
 def serialize_date(value):
-    if value == "0000-00-00 00:00:00":
-        # A NULL value in a DateTimeField is represented by the zero-date string which
-        # cannot be converted to a reasonable Python datetime
-        return
     return value.isoformat()
 
 

--- a/back/boxtribute_server/graph_ql/scalars.py
+++ b/back/boxtribute_server/graph_ql/scalars.py
@@ -14,6 +14,10 @@ def serialize_datetime(value):
 
 @date_scalar.serializer
 def serialize_date(value):
+    if value == "0000-00-00 00:00:00":
+        # A NULL value in a DateTimeField is represented by the zero-date string which
+        # cannot be converted to a reasonable Python datetime
+        return
     return value.isoformat()
 
 

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -149,6 +149,7 @@ type Beneficiary {
   gender: HumanGender!
   languages: [Language!]
   familyHead: Beneficiary
+  active: Boolean!
   isVolunteer: Boolean!
   isSigned: Boolean!
   isRegistered: Boolean!

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -156,10 +156,22 @@ type Beneficiary {
   signature: String
   dateOfSignature: Date
   tokens: Int
+  transactions: [Transaction!]
   createdBy: User!
   createdOn: Datetime!
   lastModifiedBy: User!
   lastModifiedOn: Datetime!
+}
+
+type Transaction {
+  id: ID!
+  beneficiary: Beneficiary!
+  product: Product
+  count: Int
+  tokens: Int
+  description: String
+  createdOn: Datetime!
+  createdBy: User!
 }
 
 type PageInfo {

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -109,7 +109,7 @@ type Base {
   name: String!
   organisation: Organisation!
   locations: [Location!]
-  beneficiaries(paginationInput: PaginationInput): BeneficiaryPage!
+  beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage!
   currencyName: String
 }
 
@@ -218,6 +218,19 @@ input UpdateBeneficiaryInput {
   isRegistered: Boolean
   signature: String
   dateOfSignature: Date
+}
+
+input FilterBeneficiaryInput {
+  createdFrom: Date
+  createdUntil: Date
+  active: Boolean
+  isVolunteer: Boolean
+  isRegistered: Boolean
+  """
+  Return beneficiaries where pattern is (case-insensitive) part of first name,
+  last name, or comment, or where pattern matches the group identifier
+  """
+  pattern: String
 }
 
 input PaginationInput {

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -141,8 +141,11 @@ type Beneficiary {
   id: ID!
   firstName: String!
   lastName: String!
-  dateOfBirth: Date!
-  age: Int!
+  dateOfBirth: Date
+  """
+  If dateOfBirth is not set, age will be null.
+  """
+  age: Int
   comment: String
   base: Base!
   groupIdentifier: String!

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -142,6 +142,7 @@ type Beneficiary {
   firstName: String!
   lastName: String!
   dateOfBirth: Date!
+  age: Int!
   comment: String
   base: Base!
   groupIdentifier: String!

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -89,7 +89,7 @@ type Location {
   name: String
   isShop: Boolean!
   # List of all the boxes in the location
-  boxes(paginationInput: PaginationInput): BoxPage
+  boxes(paginationInput: PaginationInput, filterInput: FilterBoxInput): BoxPage
   boxState: BoxState
   createdOn: Datetime
   # The user who generated QR code
@@ -231,6 +231,14 @@ input FilterBeneficiaryInput {
   last name, or comment, or where pattern matches the group identifier
   """
   pattern: String
+}
+
+input FilterBoxInput {
+  states: [BoxState!]
+  lastModifiedFrom: Date
+  lastModifiedUntil: Date
+  productGender: ProductGender
+  productCategoryId: Int
 }
 
 input PaginationInput {

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -151,8 +151,8 @@ type Beneficiary {
   familyHead: Beneficiary
   active: Boolean!
   isVolunteer: Boolean!
-  isSigned: Boolean!
-  isRegistered: Boolean!
+  signed: Boolean!
+  registered: Boolean!
   signature: String
   dateOfSignature: Date
   tokens: Int
@@ -210,7 +210,7 @@ input CreateBeneficiaryInput {
   languages: [Language!]
   familyHeadId: Int
   isVolunteer: Boolean!
-  isRegistered: Boolean!
+  registered: Boolean!
   signature: String
   dateOfSignature: Date
 }
@@ -227,7 +227,7 @@ input UpdateBeneficiaryInput {
   languages: [Language!]
   familyHeadId: Int
   isVolunteer: Boolean
-  isRegistered: Boolean
+  registered: Boolean
   signature: String
   dateOfSignature: Date
 }
@@ -237,7 +237,7 @@ input FilterBeneficiaryInput {
   createdUntil: Date
   active: Boolean
   isVolunteer: Boolean
-  isRegistered: Boolean
+  registered: Boolean
   """
   Return beneficiaries where pattern is (case-insensitive) part of first name,
   last name, or comment, or where pattern matches the group identifier

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -71,7 +71,7 @@ def create_beneficiary(
     date_of_birth,
     gender,
     is_volunteer,
-    is_registered,
+    registered,
     comment="",
     languages=None,
     family_head_id=None,
@@ -90,8 +90,8 @@ def create_beneficiary(
         date_of_birth=date_of_birth,
         gender=gender.value,  # convert to gender abbreviation
         is_volunteer=is_volunteer,
-        not_registered=not is_registered,
-        is_signed=signature is not None,  # set depending on signature
+        not_registered=not registered,
+        signed=signature is not None,  # set depending on signature
         comment=comment,
         family_head=family_head_id,
         created_on=now,
@@ -123,7 +123,7 @@ def update_beneficiary(
     gender=None,
     languages=None,
     family_head_id=None,
-    is_registered=None,
+    registered=None,
     signature=None,
     **data,
 ):
@@ -144,11 +144,11 @@ def update_beneficiary(
         beneficiary.family_head = family_head_id
     beneficiary.seq = 1 if family_head_id is None else 2
 
-    if is_registered is not None:
-        beneficiary.not_registered = not is_registered
+    if registered is not None:
+        beneficiary.not_registered = not registered
 
     if signature is not None:
-        beneficiary.is_signed = True
+        beneficiary.signed = True
         beneficiary.signature = signature
 
     # Set first_name, last_name, group_identifier, date_of_birth, comment, is_volunteer,

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -101,7 +101,6 @@ def create_beneficiary(
         # This is only required for compatibility with legacy DB
         seq=1 if family_head_id is None else 2,
         # These fields are required acc. to model definition
-        deleted="0000-00-00 00:00:00",
         family_id=0,
         bicycle_ban_comment="",
         workshop_ban_comment="",

--- a/back/boxtribute_server/models/definitions/beneficiary.py
+++ b/back/boxtribute_server/models/definitions/beneficiary.py
@@ -7,9 +7,7 @@ from .user import User
 
 
 class Beneficiary(db.Model):
-    is_signed = IntegerField(
-        column_name="approvalsigned", constraints=[SQL("DEFAULT 0")]
-    )
+    signed = IntegerField(column_name="approvalsigned", constraints=[SQL("DEFAULT 0")])
     bicycle_ban = DateField(column_name="bicycleban", null=True)
     bicycle_ban_comment = TextField(
         column_name="bicyclebancomment",

--- a/back/boxtribute_server/models/definitions/beneficiary.py
+++ b/back/boxtribute_server/models/definitions/beneficiary.py
@@ -35,7 +35,7 @@ class Beneficiary(db.Model):
         on_delete="SET NULL",
         on_update="CASCADE",
     )
-    date_of_birth = DateField(null=True)
+    date_of_birth = DateField(null=True, constraints=[SQL("DEFAULT NULL")])
     date_of_signature = ZeroDateTimeField()
     deleted = ZeroDateTimeField()
     email = CharField(constraints=[SQL("DEFAULT ''")])

--- a/back/boxtribute_server/models/definitions/beneficiary.py
+++ b/back/boxtribute_server/models/definitions/beneficiary.py
@@ -65,7 +65,7 @@ class Beneficiary(db.Model):
         on_update="CASCADE",
     )
     not_registered = IntegerField(
-        column_name="notregistered", constraints=[SQL("DEFAULT 0")]
+        column_name="notregistered", constraints=[SQL("DEFAULT 0")], default=False
     )
     family_head = UIntForeignKeyField(
         column_name="parent_id",
@@ -83,8 +83,10 @@ class Beneficiary(db.Model):
     signature = TextField(column_name="signaturefield", null=True)
     tent = CharField(constraints=[SQL("DEFAULT ''")])
     url = IntegerField(null=True)
-    visible = IntegerField(constraints=[SQL("DEFAULT 1")])
-    is_volunteer = IntegerField(column_name="volunteer", constraints=[SQL("DEFAULT 0")])
+    visible = IntegerField(constraints=[SQL("DEFAULT 1")], default=True)
+    is_volunteer = IntegerField(
+        column_name="volunteer", constraints=[SQL("DEFAULT 0")], default=False
+    )
     workshop_ban = DateField(column_name="workshopban", null=True)
     workshop_ban_comment = TextField(
         column_name="workshopbancomment",

--- a/back/boxtribute_server/models/definitions/beneficiary.py
+++ b/back/boxtribute_server/models/definitions/beneficiary.py
@@ -1,7 +1,7 @@
 from peewee import SQL, CharField, DateField, DateTimeField, IntegerField, TextField
 
 from ...db import db
-from ..fields import UIntForeignKeyField
+from ..fields import UIntForeignKeyField, ZeroDateTimeField
 from .base import Base
 from .user import User
 
@@ -36,10 +36,8 @@ class Beneficiary(db.Model):
         on_update="CASCADE",
     )
     date_of_birth = DateField(null=True)
-    date_of_signature = DateTimeField(
-        constraints=[SQL("DEFAULT '0000-00-00 00:00:00'")]
-    )
-    deleted = DateTimeField()
+    date_of_signature = ZeroDateTimeField()
+    deleted = ZeroDateTimeField()
     email = CharField(constraints=[SQL("DEFAULT ''")])
     extra_portion = IntegerField(
         column_name="extraportion", constraints=[SQL("DEFAULT 0")]

--- a/back/boxtribute_server/models/definitions/transaction.py
+++ b/back/boxtribute_server/models/definitions/transaction.py
@@ -4,7 +4,6 @@ from ...db import db
 from ..fields import UIntForeignKeyField
 from .beneficiary import Beneficiary
 from .product import Product
-from .size import Size
 from .user import User
 
 
@@ -44,9 +43,6 @@ class Transaction(db.Model):
         model=Product,
         null=True,
         on_update="CASCADE",
-    )
-    size = UIntForeignKeyField(
-        column_name="size_id", field="id", model=Size, null=True, on_update="CASCADE"
     )
     transaction_date = DateTimeField(index=True)
     user = UIntForeignKeyField(

--- a/back/boxtribute_server/models/definitions/transaction.py
+++ b/back/boxtribute_server/models/definitions/transaction.py
@@ -17,26 +17,8 @@ class Transaction(db.Model):
         on_update="CASCADE",
     )
     count = IntegerField()
-    created = DateTimeField(null=True)
-    created_by = UIntForeignKeyField(
-        model=User,
-        column_name="created_by",
-        field="id",
-        null=True,
-        on_delete="SET NULL",
-        on_update="CASCADE",
-    )
     description = CharField()
     tokens = IntegerField(column_name="drops", constraints=[SQL("DEFAULT 0")])
-    modified = DateTimeField(null=True)
-    modified_by = UIntForeignKeyField(
-        model=User,
-        column_name="modified_by",
-        field="id",
-        null=True,
-        on_delete="SET NULL",
-        on_update="CASCADE",
-    )
     product = UIntForeignKeyField(
         column_name="product_id",
         field="id",
@@ -44,8 +26,11 @@ class Transaction(db.Model):
         null=True,
         on_update="CASCADE",
     )
-    transaction_date = DateTimeField(index=True)
-    user = UIntForeignKeyField(
+    created_on = DateTimeField(column_name="transaction_date", index=True)
+    # Albeit the underlying MySQL table has a 'created_by' column defined it is never
+    # used in dropapp. For consistency with other FK fields to the User model the
+    # 'user_id' column is aliased as 'created_by' and exposed
+    created_by = UIntForeignKeyField(
         model=User,
         column_name="user_id",
         field="id",

--- a/back/boxtribute_server/models/definitions/transaction.py
+++ b/back/boxtribute_server/models/definitions/transaction.py
@@ -27,7 +27,7 @@ class Transaction(db.Model):
         on_update="CASCADE",
     )
     description = CharField()
-    drops = IntegerField(constraints=[SQL("DEFAULT 0")])
+    tokens = IntegerField(column_name="drops", constraints=[SQL("DEFAULT 0")])
     modified = DateTimeField(null=True)
     modified_by = UIntForeignKeyField(
         model=User,

--- a/back/boxtribute_server/models/fields.py
+++ b/back/boxtribute_server/models/fields.py
@@ -1,5 +1,5 @@
 """Custom peewee field types for data model definitions."""
-from peewee import CharField, ForeignKeyField
+from peewee import CharField, DateTimeField, ForeignKeyField
 
 
 class EnumCharField(CharField):
@@ -49,3 +49,12 @@ class UIntForeignKeyField(ForeignKeyField):
     """
 
     field_type = "INTEGER UNSIGNED"
+
+
+class ZeroDateTimeField(DateTimeField):
+    """Custom class to convert MySQL zero DATETIME field value into None."""
+
+    def adapt(self, value):
+        if value == "0000-00-00 00:00:00":
+            return
+        return super().adapt(value)

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 from boxtribute_server.db import db
 
 from .base import default_base, default_bases
-from .beneficiary import default_beneficiary
+from .beneficiary import another_beneficiary, default_beneficiary
 from .box import (
     another_box,
     another_marked_for_shipment_box,
@@ -48,6 +48,7 @@ from .transfer_agreement import (
 from .user import default_user, default_users
 
 __all__ = [
+    "another_beneficiary",
     "another_box",
     "another_location",
     "another_marked_for_shipment_box",

--- a/back/test/data/beneficiary.py
+++ b/back/test/data/beneficiary.py
@@ -42,9 +42,14 @@ def another_beneficiary_data():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_beneficiary():
     return default_beneficiary_data()
+
+
+@pytest.fixture
+def another_beneficiary():
+    return another_beneficiary_data()
 
 
 def create():

--- a/back/test/data/beneficiary.py
+++ b/back/test/data/beneficiary.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+
 import pytest
 from boxtribute_server.models.definitions.beneficiary import Beneficiary
 from data.base import data as base_data
@@ -6,22 +8,38 @@ from data.base import data as base_data
 def default_beneficiary_data():
     return {
         "id": 1,
+        "first_name": "Every",
+        "last_name": "Body",
         "base": base_data()[0]["id"],
-        "comment": "",
+        "date_of_birth": date(1995, 5, 5),
+        "created_on": datetime(2020, 6, 30),
         "created_by": None,
         "family_id": 10,
-        "seq": 3,
+        "seq": 1,
+        "group_identifier": "1234",
+        "comment": "comment for fun",
         "gender": "M",
-        # must not be empty acc. to Model definition
-        "bicycle_ban_comment": "",
-        "workshop_ban_comment": "",
     }
 
 
 def another_beneficiary_data():
-    data = default_beneficiary_data().copy()
-    data["id"] = 2
-    return data
+    return {
+        "id": 2,
+        "first_name": "No",
+        "last_name": "Body",
+        "base": base_data()[0]["id"],
+        "date_of_birth": date(2000, 1, 1),
+        "created_on": datetime(2021, 6, 30),
+        "created_by": None,
+        "family_id": 10,
+        "family_head": 1,
+        "seq": 2,
+        "group_identifier": "1234",
+        "gender": "F",
+        "is_volunteer": True,
+        "not_registered": True,
+        "deleted": datetime(2021, 12, 31),
+    }
 
 
 @pytest.fixture()

--- a/back/test/data/beneficiary.py
+++ b/back/test/data/beneficiary.py
@@ -28,7 +28,6 @@ def another_beneficiary_data():
         "first_name": "No",
         "last_name": "Body",
         "base": base_data()[0]["id"],
-        "date_of_birth": date(2000, 1, 1),
         "created_on": datetime(2021, 6, 30),
         "created_by": None,
         "family_id": 10,

--- a/back/test/data/beneficiary.py
+++ b/back/test/data/beneficiary.py
@@ -38,7 +38,7 @@ def another_beneficiary_data():
         "gender": "F",
         "is_volunteer": True,
         "not_registered": True,
-        "deleted": datetime(2021, 12, 31),
+        "deleted": datetime(2021, 12, 31),  # == not active
     }
 
 

--- a/back/test/data/box.py
+++ b/back/test/data/box.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from boxtribute_server.enums import BoxState
 from boxtribute_server.models.definitions.box import Box
@@ -16,6 +18,9 @@ def default_box_data():
         "label_identifier": "12345678",
         "state": default_box_state_data()["id"],
         "comment": "",
+        "last_modified_on": datetime(2020, 11, 27),
+        "last_modified_by": default_user_data()["id"],
+        "created_on": datetime(2020, 11, 27),
         "created_by": default_user_data()["id"],
         "items": 0,
         "size": size_data()["id"],
@@ -54,6 +59,7 @@ def marked_for_shipment_box_data():
     data = box_without_qr_code_data()
     data["id"] = 6
     data["label_identifier"] = "56789012"
+    data["last_modified_on"] = datetime(2021, 2, 2)
     return data
 
 
@@ -61,6 +67,7 @@ def another_marked_for_shipment_box_data():
     data = marked_for_shipment_box_data()
     data["id"] = 7
     data["label_identifier"] = "67890123"
+    data["last_modified_on"] = datetime(2021, 2, 2)
     return data
 
 

--- a/back/test/data/transaction.py
+++ b/back/test/data/transaction.py
@@ -1,8 +1,11 @@
 import pytest
 from boxtribute_server.models.definitions.transaction import Transaction
+from boxtribute_server.models.utils import utcnow
 from data.beneficiary import default_beneficiary_data
 from data.product import default_product_data
 from data.user import default_user_data
+
+TIME = utcnow().replace(tzinfo=None)
 
 
 def default_transaction_data():
@@ -13,7 +16,8 @@ def default_transaction_data():
         "tokens": 99,
         "description": "a transaction",
         "product": default_product_data()["id"],
-        "user": default_user_data()["id"],
+        "created_by": default_user_data()["id"],
+        "created_on": TIME,
     }
 
 

--- a/back/test/data/transaction.py
+++ b/back/test/data/transaction.py
@@ -9,7 +9,8 @@ def default_transaction_data():
     return {
         "id": 4,
         "beneficiary": default_beneficiary_data()["id"],
-        "count": 99,
+        "count": 2,
+        "tokens": 99,
         "description": "a transaction",
         "product": default_product_data()["id"],
         "user": default_user_data()["id"],

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -29,7 +29,7 @@ def test_base_specific_permissions(client, mocker):
                     gender: Male,
                     languages: [de],
                     isVolunteer: true,
-                    isRegistered: false
+                    registered: false
                 }) {
                 id
             }"""

--- a/back/test/endpoint_tests/test_beneficiary.py
+++ b/back/test/endpoint_tests/test_beneficiary.py
@@ -38,7 +38,9 @@ def _generate_beneficiary_query(id):
     }}"""
 
 
-def test_beneficiary_query(read_only_client, default_beneficiary, default_transaction):
+def test_beneficiary_query(
+    read_only_client, default_beneficiary, another_beneficiary, default_transaction
+):
     query = _generate_beneficiary_query(default_beneficiary["id"])
     beneficiary = assert_successful_request(read_only_client, query)
     assert beneficiary == {
@@ -71,6 +73,13 @@ def test_beneficiary_query(read_only_client, default_beneficiary, default_transa
             }
         ],
     }
+
+    beneficiary_id = another_beneficiary["id"]
+    query = f"""query {{ beneficiary(id: {beneficiary_id}) {{
+                age
+                dateOfBirth }} }}"""
+    beneficiary = assert_successful_request(read_only_client, query)
+    assert beneficiary == {"age": None, "dateOfBirth": None}
 
 
 def test_beneficiary_mutations(client):

--- a/back/test/endpoint_tests/test_beneficiary.py
+++ b/back/test/endpoint_tests/test_beneficiary.py
@@ -24,6 +24,16 @@ def _generate_beneficiary_query(id):
             dateOfSignature
             tokens
             createdOn
+            transactions {{
+                id
+                beneficiary {{ id }}
+                product {{ id }}
+                count
+                description
+                tokens
+                createdBy {{ id }}
+                createdOn
+            }}
         }}
     }}"""
 
@@ -48,6 +58,18 @@ def test_beneficiary_query(read_only_client, default_beneficiary, default_transa
         "dateOfSignature": None,
         "tokens": default_transaction["tokens"],
         "createdOn": default_beneficiary["created_on"].isoformat() + "+00:00",
+        "transactions": [
+            {
+                "id": str(default_transaction["id"]),
+                "beneficiary": {"id": str(default_beneficiary["id"])},
+                "product": {"id": str(default_transaction["product"])},
+                "count": default_transaction["count"],
+                "description": default_transaction["description"],
+                "tokens": default_transaction["tokens"],
+                "createdBy": {"id": str(default_transaction["created_by"])},
+                "createdOn": default_transaction["created_on"].isoformat() + "+00:00",
+            }
+        ],
     }
 
 
@@ -184,6 +206,7 @@ def test_beneficiary_mutations(client):
         "dateOfSignature": f"{dos}T00:00:00",
         "tokens": 0,
         "createdOn": created_beneficiary["createdOn"],
+        "transactions": [],
     }
 
 

--- a/back/test/endpoint_tests/test_beneficiary.py
+++ b/back/test/endpoint_tests/test_beneficiary.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 from utils import assert_successful_request
 
@@ -5,7 +7,8 @@ from utils import assert_successful_request
 def test_beneficiary_mutations(client):
     first_name = "Some"
     last_name = "One"
-    dob = "2000-01-01"
+    dob_year = 2000
+    dob = f"{dob_year}-01-01"
     base_id = 1
     group_id = "1234"
     gender = "Diverse"
@@ -32,6 +35,7 @@ def test_beneficiary_mutations(client):
                 firstName
                 lastName
                 dateOfBirth
+                age
                 comment
                 base {{ id }}
                 groupIdentifier
@@ -55,6 +59,7 @@ def test_beneficiary_mutations(client):
     assert created_beneficiary["firstName"] == first_name
     assert created_beneficiary["lastName"] == last_name
     assert created_beneficiary["dateOfBirth"] == dob
+    assert created_beneficiary["age"] == date.today().year - dob_year
     assert created_beneficiary["comment"] == comment
     assert int(created_beneficiary["base"]["id"]) == base_id
     assert created_beneficiary["groupIdentifier"] == group_id

--- a/back/test/endpoint_tests/test_beneficiary.py
+++ b/back/test/endpoint_tests/test_beneficiary.py
@@ -18,8 +18,8 @@ def _generate_beneficiary_query(id):
             languages
             familyHead {{ id }}
             isVolunteer
-            isSigned
-            isRegistered
+            signed
+            registered
             signature
             dateOfSignature
             tokens
@@ -52,8 +52,8 @@ def test_beneficiary_query(read_only_client, default_beneficiary, default_transa
         "languages": [],
         "familyHead": None,
         "isVolunteer": False,
-        "isSigned": False,
-        "isRegistered": True,
+        "signed": False,
+        "registered": True,
         "signature": None,
         "dateOfSignature": None,
         "tokens": default_transaction["tokens"],
@@ -94,7 +94,7 @@ def test_beneficiary_mutations(client):
                     gender: {gender},
                     languages: [{','.join(languages)}],
                     isVolunteer: true,
-                    isRegistered: false
+                    registered: false
                 }}"""
     mutation = f"""mutation {{
             createBeneficiary(
@@ -112,8 +112,8 @@ def test_beneficiary_mutations(client):
                 languages
                 familyHead {{ id }}
                 isVolunteer
-                isSigned
-                isRegistered
+                signed
+                registered
                 signature
                 dateOfSignature
                 createdOn
@@ -136,8 +136,8 @@ def test_beneficiary_mutations(client):
     assert created_beneficiary["languages"] == languages
     assert created_beneficiary["familyHead"] is None
     assert created_beneficiary["isVolunteer"]
-    assert not created_beneficiary["isSigned"]
-    assert not created_beneficiary["isRegistered"]
+    assert not created_beneficiary["signed"]
+    assert not created_beneficiary["registered"]
     assert created_beneficiary["signature"] is None
     assert created_beneficiary["dateOfSignature"] is None
     assert created_beneficiary["createdOn"] == created_beneficiary["lastModifiedOn"]
@@ -156,7 +156,7 @@ def test_beneficiary_mutations(client):
                     dateOfSignature: "{dos}"
                     languages: [{language}],
                     isVolunteer: false,
-                    isRegistered: true
+                    registered: true
                 }} ) {{
                 id
             }}
@@ -200,8 +200,8 @@ def test_beneficiary_mutations(client):
         "languages": [language],
         "familyHead": {"id": beneficiary_id},
         "isVolunteer": False,
-        "isSigned": True,
-        "isRegistered": True,
+        "signed": True,
+        "registered": True,
         "signature": signature,
         "dateOfSignature": f"{dos}T00:00:00",
         "tokens": 0,
@@ -269,17 +269,17 @@ def _format(parameter):
         [[{"active": "false"}], 1],
         [[{"isVolunteer": "true"}], 1],
         [[{"isVolunteer": "false"}], 1],
-        [[{"isRegistered": "true"}], 1],
-        [[{"isRegistered": "false"}], 1],
+        [[{"registered": "true"}], 1],
+        [[{"registered": "false"}], 1],
         [[{"pattern": '"Body"'}], 2],
         [[{"pattern": '"fun"'}], 1],
         [[{"pattern": '"Z"'}], 0],
         [[{"pattern": '"1234"'}], 2],
         [[{"pattern": '"123"'}], 0],
         [[{"createdFrom": '"2020-01-01"'}, {"active": "true"}], 1],
-        [[{"active": "true"}, {"isRegistered": "false"}], 0],
+        [[{"active": "true"}, {"registered": "false"}], 0],
         [[{"active": "false"}, {"pattern": '"no"'}], 1],
-        [[{"isVolunteer": "true"}, {"isRegistered": "true"}], 0],
+        [[{"isVolunteer": "true"}, {"registered": "true"}], 0],
     ],
     ids=_format,
 )
@@ -290,13 +290,13 @@ def test_beneficiaries_filtered_query(read_only_client, filters, number):
                     id
                     active
                     isVolunteer
-                    isRegistered
+                    registered
                 }} }} }}"""
     beneficiaries = assert_successful_request(read_only_client, query)["elements"]
     assert len(beneficiaries) == number
 
     for f in filters:
-        for name in ["active", "isVolunteer", "isRegistered"]:
+        for name in ["active", "isVolunteer", "registered"]:
             if name in f:
                 value = f[name] == "true"
                 assert [b[name] for b in beneficiaries] == number * [value]

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -87,7 +87,7 @@ def test_invalid_permission_for_given_resource_id(read_only_client, mocker, quer
                 gender: Male,
                 languages: [de],
                 isVolunteer: true,
-                isRegistered: false
+                registered: false
             }) {
             id
         }""",

--- a/back/test/integration_tests/test_operations.py
+++ b/back/test/integration_tests/test_operations.py
@@ -58,7 +58,7 @@ def test_mutations(auth0_client):
                     dateOfBirth: "2000-01-30",
                     gender: Female,
                     isVolunteer: false,
-                    isRegistered: false
+                    registered: false
                 }) { id firstName } }"""
     response = assert_successful_request(auth0_client, mutation)
     beneficiary_id = response.pop("id")


### PR DESCRIPTION
This PR brings an extension of the GraphQL API:
- queries for beneficiaries and boxes can now be filtered (see the new filter types in `types.graphql` @aerinsol)
- the `Beneficiary` type is extended by fields `age`, `active` (indicate whether soft-deleted or not), and `transactions`

Let me know about any remarks.
