### PR TITLE
Update CircleCI Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,7 @@ jobs:
             pyenv virtualenvs
             pyenv virtualenv env
             pyenv virtualenvs
-            ls env/bin
-            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
+            source env/bin/activate
             python -m site
             pip install -e . -r requirements.txt
             pip list
@@ -127,7 +126,7 @@ jobs:
       - run:
           name: install dev dependencies for linting and testing
           command: |
-            pyenv activate env
+            source env/bin/activate
             pip install -r requirements-dev.txt
             pip list
       # - save_cache:
@@ -139,7 +138,7 @@ jobs:
       - run:
           name: run style checks on Python files
           command: |
-            pyenv activate env
+            source env/bin/activate
             pre-commit run --files **/*.py
       - save_cache:
           key: precommit-deps-{{ checksum "../.pre-commit-config.yaml" }}
@@ -166,7 +165,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            pyenv activate env
+            source env/bin/activate
             pytest --cov-report xml:test-results/coverage.xml --cov=boxtribute_server
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,10 @@ jobs:
             pyenv root
             python --version
             pyenv version
+            pyenv virtualenvs
             pyenv virtualenv env
             pyenv virtualenvs
-            ls $(pyenv root)/versions/3.8.12/envs/env/bin
+            ls env/bin
             source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             python -m site
             pip install -e . -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ jobs:
       - run:
           name: create the python virtual environment and install non-cached dependencies
           command: |
-            python3 -m venv env
+            python --version
+            python -m venv env
             source env/bin/activate
             pip install -e . -r requirements.txt
       # Cache the installed packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - run:
           name: Install MySQL CLI; Import test data
           command: |
-            sudo apt-get install default-mysql-client
+            sudo apt-get update && sudo apt-get install -y default-mysql-client
             mysql -h 127.0.0.1 -u root -pdropapp_root dropapp_dev < init.sql
       # run tests https://circleci.com/docs/2.0/collect-test-data/#pytest
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,10 @@ jobs:
             pyenv versions
             pyenv root
             python --version
-            pyenv version
-            pyenv virtualenvs
             pyenv virtualenv env
             pyenv virtualenvs
             source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
-            python -m site
             pip install -e . -r requirements.txt
-            pip list
       # Cache the installed packages
       - save_cache:
           key: flask-deps-{{ checksum "requirements.txt" }}
@@ -129,7 +125,6 @@ jobs:
           command: |
             source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             pip install -r requirements-dev.txt
-            pip list
       # - save_cache:
       #     key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
       #     paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
           command: |
             pyenv versions
             python --version
+            python -m site
+            ls -R $(pyenv root)/versions/3.8.12
             pip install -e . -r requirements.txt
             pip list
       # Cache the installed packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             pyenv virtualenvs
             pyenv virtualenv env
             pyenv virtualenvs
-            source env/bin/activate
+            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             python -m site
             pip install -e . -r requirements.txt
             pip list
@@ -126,7 +126,7 @@ jobs:
       - run:
           name: install dev dependencies for linting and testing
           command: |
-            source env/bin/activate
+            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             pip install -r requirements-dev.txt
             pip list
       # - save_cache:
@@ -138,7 +138,7 @@ jobs:
       - run:
           name: run style checks on Python files
           command: |
-            source env/bin/activate
+            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             pre-commit run --files **/*.py
       - save_cache:
           key: precommit-deps-{{ checksum "../.pre-commit-config.yaml" }}
@@ -165,7 +165,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            source env/bin/activate
+            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             pytest --cov-report xml:test-results/coverage.xml --cov=boxtribute_server
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 orbs:
-  gcp-cli: circleci/gcp-cli@1.8.4
-  slack: circleci/slack@3.4.2
+  gcp-cli: cimg/gcp-cli@1.8.4
+  slack: cimg/slack@3.4.2
   codecov: codecov/codecov@1.1.3
 jobs:
   checkout-to-workspace:
     docker:
-      - image: circleci/python:3.8-buster-node
+      - image: cimg/python:3.8-buster-node
     steps:
       - checkout
       - persist_to_workspace:
@@ -15,7 +15,7 @@ jobs:
             - .
   build-flask:
     docker:
-      - image: circleci/python:3.8-buster
+      - image: cimg/python:3.8-buster
     working_directory: ~/back
     steps:
       - attach_workspace:
@@ -42,7 +42,7 @@ jobs:
 
   build-and-test-react:
     docker:
-      - image: circleci/python:3.8-buster-node
+      - image: cimg/python:3.8-buster-node
     working_directory: ~/react
     steps:
       - attach_workspace:
@@ -101,8 +101,8 @@ jobs:
   # following https://circleci.com/docs/2.0/project-walkthrough/
   test-flask:
     docker:
-      - image: circleci/python:3.8-buster
-      - image: circleci/mysql:5.7.32
+      - image: cimg/python:3.8-buster
+      - image: cimg/mysql:5.7.32
         environment:
           MYSQL_ROOT_PASSWORD: dropapp_root
           MYSQL_DATABASE: dropapp_dev
@@ -173,7 +173,7 @@ jobs:
       serviceName:
         type: string
     docker:
-      - image: circleci/python:3.8-buster
+      - image: cimg/python:3.8-buster
     working_directory: ~/back
     steps:
       # Attach workspace from build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
   test-flask:
     docker:
       - image: cimg/python:3.8
-      - image: cimg/mysql:5.7.32
+      - image: cimg/mysql:8.0.27
         environment:
           MYSQL_ROOT_PASSWORD: dropapp_root
           MYSQL_DATABASE: dropapp_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,11 @@ jobs:
       - run:
           name: create the python virtual environment and install non-cached dependencies
           command: |
+            pyenv versions
+            pyenv root
             python --version
             python -m venv env
+            ls -R env
             source env/bin/activate
             pip install -e . -r requirements.txt
       # Cache the installed packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   checkout-to-workspace:
     docker:
-      - image: cimg/python:3.8-buster-node
+      - image: cimg/python:3.8-node
     steps:
       - checkout
       - persist_to_workspace:
@@ -15,7 +15,7 @@ jobs:
             - .
   build-flask:
     docker:
-      - image: cimg/python:3.8-buster
+      - image: cimg/python:3.8
     working_directory: ~/back
     steps:
       - attach_workspace:
@@ -42,7 +42,7 @@ jobs:
 
   build-and-test-react:
     docker:
-      - image: cimg/python:3.8-buster-node
+      - image: cimg/python:3.8-node
     working_directory: ~/react
     steps:
       - attach_workspace:
@@ -101,7 +101,7 @@ jobs:
   # following https://circleci.com/docs/2.0/project-walkthrough/
   test-flask:
     docker:
-      - image: cimg/python:3.8-buster
+      - image: cimg/python:3.8
       - image: cimg/mysql:5.7.32
         environment:
           MYSQL_ROOT_PASSWORD: dropapp_root
@@ -173,7 +173,7 @@ jobs:
       serviceName:
         type: string
     docker:
-      - image: cimg/python:3.8-buster
+      - image: cimg/python:3.8
     working_directory: ~/back
     steps:
       # Attach workspace from build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
             pyenv versions
             python --version
             pip install -e . -r requirements.txt
+            pip list
       # Cache the installed packages
       - save_cache:
           key: flask-deps-{{ checksum "requirements.txt" }}
@@ -119,6 +120,7 @@ jobs:
           name: install dev dependencies for linting and testing
           command: |
             pip install -r requirements-dev.txt
+            pip list
       # - save_cache:
       #     key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
       #     paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
-  gcp-cli: cimg/gcp-cli@1.8.4
-  slack: cimg/slack@3.4.2
+  gcp-cli: circleci/gcp-cli@1.8.4
+  slack: circleci/slack@3.4.2
   codecov: codecov/codecov@1.1.3
 jobs:
   checkout-to-workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,13 @@ jobs:
           command: |
             pyenv versions
             pyenv root
+            git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
+            exec "$SHELL"
             python --version
+            pyenv version
+            pyenv virtualenv env
+            pyenv activate env
             python -m site
-            python -m venv env
-            source env/bin/activate
             pip install -e . -r requirements.txt
             pip list
       # Cache the installed packages
@@ -123,7 +126,7 @@ jobs:
       - run:
           name: install dev dependencies for linting and testing
           command: |
-            source env/bin/activate
+            pyenv activate env
             pip install -r requirements-dev.txt
             pip list
       # - save_cache:
@@ -135,7 +138,7 @@ jobs:
       - run:
           name: run style checks on Python files
           command: |
-            source env/bin/activate
+            pyenv activate env
             pre-commit run --files **/*.py
       - save_cache:
           key: precommit-deps-{{ checksum "../.pre-commit-config.yaml" }}
@@ -162,7 +165,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            source env/bin/activate
+            pyenv activate env
             pytest --cov-report xml:test-results/coverage.xml --cov=boxtribute_server
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ jobs:
             pyenv version
             pyenv virtualenv env
             pyenv virtualenvs
-            exec "$SHELL"
-            pyenv activate env
+            ls $(pyenv root)/versions/3.8.12/envs/env/bin
+            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             python -m site
             pip install -e . -r requirements.txt
             pip list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,14 @@ jobs:
       - restore_cache:
           key: flask-deps-{{ checksum "requirements.txt" }}
       - run:
-          name: install non-cached dependencies
+          name: create the python virtual environment and install non-cached dependencies
           command: |
             pyenv versions
+            pyenv root
             python --version
             python -m site
-            ls -R $(pyenv root)/versions/3.8.12
+            python -m venv env
+            source env/bin/activate
             pip install -e . -r requirements.txt
             pip list
       # Cache the installed packages
@@ -121,6 +123,7 @@ jobs:
       - run:
           name: install dev dependencies for linting and testing
           command: |
+            source env/bin/activate
             pip install -r requirements-dev.txt
             pip list
       # - save_cache:
@@ -132,6 +135,7 @@ jobs:
       - run:
           name: run style checks on Python files
           command: |
+            source env/bin/activate
             pre-commit run --files **/*.py
       - save_cache:
           key: precommit-deps-{{ checksum "../.pre-commit-config.yaml" }}
@@ -158,6 +162,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
+            source env/bin/activate
             pytest --cov-report xml:test-results/coverage.xml --cov=boxtribute_server
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,10 @@ jobs:
       - restore_cache:
           key: flask-deps-{{ checksum "requirements.txt" }}
       - run:
-          name: create the python virtual environment and install non-cached dependencies
+          name: install non-cached dependencies
           command: |
             pyenv versions
-            pyenv root
             python --version
-            python -m venv env
-            ls -R env
-            source env/bin/activate
             pip install -e . -r requirements.txt
       # Cache the installed packages
       - save_cache:
@@ -122,7 +118,6 @@ jobs:
       - run:
           name: install dev dependencies for linting and testing
           command: |
-            source env/bin/activate
             pip install -r requirements-dev.txt
       # - save_cache:
       #     key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
@@ -133,7 +128,6 @@ jobs:
       - run:
           name: run style checks on Python files
           command: |
-            source env/bin/activate
             pre-commit run --files **/*.py
       - save_cache:
           key: precommit-deps-{{ checksum "../.pre-commit-config.yaml" }}
@@ -160,7 +154,6 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            source env/bin/activate
             pytest --cov-report xml:test-results/coverage.xml --cov=boxtribute_server
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,6 @@ jobs:
           command: |
             pyenv versions
             pyenv root
-            git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
-            exec "$SHELL"
             python --version
             pyenv version
             pyenv virtualenv env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
           root: ~/
           paths:
             - back/*
+            - .pyenv/versions/3.8.12/envs
 
   build-and-test-react:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   checkout-to-workspace:
     docker:
-      - image: cimg/python:3.8-node
+      - image: cimg/python:3.8.12-node
     steps:
       - checkout
       - persist_to_workspace:
@@ -15,7 +15,7 @@ jobs:
             - .
   build-flask:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.8.12
     working_directory: ~/back
     steps:
       - attach_workspace:
@@ -26,7 +26,6 @@ jobs:
       - run:
           name: create the python virtual environment and install non-cached dependencies
           command: |
-            pyenv versions
             pyenv root
             python --version
             pyenv virtualenv env
@@ -47,7 +46,7 @@ jobs:
 
   build-and-test-react:
     docker:
-      - image: cimg/python:3.8-node
+      - image: cimg/python:3.8.12-node
     working_directory: ~/react
     steps:
       - attach_workspace:
@@ -106,7 +105,7 @@ jobs:
   # following https://circleci.com/docs/2.0/project-walkthrough/
   test-flask:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.8.12
       - image: cimg/mysql:8.0.27
         environment:
           MYSQL_ROOT_PASSWORD: dropapp_root
@@ -178,7 +177,7 @@ jobs:
       serviceName:
         type: string
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.8.12
     working_directory: ~/back
     steps:
       # Attach workspace from build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ jobs:
             python --version
             pyenv version
             pyenv virtualenv env
+            pyenv virtualenvs
+            exec "$SHELL"
             pyenv activate env
             python -m site
             pip install -e . -r requirements.txt


### PR DESCRIPTION
The 'circleci' namespace is deprecated as per Dec 31st, 2021 (see
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)
