### PR TITLE
Create GraphQL documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ back/test-results
 *.prof
 
 yarn-error.log
+
+public/
+*.zip

--- a/back/README.md
+++ b/back/README.md
@@ -11,7 +11,7 @@
    1. [Working with MySQL](#working-with-mysql)
    1. [Debugging](#debugging)
 1. [Testing](#testing)
-1. [GraphQL Playground](#graphql-playground)
+1. [GraphQL API](#graphql-api)
 1. [Production environment](#production-environment)
 1. [Performance evaluation](#performance-evaluation)
 1. [Authentication and Authorization on the back-end](#authentication-and-authorization)
@@ -247,9 +247,18 @@ From the repository root, run
 
 and inspect the reported output. Open the HTML report via `back/htmlcov/index.html` to browse coverage for individual source code files.
 
-## GraphQL Playground
+## GraphQL API
 
-The back-end exposes the GraphQL API at the `/graphql` endpoint. You can experiment with the API in the GraphQL playground.
+The back-end exposes the GraphQL API at the `/graphql` endpoint.
+It is consumed by our front-end, and by partners (for data retrieval).
+
+### Schema documentation
+
+For building a static web documentation of the schema, see [this directory](../docs/graphql-api).
+
+### Playground
+
+You can experiment with the API in the GraphQL playground.
 
 1. Set `export FLASK_ENV=development`
 1. Start the required services by `docker-compose up webapp db`

--- a/back/boxtribute_server/graph_ql/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/inputs.graphql
@@ -1,0 +1,90 @@
+"""
+GraphQL input types for mutations **only**.
+"""
+
+input CreateBoxInput {
+  productId: Int!
+  sizeId: Int!
+  items: Int!
+  locationId: Int!
+  comment: String!
+  qrCode: String
+}
+
+input UpdateBoxInput {
+  labelIdentifier: String!
+  productId: Int
+  sizeId: Int
+  items: Int
+  locationId: Int
+  comment: String
+}
+
+input CreateBeneficiaryInput {
+  firstName: String!
+  lastName: String!
+  baseId: Int!
+  groupIdentifier: String!
+  dateOfBirth: Date!
+  comment: String
+  gender: HumanGender!
+  languages: [Language!]
+  familyHeadId: Int
+  isVolunteer: Boolean!
+  registered: Boolean!
+  signature: String
+  dateOfSignature: Date
+}
+
+input UpdateBeneficiaryInput {
+  id: ID!
+  firstName: String
+  lastName: String
+  baseId: Int
+  groupIdentifier: String
+  dateOfBirth: Date
+  comment: String
+  gender: HumanGender
+  languages: [Language!]
+  familyHeadId: Int
+  isVolunteer: Boolean
+  registered: Boolean
+  signature: String
+  dateOfSignature: Date
+}
+
+input TransferAgreementCreationInput {
+  targetOrganisationId: Int!
+  type: TransferAgreementType!
+  # pass local date and timezone information (e.g. 'Europe/Berlin')
+  validFrom: Date
+  validUntil: Date
+  timezone: String
+  sourceBaseIds: [Int!]
+  targetBaseIds: [Int!]
+}
+
+input ShipmentCreationInput {
+  sourceBaseId: Int!
+  targetBaseId: Int!
+  transferAgreementId: Int!
+}
+
+input ShipmentUpdateInput {
+  id: ID!
+  targetBaseId: Int
+  # label identifiers of boxes prepared for shipment
+  preparedBoxLabelIdentifiers: [String!]
+  # label identifiers of prepared boxes to be moved back to stock
+  removedBoxLabelIdentifiers: [String!]
+  # label identifiers of received boxes to be moved into target stock
+  receivedShipmentDetailUpdateInputs: [ShipmentDetailUpdateInput!]
+  # label identifiers of boxes that went lost during shipment
+  lostBoxLabelIdentifiers: [String!]
+}
+
+input ShipmentDetailUpdateInput {
+  id: ID!
+  targetProductId: Int!
+  targetLocationId: Int!
+}

--- a/back/boxtribute_server/graph_ql/mutations.graphql
+++ b/back/boxtribute_server/graph_ql/mutations.graphql
@@ -1,0 +1,17 @@
+type Mutation {
+  createQrCode(boxLabelIdentifier: String): QrCode
+  createBox(boxCreationInput: CreateBoxInput): Box
+  updateBox(boxUpdateInput: UpdateBoxInput): Box
+  createBeneficiary(creationInput: CreateBeneficiaryInput): Beneficiary
+  updateBeneficiary(updateInput: UpdateBeneficiaryInput): Beneficiary
+
+  createTransferAgreement(creationInput: TransferAgreementCreationInput): TransferAgreement
+  acceptTransferAgreement(id: ID!): TransferAgreement
+  rejectTransferAgreement(id: ID!): TransferAgreement
+  cancelTransferAgreement(id: ID!): TransferAgreement
+
+  createShipment(creationInput: ShipmentCreationInput): Shipment
+  updateShipment(updateInput: ShipmentUpdateInput): Shipment
+  cancelShipment(id: ID!): Shipment
+  sendShipment(id: ID!): Shipment
+}

--- a/back/boxtribute_server/graph_ql/queries.graphql
+++ b/back/boxtribute_server/graph_ql/queries.graphql
@@ -1,27 +1,52 @@
 type Query {
+  """
+  Return all [`Bases`]({{Types.Base}}) that the client is authorized to view.
+  """
   bases: [Base!]!
   base(id: ID!): Base
   organisation(id: ID!): Organisation
+  """
+  Return all [`Organisations`]({{Types.Organisation}}) that the client is authorized to view.
+  """
   organisations: [Organisation!]!
   user(id: ID): User
+  """
+  Return all [`Users`]({{Types.User}}) that the client is authorized to view.
+  """
   users: [User!]!
   box(labelIdentifier: String!): Box
   qrCode(qrCode: String!): QrCode
   qrExists(qrCode: String): Boolean
   location(id: ID!): Location
+  """
+  Return all [`Locations`]({{Types.Location}}) that the client is authorized to view.
+  """
   locations: [Location!]!
   product(id: ID!): Product
+  """
+  Return all [`Products`]({{Types.Product}}) that the client is authorized to view.
+  """
   products(paginationInput: PaginationInput): ProductPage!
   productCategory(id: ID!): ProductCategory
+  """
+  Return all [`ProductCategories`]({{Types.ProductCategory}}) that the client is authorized to view.
+  """
   productCategories: [ProductCategory!]!
   beneficiary(id: ID!): Beneficiary
+  """
+  Return all [`Beneficiaries`]({{Types.Beneficiary}}) that the client is authorized to view.
+  """
   beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage!
   transferAgreement(id: ID!): TransferAgreement
   """
+  Return all [`TransferAgreements`]({{Types.TransferAgreement}}) that the client is authorized to view.
   Without any arguments, return transfer agreements that involve client's organisation,
   regardless of agreement state. Optionally filter for agreements of certain state(s).
   """
   transferAgreements(states: [TransferAgreementState!]): [TransferAgreement!]!
   shipment(id: ID!): Shipment
+  """
+  Return all [`Shipments`]({{Types.Shipment}}) that the client is authorized to view.
+  """
   shipments: [Shipment!]!
 }

--- a/back/boxtribute_server/graph_ql/queries.graphql
+++ b/back/boxtribute_server/graph_ql/queries.graphql
@@ -1,41 +1,27 @@
 type Query {
-  """
-  Return all [`Bases`]({{Types.Base}}) that the client is authorized to view.
-  """
+  " Return all [`Bases`]({{Types.Base}}) that the client is authorized to view. "
   bases: [Base!]!
   base(id: ID!): Base
   organisation(id: ID!): Organisation
-  """
-  Return all [`Organisations`]({{Types.Organisation}}) that the client is authorized to view.
-  """
+  " Return all [`Organisations`]({{Types.Organisation}}) that the client is authorized to view. "
   organisations: [Organisation!]!
   user(id: ID): User
-  """
-  Return all [`Users`]({{Types.User}}) that the client is authorized to view.
-  """
+  " Return all [`Users`]({{Types.User}}) that the client is authorized to view. "
   users: [User!]!
   box(labelIdentifier: String!): Box
   qrCode(qrCode: String!): QrCode
   qrExists(qrCode: String): Boolean
   location(id: ID!): Location
-  """
-  Return all [`Locations`]({{Types.Location}}) that the client is authorized to view.
-  """
+  " Return all [`Locations`]({{Types.Location}}) that the client is authorized to view. "
   locations: [Location!]!
   product(id: ID!): Product
-  """
-  Return all [`Products`]({{Types.Product}}) that the client is authorized to view.
-  """
+  " Return all [`Products`]({{Types.Product}}) that the client is authorized to view. "
   products(paginationInput: PaginationInput): ProductPage!
   productCategory(id: ID!): ProductCategory
-  """
-  Return all [`ProductCategories`]({{Types.ProductCategory}}) that the client is authorized to view.
-  """
+  " Return all [`ProductCategories`]({{Types.ProductCategory}}) that the client is authorized to view. "
   productCategories: [ProductCategory!]!
   beneficiary(id: ID!): Beneficiary
-  """
-  Return all [`Beneficiaries`]({{Types.Beneficiary}}) that the client is authorized to view.
-  """
+  " Return all [`Beneficiaries`]({{Types.Beneficiary}}) that the client is authorized to view. "
   beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage!
   transferAgreement(id: ID!): TransferAgreement
   """
@@ -45,8 +31,6 @@ type Query {
   """
   transferAgreements(states: [TransferAgreementState!]): [TransferAgreement!]!
   shipment(id: ID!): Shipment
-  """
-  Return all [`Shipments`]({{Types.Shipment}}) that the client is authorized to view.
-  """
+  " Return all [`Shipments`]({{Types.Shipment}}) that the client is authorized to view. "
   shipments: [Shipment!]!
 }

--- a/back/boxtribute_server/graph_ql/queries.graphql
+++ b/back/boxtribute_server/graph_ql/queries.graphql
@@ -25,21 +25,3 @@ type Query {
   shipment(id: ID!): Shipment
   shipments: [Shipment!]!
 }
-
-type Mutation {
-  createQrCode(boxLabelIdentifier: String): QrCode
-  createBox(boxCreationInput: CreateBoxInput): Box
-  updateBox(boxUpdateInput: UpdateBoxInput): Box
-  createBeneficiary(creationInput: CreateBeneficiaryInput): Beneficiary
-  updateBeneficiary(updateInput: UpdateBeneficiaryInput): Beneficiary
-
-  createTransferAgreement(creationInput: TransferAgreementCreationInput): TransferAgreement
-  acceptTransferAgreement(id: ID!): TransferAgreement
-  rejectTransferAgreement(id: ID!): TransferAgreement
-  cancelTransferAgreement(id: ID!): TransferAgreement
-
-  createShipment(creationInput: ShipmentCreationInput): Shipment
-  updateShipment(updateInput: ShipmentUpdateInput): Shipment
-  cancelShipment(id: ID!): Shipment
-  sendShipment(id: ID!): Shipment
-}

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -290,6 +290,8 @@ def resolve_beneficiary_languages(beneficiary_obj, info):
 
 @beneficiary.field("gender")
 def resolve_beneficiary_gender(beneficiary_obj, info):
+    if beneficiary_obj.gender == "":
+        return
     return HumanGender(beneficiary_obj.gender)
 
 

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -15,11 +15,11 @@ type Box {
   # A size from a size range, consider making this enum
   size: String
   state: BoxState!
-  qrCode: QrCode!
-  createdBy: User!
-  createdOn: Datetime!
-  lastModifiedBy: User!
-  lastModifiedOn: Datetime!
+  qrCode: QrCode
+  createdBy: User
+  createdOn: Datetime
+  lastModifiedBy: User
+  lastModifiedOn: Datetime
   comment: String
 }
 
@@ -49,10 +49,10 @@ type Product {
   base: Base!
   price: Float
   gender: ProductGender
-  createdBy: User!
-  createdOn: Datetime!
-  lastModifiedBy: User!
-  lastModifiedOn: Datetime!
+  createdBy: User
+  createdOn: Datetime
+  lastModifiedBy: User
+  lastModifiedOn: Datetime
 }
 
 """
@@ -136,10 +136,10 @@ type Location {
   Default state for boxes in this location
   """
   boxState: BoxState
+  createdBy: User
   createdOn: Datetime
-  createdBy: User!
-  lastModifiedBy: User!
-  lastModifiedOn: Datetime!
+  lastModifiedBy: User
+  lastModifiedOn: Datetime
 }
 
 """
@@ -249,9 +249,9 @@ type Beneficiary {
   List of all [`Transactions`]({{Types.Transaction}}) that this beneficiary executed
   """
   transactions: [Transaction!]
-  createdBy: User!
-  createdOn: Datetime!
-  lastModifiedBy: User!
+  createdBy: User
+  createdOn: Datetime
+  lastModifiedBy: User
   lastModifiedOn: Datetime
 }
 
@@ -271,8 +271,8 @@ type Transaction {
   """
   tokens: Int
   description: String
+  createdBy: User
   createdOn: Datetime!
-  createdBy: User!
 }
 
 """

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -229,7 +229,7 @@ type Beneficiary {
   All members of a family have the same group identifier
   """
   groupIdentifier: String!
-  gender: HumanGender!
+  gender: HumanGender
   languages: [Language!]
   """
   Null if this beneficiary is the family head

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -1,11 +1,15 @@
-"""
-GraphQL basic types as returned by queries and mutations, and input types for queries.
-"""
+# GraphQL basic types as returned by queries and mutations, and input types for queries.
 
+"""
+Representation of a box storing items of a [`Product`]({{Types.Product}}) in a [`Location`]({{Types.Location}})
+"""
 type Box {
   id: ID!
   labelIdentifier: String!
   location: Location
+  """
+  The number of items the box contains.
+  """
   items: Int!
   product: Product!
   # A size from a size range, consider making this enum
@@ -14,12 +18,14 @@ type Box {
   qrCode: QrCode!
   createdBy: User!
   createdOn: Datetime!
-  # The user who last changed something about the box
   lastModifiedBy: User!
   lastModifiedOn: Datetime!
   comment: String
 }
 
+"""
+Representation of a QR code, possibly associated with a [`Box`]({{Types.Box}}).
+"""
 type QrCode {
   id: ID!
   code: String!
@@ -27,37 +33,57 @@ type QrCode {
   createdOn: Datetime
 }
 
+"""
+Representation of a product, containing information about [`ProductCategory`]({{Types.ProductCategory}}), size, and [`ProductGender`]({{Types.ProductGender}}).
+The product is registered in a specific [`Base`]({{Types.Base}}).
+"""
 type Product {
   id: ID!
   name: String!
   category: ProductCategory!
   sizeRange: SizeRange!
+  """
+  List of sizes for the product.
+  """
   sizes: [String!]!
   base: Base!
   price: Float
   gender: ProductGender
   createdBy: User!
   createdOn: Datetime!
-  # The user who last changed something about the box
   lastModifiedBy: User!
   lastModifiedOn: Datetime!
 }
 
+"""
+Representation of a product category.
+"""
 type ProductCategory {
   id: ID!
   name: String!
+  """
+  List of all products registered in bases the client is authorized to view.
+  """
   products(paginationInput: PaginationInput): ProductPage
   sizeRanges: [SizeRange]
-  # Non-clothing categories don't have a product gender
+  """
+  Non-clothing categories don't have a product gender.
+  """
   hasGender: Boolean!
 }
 
+"""
+Utility type holding a page of [`Products`]({{Types.Product}}).
+"""
 type ProductPage {
   elements: [Product!]!
   pageInfo: PageInfo!
   totalCount: Int!
 }
 
+"""
+Classificators for [`Product`]({{Types.Product}}) gender.
+"""
 enum ProductGender {
   Men
   Women
@@ -71,6 +97,9 @@ enum ProductGender {
   none
 }
 
+"""
+Classificators for [`Box`]({{Types.Box}}) state.
+"""
 enum BoxState {
   InStock
   Lost
@@ -80,6 +109,9 @@ enum BoxState {
   Scrap
 }
 
+"""
+Representation of group of sizes.
+"""
 type SizeRange {
   id: ID!
   label: String!
@@ -87,42 +119,73 @@ type SizeRange {
   productCategory: [ProductCategory!]
 }
 
+"""
+Representation of a physical location used to store [`Boxes`]({{Types.Box}}).
+The location is part of a specific [`Base`]({{Types.Base}}).
+"""
 type Location {
   id: ID!
   base: Base!
   name: String
   isShop: Boolean!
-  # List of all the boxes in the location
+  """
+  List of all the [`Boxes`]({{Types.Box}}) in this location
+  """
   boxes(paginationInput: PaginationInput, filterInput: FilterBoxInput): BoxPage
+  """
+  Default state for boxes in this location
+  """
   boxState: BoxState
   createdOn: Datetime
-  # The user who generated QR code
   createdBy: User!
   lastModifiedBy: User!
   lastModifiedOn: Datetime!
 }
 
+"""
+Utility type holding a page of [`Boxes`]({{Types.Box}}).
+"""
 type BoxPage {
   elements: [Box!]!
   pageInfo: PageInfo!
   totalCount: Int!
 }
 
+"""
+Representation of a base.
+The base is managed by a specific [`Organisation`]({{Types.Organisation}}).
+"""
 type Base {
   id: ID!
   name: String!
   organisation: Organisation!
+  """
+  List of all [`Locations`]({{Types.Location}}) present in this base
+  """
   locations: [Location!]
+  """
+  List of all [`Beneficiaries`]({{Types.Beneficiary}}) registered in this base
+  """
   beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage!
   currencyName: String
 }
 
+"""
+Representation of an organisation.
+"""
 type Organisation {
   id: ID!
   name: String!
+  """
+  List of all [`Bases`]({{Types.Base}}) managed by this organisation
+  """
   bases: [Base!]
 }
 
+"""
+Representation of a user signed up for the web application.
+The user is a member of a specific [`Organisation`]({{Types.Organisation}}).
+"""
 type User {
   id: ID!
   organisation: Organisation
@@ -130,17 +193,27 @@ type User {
   email: String!
   validFirstDay: Date
   validLastDay: Date
+  """
+  List of all [`Bases`]({{Types.Base}}) this user can access
+  """
   bases: [Base]
   lastLogin: Datetime
   lastAction: Datetime
 }
 
+"""
+Utility type holding a page of [`Beneficiaries`]({{Types.Beneficiary}}).
+"""
 type BeneficiaryPage {
   elements: [Beneficiary!]
   pageInfo: PageInfo!
   totalCount: Int!
 }
 
+"""
+Representation of a beneficiary.
+The beneficiary is registered in a specific [`Base`]({{Types.Base}}).
+"""
 type Beneficiary {
   id: ID!
   firstName: String!
@@ -152,9 +225,15 @@ type Beneficiary {
   age: Int
   comment: String
   base: Base!
+  """
+  All members of a family have the same group identifier
+  """
   groupIdentifier: String!
   gender: HumanGender!
   languages: [Language!]
+  """
+  Null if this beneficiary is the family head
+  """
   familyHead: Beneficiary
   active: Boolean!
   isVolunteer: Boolean!
@@ -162,7 +241,13 @@ type Beneficiary {
   registered: Boolean!
   signature: String
   dateOfSignature: Date
+  """
+  Number of tokens the beneficiary holds (sum of all transaction values)
+  """
   tokens: Int
+  """
+  List of all [`Transactions`]({{Types.Transaction}}) that this beneficiary executed
+  """
   transactions: [Transaction!]
   createdBy: User!
   createdOn: Datetime!
@@ -170,52 +255,107 @@ type Beneficiary {
   lastModifiedOn: Datetime
 }
 
+"""
+Representation of a transaction executed by a beneficiary (spending or receiving tokens).
+"""
 type Transaction {
   id: ID!
   beneficiary: Beneficiary!
   product: Product
+  """
+  Number of transferred products
+  """
   count: Int
+  """
+  Value of the transaction
+  """
   tokens: Int
   description: String
   createdOn: Datetime!
   createdBy: User!
 }
 
+"""
+Additional information passed along in `*Page` types.
+The client shall use the `has*Page` fields to determine whether to fetch more data.
+"""
 type PageInfo {
+  """
+  If true, a previous page is available.
+  """
   hasPreviousPage: Boolean!
+  """
+  If true, a next page is available.
+  """
   hasNextPage: Boolean!
+  """
+  An identifier for the first element on the page. The client shall use it for the [`PaginationInput.before`]({{Types.PaginationInput}}) field
+  """
   startCursor: String!
+  """
+  An identifier for the last element on the page. The client shall use it for the [`PaginationInput.after`]({{Types.PaginationInput}}) field
+  """
   endCursor: String!
 }
 
+"""
+Optional filter values when retrieving [`Beneficiaries`]({{Types.Beneficiary}}).
+If several fields are defined (not null), they are combined into a filter expression using logical AND (i.e. the filter returns only elements for which *all* fields are true).
+"""
 input FilterBeneficiaryInput {
+  """
+  Filter for all beneficiaries who were created on this date (incl.), or later.
+  """
   createdFrom: Date
+  """
+  Filter for all beneficiaries who were created on this date (incl.), or earlier.
+  """
   createdUntil: Date
   active: Boolean
   isVolunteer: Boolean
   registered: Boolean
   """
-  Return beneficiaries where pattern is (case-insensitive) part of first name,
-  last name, or comment, or where pattern matches the group identifier
+  Filter for all beneficiaries where pattern is (case-insensitive) part of first name, last name, or comment, or where pattern matches the group identifier
   """
   pattern: String
 }
 
+"""
+Optional filter values when retrieving [`Boxes`]({{Types.Box}}).
+If several fields are defined (not null), they are combined into a filter expression using logical AND (i.e. the filter returns only elements for which *all* fields are true).
+"""
 input FilterBoxInput {
+  """
+  Filter for all boxes that have *one* of the specified states.
+  """
   states: [BoxState!]
+  """
+  Filter for all boxes that who were last modified on this date (incl.), or later.
+  """
   lastModifiedFrom: Date
+  """
+  Filter for all boxes that who were last modified on this date (incl.), or earlier.
+  """
   lastModifiedUntil: Date
   productGender: ProductGender
   productCategoryId: Int
 }
 
+"""
+Optional input for queries/fields that return a page of elements.
+The specified fields must be either none OR `first` OR `after, first` OR `before, last`. Other combinations result in unexpected behavior and/or errors.
+The default page size (`first` and `last`, resp.) is 50.
+This format is inspired by https://relay.dev/graphql/connections.htm#sec-Forward-pagination-arguments
+"""
 input PaginationInput {
-  # PaginationInput must be either (first) OR (after, first) OR (before, last).
-  # Indicate requesting paginating of the first X elements after cursor
-  # cf. https://relay.dev/graphql/connections.htm#sec-Forward-pagination-arguments
+  """
+  Indicate requesting paginating of the first X elements after this cursor. By default, the first relevant element of the database. See also [`PageInfo.endCursor`]({{Types.PageInfo}})
+  """
   after: String
   first: Int
-  # ... or the last X elements before cursor
+  """
+  Indicate requesting paginating of the last X elements before this cursor. See also [`PageInfo.startCursor`]({{Types.PageInfo}})
+  """
   before: String
   last: Int
 }
@@ -226,6 +366,9 @@ enum HumanGender {
   Diverse
 }
 
+"""
+Language codes.
+"""
 enum Language {
   nl
   en

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -5,11 +5,10 @@ Representation of a box storing items of a [`Product`]({{Types.Product}}) in a [
 """
 type Box {
   id: ID!
+  " Sequence of numbers for identifying the box, usually written on box label "
   labelIdentifier: String!
   location: Location
-  """
-  The number of items the box contains.
-  """
+  " The number of items the box contains. "
   items: Int!
   product: Product!
   # A size from a size range, consider making this enum
@@ -42,9 +41,7 @@ type Product {
   name: String!
   category: ProductCategory!
   sizeRange: SizeRange!
-  """
-  List of sizes for the product.
-  """
+  " List of sizes for the product. "
   sizes: [String!]!
   base: Base!
   price: Float
@@ -61,14 +58,10 @@ Representation of a product category.
 type ProductCategory {
   id: ID!
   name: String!
-  """
-  List of all products registered in bases the client is authorized to view.
-  """
+  " List of all products registered in bases the client is authorized to view. "
   products(paginationInput: PaginationInput): ProductPage
   sizeRanges: [SizeRange]
-  """
-  Non-clothing categories don't have a product gender.
-  """
+  " Non-clothing categories don't have a product gender. "
   hasGender: Boolean!
 }
 
@@ -128,13 +121,9 @@ type Location {
   base: Base!
   name: String
   isShop: Boolean!
-  """
-  List of all the [`Boxes`]({{Types.Box}}) in this location
-  """
+  " List of all the [`Boxes`]({{Types.Box}}) in this location "
   boxes(paginationInput: PaginationInput, filterInput: FilterBoxInput): BoxPage
-  """
-  Default state for boxes in this location
-  """
+  " Default state for boxes in this location "
   boxState: BoxState
   createdBy: User
   createdOn: Datetime
@@ -159,13 +148,9 @@ type Base {
   id: ID!
   name: String!
   organisation: Organisation!
-  """
-  List of all [`Locations`]({{Types.Location}}) present in this base
-  """
+  " List of all [`Locations`]({{Types.Location}}) present in this base "
   locations: [Location!]
-  """
-  List of all [`Beneficiaries`]({{Types.Beneficiary}}) registered in this base
-  """
+  " List of all [`Beneficiaries`]({{Types.Beneficiary}}) registered in this base "
   beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage!
   currencyName: String
 }
@@ -176,9 +161,7 @@ Representation of an organisation.
 type Organisation {
   id: ID!
   name: String!
-  """
-  List of all [`Bases`]({{Types.Base}}) managed by this organisation
-  """
+  " List of all [`Bases`]({{Types.Base}}) managed by this organisation "
   bases: [Base!]
 }
 
@@ -193,9 +176,7 @@ type User {
   email: String!
   validFirstDay: Date
   validLastDay: Date
-  """
-  List of all [`Bases`]({{Types.Base}}) this user can access
-  """
+  " List of all [`Bases`]({{Types.Base}}) this user can access "
   bases: [Base]
   lastLogin: Datetime
   lastAction: Datetime
@@ -219,21 +200,15 @@ type Beneficiary {
   firstName: String!
   lastName: String!
   dateOfBirth: Date
-  """
-  If dateOfBirth is not set, age will be null.
-  """
+  " If dateOfBirth is not set, age will be null. "
   age: Int
   comment: String
   base: Base!
-  """
-  All members of a family have the same group identifier
-  """
+  " All members of a family have the same group identifier "
   groupIdentifier: String!
   gender: HumanGender
   languages: [Language!]
-  """
-  Null if this beneficiary is the family head
-  """
+  " Null if this beneficiary is the family head "
   familyHead: Beneficiary
   active: Boolean!
   isVolunteer: Boolean!
@@ -241,13 +216,9 @@ type Beneficiary {
   registered: Boolean!
   signature: String
   dateOfSignature: Date
-  """
-  Number of tokens the beneficiary holds (sum of all transaction values)
-  """
+  " Number of tokens the beneficiary holds (sum of all transaction values) "
   tokens: Int
-  """
-  List of all [`Transactions`]({{Types.Transaction}}) that this beneficiary executed
-  """
+  " List of all [`Transactions`]({{Types.Transaction}}) that this beneficiary executed "
   transactions: [Transaction!]
   createdBy: User
   createdOn: Datetime
@@ -262,13 +233,9 @@ type Transaction {
   id: ID!
   beneficiary: Beneficiary!
   product: Product
-  """
-  Number of transferred products
-  """
+  " Number of transferred products "
   count: Int
-  """
-  Value of the transaction
-  """
+  " Value of the transaction "
   tokens: Int
   description: String
   createdBy: User
@@ -280,13 +247,9 @@ Additional information passed along in `*Page` types.
 The client shall use the `has*Page` fields to determine whether to fetch more data.
 """
 type PageInfo {
-  """
-  If true, a previous page is available.
-  """
+  " If true, a previous page is available. "
   hasPreviousPage: Boolean!
-  """
-  If true, a next page is available.
-  """
+  " If true, a next page is available. "
   hasNextPage: Boolean!
   """
   An identifier for the first element on the page. The client shall use it for the [`PaginationInput.before`]({{Types.PaginationInput}}) field
@@ -303,13 +266,9 @@ Optional filter values when retrieving [`Beneficiaries`]({{Types.Beneficiary}}).
 If several fields are defined (not null), they are combined into a filter expression using logical AND (i.e. the filter returns only elements for which *all* fields are true).
 """
 input FilterBeneficiaryInput {
-  """
-  Filter for all beneficiaries who were created on this date (incl.), or later.
-  """
+  " Filter for all beneficiaries who were created on this date (incl.), or later. "
   createdFrom: Date
-  """
-  Filter for all beneficiaries who were created on this date (incl.), or earlier.
-  """
+  " Filter for all beneficiaries who were created on this date (incl.), or earlier. "
   createdUntil: Date
   active: Boolean
   isVolunteer: Boolean
@@ -325,17 +284,11 @@ Optional filter values when retrieving [`Boxes`]({{Types.Box}}).
 If several fields are defined (not null), they are combined into a filter expression using logical AND (i.e. the filter returns only elements for which *all* fields are true).
 """
 input FilterBoxInput {
-  """
-  Filter for all boxes that have *one* of the specified states.
-  """
+  " Filter for all boxes that have *one* of the specified states. "
   states: [BoxState!]
-  """
-  Filter for all boxes that who were last modified on this date (incl.), or later.
-  """
+  " Filter for all boxes that who were last modified on this date (incl.), or later. "
   lastModifiedFrom: Date
-  """
-  Filter for all boxes that who were last modified on this date (incl.), or earlier.
-  """
+  " Filter for all boxes that who were last modified on this date (incl.), or earlier. "
   lastModifiedUntil: Date
   productGender: ProductGender
   productCategoryId: Int
@@ -396,13 +349,9 @@ type TransferAgreement {
   validFrom: Datetime!
   validUntil: Datetime
   comment: String
-  """
-  List of all bases of the source organisation included in the agreement
-  """
+  " List of all bases of the source organisation included in the agreement "
   sourceBases: [Base!]!
-  """
-  List of all bases of the target organisation included in the agreement
-  """
+  " List of all bases of the target organisation included in the agreement "
   targetBases: [Base!]
   shipments: [Shipment!]!
 }

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -1,3 +1,7 @@
+"""
+GraphQL basic types as returned by queries and mutations, and input types for queries.
+"""
+
 type Box {
   id: ID!
   labelIdentifier: String!
@@ -163,7 +167,7 @@ type Beneficiary {
   createdBy: User!
   createdOn: Datetime!
   lastModifiedBy: User!
-  lastModifiedOn: Datetime!
+  lastModifiedOn: Datetime
 }
 
 type Transaction {
@@ -182,57 +186,6 @@ type PageInfo {
   hasNextPage: Boolean!
   startCursor: String!
   endCursor: String!
-}
-
-input CreateBoxInput {
-  productId: Int!
-  sizeId: Int!
-  items: Int!
-  locationId: Int!
-  comment: String!
-  qrCode: String
-}
-
-input UpdateBoxInput {
-  labelIdentifier: String!
-  productId: Int
-  sizeId: Int
-  items: Int
-  locationId: Int
-  comment: String
-}
-
-input CreateBeneficiaryInput {
-  firstName: String!
-  lastName: String!
-  baseId: Int!
-  groupIdentifier: String!
-  dateOfBirth: Date!
-  comment: String
-  gender: HumanGender!
-  languages: [Language!]
-  familyHeadId: Int
-  isVolunteer: Boolean!
-  registered: Boolean!
-  signature: String
-  dateOfSignature: Date
-}
-
-input UpdateBeneficiaryInput {
-  id: ID!
-  firstName: String
-  lastName: String
-  baseId: Int
-  groupIdentifier: String
-  dateOfBirth: Date
-  comment: String
-  gender: HumanGender
-  languages: [Language!]
-  familyHeadId: Int
-  isVolunteer: Boolean
-  registered: Boolean
-  signature: String
-  dateOfSignature: Date
 }
 
 input FilterBeneficiaryInput {
@@ -340,42 +293,6 @@ type ShipmentDetail {
   createdOn: Datetime!
   deletedBy: User
   deletedOn: Datetime
-}
-
-input TransferAgreementCreationInput {
-  targetOrganisationId: Int!
-  type: TransferAgreementType!
-  # pass local date and timezone information (e.g. 'Europe/Berlin')
-  validFrom: Date
-  validUntil: Date
-  timezone: String
-  sourceBaseIds: [Int!]
-  targetBaseIds: [Int!]
-}
-
-input ShipmentCreationInput {
-  sourceBaseId: Int!
-  targetBaseId: Int!
-  transferAgreementId: Int!
-}
-
-input ShipmentUpdateInput {
-  id: ID!
-  targetBaseId: Int
-  # label identifiers of boxes prepared for shipment
-  preparedBoxLabelIdentifiers: [String!]
-  # label identifiers of prepared boxes to be moved back to stock
-  removedBoxLabelIdentifiers: [String!]
-  # label identifiers of received boxes to be moved into target stock
-  receivedShipmentDetailUpdateInputs: [ShipmentDetailUpdateInput!]
-  # label identifiers of boxes that went lost during shipment
-  lostBoxLabelIdentifiers: [String!]
-}
-
-input ShipmentDetailUpdateInput {
-  id: ID!
-  targetProductId: Int!
-  targetLocationId: Int!
 }
 
 enum TransferAgreementState {

--- a/back/test/data/beneficiary.py
+++ b/back/test/data/beneficiary.py
@@ -34,7 +34,6 @@ def another_beneficiary_data():
         "family_head": 1,
         "seq": 2,
         "group_identifier": "1234",
-        "gender": "F",
         "is_volunteer": True,
         "not_registered": True,
         "deleted": datetime(2021, 12, 31),  # == not active

--- a/back/test/endpoint_tests/test_beneficiary.py
+++ b/back/test/endpoint_tests/test_beneficiary.py
@@ -76,10 +76,11 @@ def test_beneficiary_query(
 
     beneficiary_id = another_beneficiary["id"]
     query = f"""query {{ beneficiary(id: {beneficiary_id}) {{
+                gender
                 age
                 dateOfBirth }} }}"""
     beneficiary = assert_successful_request(read_only_client, query)
-    assert beneficiary == {"age": None, "dateOfBirth": None}
+    assert beneficiary == {"gender": None, "age": None, "dateOfBirth": None}
 
 
 def test_beneficiary_mutations(client):

--- a/docs/graphql-api/Dockerfile
+++ b/docs/graphql-api/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:17.4.0-alpine3.15
+
+RUN npm install -g spectaql
+
+ENTRYPOINT ["npx", "spectaql"]

--- a/docs/graphql-api/README.md
+++ b/docs/graphql-api/README.md
@@ -1,0 +1,34 @@
+Generate static documentation for boxtribute GraphQL API using [spectaql](https://github.com/anvilco/spectaql).
+
+Tested with spectaql v0.11.0.
+
+### Configuration files
+
+1. `query-api-config.yml`: Generate documentation only for GraphQL queries and relevant types. Mutations and input types are excluded. Intended for partner organisations who want to retrieve data
+1. `full-api-config.yml`: Generate documentation of full GraphQL schema. Intended for internal boxtribute development
+
+Substitute one of these file paths for `some-config.yml` in the command examples below.
+
+### Usage
+
+You can run `spectacle` in your local environment, or via a provided Docker image. Select one of the following acc. to your taste.
+
+#### Local installation
+
+1. Run `npm install -g spectaql`
+1. Execute `npx spectaqle some-config.yml`
+
+#### Dockerized installation
+
+1. Build the Docker image with `docker build -t spectaql .` (alpine-based, 280MB)
+1. Execute `spectaql` by `./run some-config.yml`
+
+### Result
+
+Open `public/index.html` in the web browser. (Alternatively you can add the `-D` flag to the previous `spectaqle` command to start an HTTP server with file watcher and live reloading on port 4400)
+
+See more options with the `--help` flag, or by inspecting the config files.
+
+### Export
+
+Run `zip -r docs.zip public` and distribute the zip file.

--- a/docs/graphql-api/full-api-config.yml
+++ b/docs/graphql-api/full-api-config.yml
@@ -1,0 +1,271 @@
+# This config will not run "as-is" and will need to be modified. You can see a minimal working
+# config in /examples/config.yml
+
+spectaql:
+  # Optional path to an image to use as the logo in the top-left of the output
+  logoFile: ../../react/src/Assets/images/Boxtribute Main Logo-03@2x.png
+  # Optional path to an image to use as a favicon for the site when it's not embedded
+  # faviconFile: path/to/favicon.png
+  # Optional path to a JS file that will be bundled into the spectaql.min.js with all the other
+  # required JS. Can be useful for setting some values, such as for the Traverse.defaults object
+  # additionalJsFile: path/to/additional.js
+
+  # Optional string specifying how to build and include CSS for the output:
+  #   full: will include a very opinionated set of CSS to make the output look good
+  #   basic: will include a very minimal set of CSS mostly used for layout purposes.
+  #     You can then season to taste with your own additional CSS
+  #
+  # Default: full
+  cssBuildMode: full # or basic
+
+
+introspection:
+  ##############################################
+  # These options specify where/how to get the information requried to generate your
+  # documentation.
+  #
+  # Each of these have corresponding CLI options where they can be expressed instead of here.
+  # The CLI options will take precedence over what is in your config file
+  #
+  # 1 and only 1 of the following options must be provided:
+  #
+
+  # URL of the GraphQL endpoint to hit if you want to generate the documentation based on live Introspection Query results
+  # NOTE: If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement.
+  # url: https://yoursite.com/graphql
+
+  # If using the "url" option above, any headers (such as Authorization) can be added here. This
+  # can also be added via the CLI options
+  # headers:
+  #   Authorization: Bearer s3cretT0k2n
+
+  # File containing a GraphQL Schema Definition written in SDL.
+  # Can also pass an array of paths (or glob supported by @graphql-tools/load-files)
+  # like so:
+  # schemaFile:
+  #   - path/to/schema/part1.gql
+  #   - path/to/schema/part2.gql
+  schemaFile:
+      - ../../back/boxtribute_server/graph_ql/types.graphql
+      - ../../back/boxtribute_server/graph_ql/queries.graphql
+      - ../../back/boxtribute_server/graph_ql/mutations.graphql
+      - ../../back/boxtribute_server/graph_ql/inputs.graphql
+
+  # File containing Introspection Query response in JS module export, or JSON format
+  # introspectionFile: path/to/introspection.js[on]
+
+  #
+  #
+  ##############################################
+
+  ##############################################
+  # These options are for random display or augmentation related things that didn't
+  # really fit anywhere else.
+  #
+
+  # Whether you would like to strip any trailing commas from the descriptions to keep
+  # things fresh and clean.
+  #
+  # Default: false
+  removeTrailingPeriodFromDescriptions: false
+
+  #
+  #
+  ##############################################
+
+
+  ##############################################
+  # These options specify how, where and if any "metadata" information is to be added to your Introspection
+  # Query results IF it is not already present. If you are not dealing with metadata, or you have already
+  # baked it into your Introspection Query results somehow (on the server-side, for example) then you
+  # can ignore these options completely.
+  #
+
+  # File that contains your metadata data in JS module export, or JSON format
+  metadataFile: metadata.json
+
+  # The path to a key from which to read the documentation-related metadata at each level of your metadata file.
+  # Defaults to 'documentation', but in case you use a different name, or have a complex/nested metadata structure, you can
+  # specify it here.
+  #
+  # Default: documentation
+  # metadatasReadPath: documentation
+
+  # The metadata that was just read from the above key path will be woven into your Introspection Query results.
+  # This option specifies the key path where that data will be written at each level.
+  #
+  #   ***
+  #   In order to ensure that the metadata you've written can be found later on down the line, this value
+  #   should be set the same as the "metadatasPath" option below
+  #   ***
+  #
+  # Defaults to 'documentation', but in case you have a complex/nested metadata structure, you can
+  # specify it here.
+  #
+  # Default: documentation
+  # metadatasWritePath: documentation
+
+  #
+  #
+  ##############################################
+
+  ##############################################
+  # These options specify how, where and if any "metadata" information is to be found, or
+  # used/ignored when processing your documentation.
+  #
+
+  # The key path in your Introspection Query results where metadata supported by this library can
+  # be found.
+  # Defaults to 'documentation', but in case you have a complex/nested metadata structure, you can
+  # specify it here.
+  #
+  # Default: documentation
+  # metadatasPath: documentation
+
+  # Whether or not to look for and use metadata in your data. If turned off, metadata will be ignored
+  # even if it's there
+  #
+  # Default: true
+  metadatas: false
+
+  #
+  #
+  ##############################################
+
+
+  # This allows you to specify a custom path to a JS moddule to handle the generation of
+  # example values for your schema. The default is "./customizations/examples" which starts
+  # out doing nothing
+  #
+  # Default: ./customizations/examples
+  # dynamicExamplesProcessingModule: path/to/examples.js
+
+  ##############################################
+  # These options specify what the default behavior should be
+  # (regarding documented vs non-documented) in the absence of
+  # metadata directives on a given item
+
+  # Whether to document any Queries at all, in the absence of a metadata directive
+  # Default: true
+  queriesDocumentedDefault: true
+  # Whether to document an individual Query, in the absence of a metadata directive
+  # Default: true
+  queryDocumentedDefault: true
+  # Whether to document a Query Argument, in the absence of a metadata directive
+  # Default: true
+  queryArgDocumentedDefault: true
+  # Hide any Queries with undocumented return types so as not to reference something
+  # that seemingly does not exist.
+  # Default: true
+  hideQueriesWithUndocumentedReturnType: true
+
+  # Whether to document any Mutations at all, in the absence of a metadata directive
+  # Default: true
+  mutationsDocumentedDefault: true
+  # Whether to document an individual Mutation, in the absence of a metadata directive
+  # Default: true
+  mutationDocumentedDefault: true
+  # Whether to document a Mutation Argument, in the absence of a metadata directive
+  # Default: true
+  mutationArgDocumentedDefault: true
+  # Hide any Mutations with undocumented return types so as not to reference something
+  # that seemingly does not exist.
+  # Default: true
+  hideMutationsWithUndocumentedReturnType: true
+
+  # Whether to document any Types at all
+  # Default: true
+  typesDocumented: true
+  # Whether to document an individual Type, in the absence of a metadata directive
+  # Default: true
+  typeDocumentedDefault: true
+  # Whether to document an individual Field, in the absence of a metadata directive
+  # Default: true
+  fieldDocumentedDefault: true
+  # Whether to document an individual Argument, in the absence of a metadata directive
+  # Default: true
+  argDocumentedDefault: true
+  # Hide any fields with undocumented return types so as not to reference something
+  # that seemingly does not exist.
+  # Default: true
+  hideFieldsWithUndocumentedReturnType: true
+
+  #
+  #
+  ##############################################
+
+servers:
+  # NOTE: If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement.
+
+  # same format as for OpenAPI Specification https://swagger.io/specification/#server-object
+
+  - url: https://www.boxtribute.org/graphql
+    description: Production Server
+    # Indicates to use this server's URL as the typical GraphQL request base in the documentation
+    # If no server entries have this indicator, the first server's URL will be used.
+    # If no server entries are defined at all, the Introspection URL will be used.
+    production: true
+
+info:
+  # Tries to adhere to OpenAPI Specification https://swagger.io/specification/#info-object
+  # Will be used to populate the Welcome section of the output
+
+  ##############################################
+  # Introduction area flags
+  #
+
+  # Set to true to do no Introduction area rendering at all. Supersedes the below options
+  # Default: false
+  x-hideIntroduction: false
+  # Set to true to not render a friendly Welcome section based on the description in this area
+  # Default: false
+  x-hideWelcome: false
+  # Set to true to not render your intro items
+  # Default: false
+  x-hideIntroItems: false
+
+  # Set to true to not render the deprecated label
+  # Default: false
+  x-hideIsDeprecated: false
+  # Set to true to not render the deprecation reason
+  # Default: false
+  x-hideDeprecationReason: false
+
+  #
+  ##############################################
+
+  description: These pages contain the documentation for the boxtribute GraphQL API. Have fun exploring!
+  version: 0.0.1
+  title: Welcome!
+  # This is non-standard and optional. If omitted, will use "title". Also only relevant
+  # when building non-embedded.
+  x-htmlTitle: boxtribute GraphQL API documentation
+  termsOfService: 'https://www.boxtribute.org'
+  contact:
+    name: boxtribute Support
+    email: help@boxtribute.org
+    url: https://www.boxtribute.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+  # A non-standard array of items to display in your Introduction Area
+  x-introItems:
+    # Can be a Title (for the Nav panel) + URL to simply add a link to somewhere
+    - title: boxtribute website
+      url: https://www.boxtribute.org
+    # Can be a Title (for the Nav panel) + description (for the Content panel)
+    - title: Login to boxtribute web app
+      url: https://www.app.boxtribute.org
+    - title: Authentication and Authorization
+      description: Lorem ipsum explain how to authenticate, and what clients are authorized for
+
+  # If you really want to hide the "Documentation by" at the bottom of your output, you can do so here
+  # Default: false
+  x-hidePoweredBy: false
+
+  # If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement. This allows for that.
+  x-swaggerUrl: https://www.boxtribute.org/graphql

--- a/docs/graphql-api/metadata.json
+++ b/docs/graphql-api/metadata.json
@@ -1,0 +1,118 @@
+{
+  "OBJECT": {
+    "SecretType": {
+      "documentation": { "undocumented": true }
+    },
+    "Base": {
+      "fields": {
+        "name": {
+          "documentation": { "example": "Lesvos" }
+        },
+        "currencyName": {
+          "documentation": { "example": "drops" }
+        }
+      }
+    },
+    "Beneficiary": {
+      "fields": {
+        "firstName": {
+          "documentation": { "example": "Some" }
+        },
+        "lastName": {
+          "documentation": { "example": "One" }
+        },
+        "age": {
+          "documentation": { "example": 25 }
+        },
+        "comment": {
+          "documentation": { "example": "very nice" }
+        }
+      }
+    },
+    "Box": {
+      "fields": {
+        "size": {
+          "documentation": { "example": "XL" }
+        },
+        "comment": {
+          "documentation": { "example": "very new" }
+        }
+      }
+    },
+    "Location": {
+      "fields": {
+        "name": {
+          "documentation": { "example": "Warehouse Kids" }
+        }
+      }
+    },
+    "Organisation": {
+      "fields": {
+        "name": {
+          "documentation": { "example": "Helpful Helpers" }
+        }
+      }
+    },
+    "Product": {
+      "fields": {
+        "name": {
+          "documentation": { "example": "gloves" }
+        },
+        "sizes": {
+          "documentation": { "example": "Kids 6-10, Kids 10-13" }
+        }
+      }
+    },
+    "ProductCategory": {
+      "fields": {
+        "name": {
+          "documentation": { "example": "Clothing" }
+        }
+      }
+    },
+    "Query": {
+      "fields": {
+        "myQuery": {
+          "args": {
+            "nonReqQueryArg": {
+              "documentation": { "example": "Metadata example of `nonReqQueryArg`" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "SCALAR": {
+    "Datetime": {
+      "documentation": { "example": "\"2016-10-17T01:08:03\"" }
+    },
+    "Date": {
+      "documentation": { "example": "\"2020-11-20\"" }
+    }
+  },
+  "INPUT_OBJECT": {
+    "PaginationInput": {
+      "inputFields": {
+        "first": {
+          "documentation": { "example": 50 }
+        },
+        "after": {
+          "documentation": { "example": "c00ffeeb33f" }
+        },
+        "before": {
+          "documentation": { "example": null }
+        },
+        "last": {
+          "documentation": { "example": null }
+        }
+      }
+    },
+    "FilterBoxInput": {
+      "inputFields": {
+        "states": {
+          "documentation": { "example": "[InStock]" }
+        }
+      }
+    }
+  }
+}

--- a/docs/graphql-api/query-api-config.yml
+++ b/docs/graphql-api/query-api-config.yml
@@ -1,0 +1,269 @@
+# This config will not run "as-is" and will need to be modified. You can see a minimal working
+# config in /examples/config.yml
+
+spectaql:
+  # Optional path to an image to use as the logo in the top-left of the output
+  logoFile: ../../react/src/Assets/images/Boxtribute Main Logo-03@2x.png
+  # Optional path to an image to use as a favicon for the site when it's not embedded
+  # faviconFile: path/to/favicon.png
+  # Optional path to a JS file that will be bundled into the spectaql.min.js with all the other
+  # required JS. Can be useful for setting some values, such as for the Traverse.defaults object
+  # additionalJsFile: path/to/additional.js
+
+  # Optional string specifying how to build and include CSS for the output:
+  #   full: will include a very opinionated set of CSS to make the output look good
+  #   basic: will include a very minimal set of CSS mostly used for layout purposes.
+  #     You can then season to taste with your own additional CSS
+  #
+  # Default: full
+  cssBuildMode: full # or basic
+
+
+introspection:
+  ##############################################
+  # These options specify where/how to get the information requried to generate your
+  # documentation.
+  #
+  # Each of these have corresponding CLI options where they can be expressed instead of here.
+  # The CLI options will take precedence over what is in your config file
+  #
+  # 1 and only 1 of the following options must be provided:
+  #
+
+  # URL of the GraphQL endpoint to hit if you want to generate the documentation based on live Introspection Query results
+  # NOTE: If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement.
+  # url: https://yoursite.com/graphql
+
+  # If using the "url" option above, any headers (such as Authorization) can be added here. This
+  # can also be added via the CLI options
+  # headers:
+  #   Authorization: Bearer s3cretT0k2n
+
+  # File containing a GraphQL Schema Definition written in SDL.
+  # Can also pass an array of paths (or glob supported by @graphql-tools/load-files)
+  # like so:
+  # schemaFile:
+  #   - path/to/schema/part1.gql
+  #   - path/to/schema/part2.gql
+  schemaFile:
+      - ../../back/boxtribute_server/graph_ql/types.graphql
+      - ../../back/boxtribute_server/graph_ql/queries.graphql
+
+  # File containing Introspection Query response in JS module export, or JSON format
+  # introspectionFile: path/to/introspection.js[on]
+
+  #
+  #
+  ##############################################
+
+  ##############################################
+  # These options are for random display or augmentation related things that didn't
+  # really fit anywhere else.
+  #
+
+  # Whether you would like to strip any trailing commas from the descriptions to keep
+  # things fresh and clean.
+  #
+  # Default: false
+  removeTrailingPeriodFromDescriptions: false
+
+  #
+  #
+  ##############################################
+
+
+  ##############################################
+  # These options specify how, where and if any "metadata" information is to be added to your Introspection
+  # Query results IF it is not already present. If you are not dealing with metadata, or you have already
+  # baked it into your Introspection Query results somehow (on the server-side, for example) then you
+  # can ignore these options completely.
+  #
+
+  # File that contains your metadata data in JS module export, or JSON format
+  metadataFile: metadata.json
+
+  # The path to a key from which to read the documentation-related metadata at each level of your metadata file.
+  # Defaults to 'documentation', but in case you use a different name, or have a complex/nested metadata structure, you can
+  # specify it here.
+  #
+  # Default: documentation
+  # metadatasReadPath: documentation
+
+  # The metadata that was just read from the above key path will be woven into your Introspection Query results.
+  # This option specifies the key path where that data will be written at each level.
+  #
+  #   ***
+  #   In order to ensure that the metadata you've written can be found later on down the line, this value
+  #   should be set the same as the "metadatasPath" option below
+  #   ***
+  #
+  # Defaults to 'documentation', but in case you have a complex/nested metadata structure, you can
+  # specify it here.
+  #
+  # Default: documentation
+  # metadatasWritePath: documentation
+
+  #
+  #
+  ##############################################
+
+  ##############################################
+  # These options specify how, where and if any "metadata" information is to be found, or
+  # used/ignored when processing your documentation.
+  #
+
+  # The key path in your Introspection Query results where metadata supported by this library can
+  # be found.
+  # Defaults to 'documentation', but in case you have a complex/nested metadata structure, you can
+  # specify it here.
+  #
+  # Default: documentation
+  # metadatasPath: documentation
+
+  # Whether or not to look for and use metadata in your data. If turned off, metadata will be ignored
+  # even if it's there
+  #
+  # Default: true
+  metadatas: false
+
+  #
+  #
+  ##############################################
+
+
+  # This allows you to specify a custom path to a JS moddule to handle the generation of
+  # example values for your schema. The default is "./customizations/examples" which starts
+  # out doing nothing
+  #
+  # Default: ./customizations/examples
+  # dynamicExamplesProcessingModule: path/to/examples.js
+
+  ##############################################
+  # These options specify what the default behavior should be
+  # (regarding documented vs non-documented) in the absence of
+  # metadata directives on a given item
+
+  # Whether to document any Queries at all, in the absence of a metadata directive
+  # Default: true
+  queriesDocumentedDefault: true
+  # Whether to document an individual Query, in the absence of a metadata directive
+  # Default: true
+  queryDocumentedDefault: true
+  # Whether to document a Query Argument, in the absence of a metadata directive
+  # Default: true
+  queryArgDocumentedDefault: true
+  # Hide any Queries with undocumented return types so as not to reference something
+  # that seemingly does not exist.
+  # Default: true
+  hideQueriesWithUndocumentedReturnType: true
+
+  # Whether to document any Mutations at all, in the absence of a metadata directive
+  # Default: true
+  mutationsDocumentedDefault: true
+  # Whether to document an individual Mutation, in the absence of a metadata directive
+  # Default: true
+  mutationDocumentedDefault: true
+  # Whether to document a Mutation Argument, in the absence of a metadata directive
+  # Default: true
+  mutationArgDocumentedDefault: true
+  # Hide any Mutations with undocumented return types so as not to reference something
+  # that seemingly does not exist.
+  # Default: true
+  hideMutationsWithUndocumentedReturnType: true
+
+  # Whether to document any Types at all
+  # Default: true
+  typesDocumented: true
+  # Whether to document an individual Type, in the absence of a metadata directive
+  # Default: true
+  typeDocumentedDefault: true
+  # Whether to document an individual Field, in the absence of a metadata directive
+  # Default: true
+  fieldDocumentedDefault: true
+  # Whether to document an individual Argument, in the absence of a metadata directive
+  # Default: true
+  argDocumentedDefault: true
+  # Hide any fields with undocumented return types so as not to reference something
+  # that seemingly does not exist.
+  # Default: true
+  hideFieldsWithUndocumentedReturnType: true
+
+  #
+  #
+  ##############################################
+
+servers:
+  # NOTE: If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement.
+
+  # same format as for OpenAPI Specification https://swagger.io/specification/#server-object
+
+  - url: https://www.boxtribute.org/graphql
+    description: Production Server
+    # Indicates to use this server's URL as the typical GraphQL request base in the documentation
+    # If no server entries have this indicator, the first server's URL will be used.
+    # If no server entries are defined at all, the Introspection URL will be used.
+    production: true
+
+info:
+  # Tries to adhere to OpenAPI Specification https://swagger.io/specification/#info-object
+  # Will be used to populate the Welcome section of the output
+
+  ##############################################
+  # Introduction area flags
+  #
+
+  # Set to true to do no Introduction area rendering at all. Supersedes the below options
+  # Default: false
+  x-hideIntroduction: false
+  # Set to true to not render a friendly Welcome section based on the description in this area
+  # Default: false
+  x-hideWelcome: false
+  # Set to true to not render your intro items
+  # Default: false
+  x-hideIntroItems: false
+
+  # Set to true to not render the deprecated label
+  # Default: false
+  x-hideIsDeprecated: false
+  # Set to true to not render the deprecation reason
+  # Default: false
+  x-hideDeprecationReason: false
+
+  #
+  ##############################################
+
+  description: These pages contain the documentation for the boxtribute GraphQL API (queries only). Have fun exploring!
+  version: 0.0.1
+  title: Welcome!
+  # This is non-standard and optional. If omitted, will use "title". Also only relevant
+  # when building non-embedded.
+  x-htmlTitle: boxtribute GraphQL API documentation
+  termsOfService: 'https://www.boxtribute.org'
+  contact:
+    name: boxtribute Support
+    email: help@boxtribute.org
+    url: https://www.boxtribute.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+  # A non-standard array of items to display in your Introduction Area
+  x-introItems:
+    # Can be a Title (for the Nav panel) + URL to simply add a link to somewhere
+    - title: boxtribute website
+      url: https://www.boxtribute.org
+    # Can be a Title (for the Nav panel) + description (for the Content panel)
+    - title: Login to boxtribute web app
+      url: https://www.api.boxtribute.org
+    - title: Authentication and Authorization
+      description: Lorem ipsum explain how to authenticate, and what clients are authorized for
+
+  # If you really want to hide the "Documentation by" at the bottom of your output, you can do so here
+  # Default: false
+  x-hidePoweredBy: false
+
+  # If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement. This allows for that.
+  x-swaggerUrl: https://www.boxtribute.org/graphql

--- a/docs/graphql-api/run
+++ b/docs/graphql-api/run
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Mount root of repository into container /repo and execute spectaql in sub-directory
+# of docs/
+docker run \
+    -it --rm \
+    -v "$SCRIPT_DIR"/../../:/repo \
+    -w /repo/docs/graphql-api \
+    -p 4400:4400 \
+    -p 4401:4401 \
+    spectaql:latest \
+    "$@"


### PR DESCRIPTION
Here comes the documentation of our GraphQL documentation.

After some research, I decided to use [SpectaQL](https://github.com/anvilco/spectaql) for generation (I consider it an active, well-documented project. Indeed it was very easy to set up). The generated GraphQL documentation (excluding mutations) is attached to the linked Trello card. Please extract it and have a look at `index.html` in your web browser. I really like the interactivity of the documentation framework.

As a preparation I split the schema definitions into several files:
- "external" API consumers access queries and relevant types (no mutations)
- our front-end consumes the full schema (queries, types, mutations, inputs)

I have a local repository for building the documentation. What do you think about putting the relevant instructions and scripts into `docs/graphql-api/` @aerinsol @vahidbazzaz? For now it can be build and distributed from there. Later we might want to think about hosting the documentation online (and introspecting the production server for information about the GraphQL schema).
