### PR TITLE
Implement GraphQL metrics query

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -249,8 +249,8 @@ and inspect the reported output. Open the HTML report via `back/htmlcov/index.ht
 
 ## GraphQL API
 
-The back-end exposes the GraphQL API at the `/graphql` endpoint.
-It is consumed by our front-end, and by partners (for data retrieval).
+The back-end exposes the GraphQL API in two variants.
+The full API is consumed by our front-end at the `/graphql` endpoint. The 'query' API is used by our partners at `/api` (for data retrieval).
 
 ### Schema documentation
 
@@ -262,7 +262,7 @@ You can experiment with the API in the GraphQL playground.
 
 1. Set `export FLASK_ENV=development`
 1. Start the required services by `docker-compose up webapp db`
-1. Open `localhost:5005/graphql`.
+1. Open `localhost:5005/graphql` (or `/api`)
 1. Simulate being a valid, logged-in user by fetching an authorization token (internally the variables of the `.env` file are used): `./fetch_token`
 1. Copy the content of the `access_token` field (alternatively, you can pipe the above command ` | jq -r .access_token | xclip -i -selection c` to copy it to the system clipboard)
 1.  Insert the access token in the following format on the playground in the section on the bottom left of the playground called HTTP Headers.

--- a/back/boxtribute_server/graph_ql/definitions.py
+++ b/back/boxtribute_server/graph_ql/definitions.py
@@ -7,3 +7,8 @@ MODULE_DIRECTORY = Path(__file__).resolve().parent
 
 # Recursively load any .graphql files
 definitions = load_schema_from_path(MODULE_DIRECTORY)
+
+query_api_definitions = "\n".join(
+    load_schema_from_path(MODULE_DIRECTORY / f"{name}.graphql")
+    for name in ["types", "queries"]
+)

--- a/back/boxtribute_server/graph_ql/queries.graphql
+++ b/back/boxtribute_server/graph_ql/queries.graphql
@@ -33,4 +33,6 @@ type Query {
   shipment(id: ID!): Shipment
   " Return all [`Shipments`]({{Types.Shipment}}) that the client is authorized to view. "
   shipments: [Shipment!]!
+  " Return various metrics about stock and beneficiaries for client's organisation. "
+  metrics: Metrics
 }

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -505,6 +505,14 @@ def resolve_organisation_bases(organisation_obj, info):
     return Base.select().where(Base.organisation_id == organisation_obj.id)
 
 
+@beneficiary.field("base")
+@location.field("base")
+@product.field("base")
+def resolve_resource_base(obj, info):
+    authorize(permission="base:read")
+    return obj.base
+
+
 @product.field("gender")
 def resolve_product_gender(product_obj, info):
     # Instead of a ProductGender instance return an integer for EnumType conversion

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -367,13 +367,13 @@ def resolve_update_beneficiary(_, info, update_input):
 @mutation.field("createTransferAgreement")
 @convert_kwargs_to_snake_case
 def resolve_create_transfer_agreement(_, info, creation_input):
-    authorize(permission="transfer_agreement:write")
+    authorize(permission="transfer_agreement:create")
     return create_transfer_agreement(**creation_input, user=g.user)
 
 
 @mutation.field("acceptTransferAgreement")
 def resolve_accept_transfer_agreement(_, info, id):
-    authorize(permission="transfer_agreement:write")
+    authorize(permission="transfer_agreement:edit")
     agreement = TransferAgreement.get_by_id(id)
     authorize(organisation_id=agreement.target_organisation_id)
     return accept_transfer_agreement(id=id, user=g.user)
@@ -381,7 +381,7 @@ def resolve_accept_transfer_agreement(_, info, id):
 
 @mutation.field("rejectTransferAgreement")
 def resolve_reject_transfer_agreement(_, info, id):
-    authorize(permission="transfer_agreement:write")
+    authorize(permission="transfer_agreement:edit")
     agreement = TransferAgreement.get_by_id(id)
     authorize(organisation_id=agreement.target_organisation_id)
     return reject_transfer_agreement(id=id, user=g.user)
@@ -389,7 +389,7 @@ def resolve_reject_transfer_agreement(_, info, id):
 
 @mutation.field("cancelTransferAgreement")
 def resolve_cancel_transfer_agreement(_, info, id):
-    authorize(permission="transfer_agreement:write")
+    authorize(permission="transfer_agreement:edit")
     agreement = TransferAgreement.get_by_id(id)
     authorize(
         organisation_ids=[
@@ -403,7 +403,7 @@ def resolve_cancel_transfer_agreement(_, info, id):
 @mutation.field("createShipment")
 @convert_kwargs_to_snake_case
 def resolve_create_shipment(_, info, creation_input):
-    authorize(permission="shipment:write")
+    authorize(permission="shipment:create")
     agreement = TransferAgreement.get_by_id(creation_input["transfer_agreement_id"])
     organisation_ids = [agreement.source_organisation_id]
     if agreement.type == TransferAgreementType.Bidirectional:
@@ -415,7 +415,7 @@ def resolve_create_shipment(_, info, creation_input):
 @mutation.field("updateShipment")
 @convert_kwargs_to_snake_case
 def resolve_update_shipment(_, info, update_input):
-    authorize(permission="shipment:write")
+    authorize(permission="shipment:edit")
 
     shipment = Shipment.get_by_id(update_input["id"])
     source_update_fields = [
@@ -444,7 +444,7 @@ def resolve_update_shipment(_, info, update_input):
 
 @mutation.field("cancelShipment")
 def resolve_cancel_shipment(_, info, id):
-    authorize(permission="shipment:write")
+    authorize(permission="shipment:edit")
     shipment = Shipment.get_by_id(id)
     authorize(
         organisation_ids=[
@@ -457,7 +457,7 @@ def resolve_cancel_shipment(_, info, id):
 
 @mutation.field("sendShipment")
 def resolve_send_shipment(_, info, id):
-    authorize(permission="shipment:write")
+    authorize(permission="shipment:edit")
     shipment = Shipment.get_by_id(id)
     authorize(organisation_id=shipment.source_base.organisation_id)
     return send_shipment(id=id, user=g.user)

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -558,8 +558,21 @@ def resolve_shipment_details(shipment_obj, info):
     )
 
 
+@shipment.field("sourceBase")
+def resolve_shipment_source_base(shipment_obj, info):
+    authorize(permission="base:read")
+    return shipment_obj.source_base
+
+
+@shipment.field("targetBase")
+def resolve_shipment_target_base(shipment_obj, info):
+    authorize(permission="base:read")
+    return shipment_obj.target_base
+
+
 @transfer_agreement.field("sourceBases")
 def resolve_transfer_agreement_source_bases(transfer_agreement_obj, info):
+    authorize(permission="base:read")
     return retrieve_transfer_agreement_bases(
         transfer_agreement=transfer_agreement_obj, kind="source"
     )
@@ -567,6 +580,7 @@ def resolve_transfer_agreement_source_bases(transfer_agreement_obj, info):
 
 @transfer_agreement.field("targetBases")
 def resolve_transfer_agreement_target_bases(transfer_agreement_obj, info):
+    authorize(permission="base:read")
     return retrieve_transfer_agreement_bases(
         transfer_agreement=transfer_agreement_obj, kind="target"
     )

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -43,7 +43,7 @@ from ..models.definitions.transaction import Transaction
 from ..models.definitions.transfer_agreement import TransferAgreement
 from ..models.definitions.user import User
 from ..models.definitions.x_beneficiary_language import XBeneficiaryLanguage
-from ..models.metrics import compute_number_of_families_served
+from ..models.metrics import compute_number_of_families_served, compute_number_of_sales
 from .filtering import derive_beneficiary_filter, derive_box_filter
 from .pagination import load_into_page
 
@@ -510,6 +510,13 @@ def resolve_location_boxes(
 @metrics.field("numberOfFamiliesServed")
 def resolve_metrics_number_of_families_served(metrics_obj, _, after=None):
     return compute_number_of_families_served(
+        organisation_id=g.user["organisation_id"], after=after
+    )
+
+
+@metrics.field("numberOfSales")
+def resolve_metrics_number_of_sales(*_, after=None):
+    return compute_number_of_sales(
         organisation_id=g.user["organisation_id"], after=after
     )
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -508,8 +508,10 @@ def resolve_location_boxes(
 
 
 @metrics.field("numberOfFamiliesServed")
-def resolve_metrics_number_of_families_served(metrics_obj, _):
-    return compute_number_of_families_served()
+def resolve_metrics_number_of_families_served(metrics_obj, _, after=None):
+    return compute_number_of_families_served(
+        organisation_id=g.user["organisation_id"], after=after
+    )
 
 
 @organisation.field("bases")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -43,7 +43,11 @@ from ..models.definitions.transaction import Transaction
 from ..models.definitions.transfer_agreement import TransferAgreement
 from ..models.definitions.user import User
 from ..models.definitions.x_beneficiary_language import XBeneficiaryLanguage
-from ..models.metrics import compute_number_of_families_served, compute_number_of_sales
+from ..models.metrics import (
+    compute_number_of_families_served,
+    compute_number_of_sales,
+    compute_stock_overview,
+)
 from .filtering import derive_beneficiary_filter, derive_box_filter
 from .pagination import load_into_page
 
@@ -519,6 +523,11 @@ def resolve_metrics_number_of_sales(*_, after=None):
     return compute_number_of_sales(
         organisation_id=g.user["organisation_id"], after=after
     )
+
+
+@metrics.field("stockOverview")
+def resolve_metrics_stock_overview(*_):
+    return compute_stock_overview(organisation_id=g.user["organisation_id"])
 
 
 @organisation.field("bases")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -43,6 +43,7 @@ from ..models.definitions.transaction import Transaction
 from ..models.definitions.transfer_agreement import TransferAgreement
 from ..models.definitions.user import User
 from ..models.definitions.x_beneficiary_language import XBeneficiaryLanguage
+from ..models.metrics import compute_number_of_families_served
 from .filtering import derive_beneficiary_filter, derive_box_filter
 from .pagination import load_into_page
 
@@ -61,6 +62,7 @@ base = _register_object_type("Base")
 beneficiary = _register_object_type("Beneficiary")
 box = _register_object_type("Box")
 location = _register_object_type("Location")
+metrics = _register_object_type("Metrics")
 organisation = _register_object_type("Organisation")
 product = _register_object_type("Product")
 product_category = _register_object_type("ProductCategory")
@@ -256,6 +258,11 @@ def resolve_shipments(_, info):
             | (TransferAgreement.target_organisation == user_organisation_id)
         )
     )
+
+
+@query.field("metrics")
+def resolve_metrics(*_):
+    return {}
 
 
 @beneficiary.field("tokens")
@@ -498,6 +505,11 @@ def resolve_location_boxes(
     return load_into_page(
         Box, filter_condition, selection=selection, pagination_input=pagination_input
     )
+
+
+@metrics.field("numberOfFamiliesServed")
+def resolve_metrics_number_of_families_served(metrics_obj, _):
+    return compute_number_of_families_served()
 
 
 @organisation.field("bases")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -66,6 +66,7 @@ product = _register_object_type("Product")
 product_category = _register_object_type("ProductCategory")
 qr_code = _register_object_type("QrCode")
 shipment = _register_object_type("Shipment")
+shipment_detail = _register_object_type("ShipmentDetail")
 transfer_agreement = _register_object_type("TransferAgreement")
 user = _register_object_type("User")
 
@@ -568,6 +569,30 @@ def resolve_shipment_source_base(shipment_obj, info):
 def resolve_shipment_target_base(shipment_obj, info):
     authorize(permission="base:read")
     return shipment_obj.target_base
+
+
+@shipment_detail.field("sourceProduct")
+def resolve_shipment_detail_source_product(detail_obj, info):
+    authorize(permission="product:read")
+    return detail_obj.source_product
+
+
+@shipment_detail.field("targetProduct")
+def resolve_shipment_detail_target_product(detail_obj, info):
+    authorize(permission="product:read")
+    return detail_obj.target_product
+
+
+@shipment_detail.field("sourceLocation")
+def resolve_shipment_detail_source_location(detail_obj, info):
+    authorize(permission="location:read")
+    return detail_obj.source_location
+
+
+@shipment_detail.field("targetLocation")
+def resolve_shipment_detail_target_location(detail_obj, info):
+    authorize(permission="location:read")
+    return detail_obj.target_location
 
 
 @transfer_agreement.field("sourceBases")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -126,15 +126,17 @@ def resolve_qr_exists(_, info, qr_code):
 
 
 @query.field("qrCode")
+@box.field("qrCode")
 @convert_kwargs_to_snake_case
-def resolve_qr_code(_, info, qr_code):
+def resolve_qr_code(obj, info, qr_code=None):
     authorize(permission="qr:read")
-    return QrCode.get(QrCode.code == qr_code)
+    return obj.qr_code if qr_code is None else QrCode.get(QrCode.code == qr_code)
 
 
 @query.field("product")
-def resolve_product(_, info, id):
-    product = Product.get_by_id(id)
+@box.field("product")
+def resolve_product(obj, info, id=None):
+    product = obj.product if id is None else Product.get_by_id(id)
     authorize(permission="product:read", base_id=product.base_id)
     return product
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -44,6 +44,7 @@ from ..models.definitions.transfer_agreement import TransferAgreement
 from ..models.definitions.user import User
 from ..models.definitions.x_beneficiary_language import XBeneficiaryLanguage
 from ..models.metrics import (
+    compute_moved_stock_overview,
     compute_number_of_families_served,
     compute_number_of_sales,
     compute_stock_overview,
@@ -528,6 +529,11 @@ def resolve_metrics_number_of_sales(*_, after=None):
 @metrics.field("stockOverview")
 def resolve_metrics_stock_overview(*_):
     return compute_stock_overview(organisation_id=g.user["organisation_id"])
+
+
+@metrics.field("movedStockOverview")
+def resolve_metrics_moved_stock_overview(*_):
+    return compute_moved_stock_overview(organisation_id=g.user["organisation_id"])
 
 
 @organisation.field("bases")

--- a/back/boxtribute_server/graph_ql/schema.py
+++ b/back/boxtribute_server/graph_ql/schema.py
@@ -1,15 +1,27 @@
 from ariadne import make_executable_schema, snake_case_fallback_resolvers
 
-from .definitions import definitions
+from .definitions import definitions, query_api_definitions
 from .enums import enum_types
 from .resolvers import mutation, object_types, query
 from .scalars import date_scalar, datetime_scalar
 
-schema = make_executable_schema(
+full_api_schema = make_executable_schema(
     definitions,
     [
         query,
         mutation,
+        date_scalar,
+        datetime_scalar,
+        *object_types,
+        *enum_types,
+    ],
+    snake_case_fallback_resolvers,
+)
+
+query_api_schema = make_executable_schema(
+    query_api_definitions,
+    [
+        query,
         date_scalar,
         datetime_scalar,
         *object_types,

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -350,7 +350,7 @@ type TransferAgreement {
   validUntil: Datetime
   comment: String
   " List of all bases of the source organisation included in the agreement "
-  sourceBases: [Base!]!
+  sourceBases: [Base!]
   " List of all bases of the target organisation included in the agreement "
   targetBases: [Base!]
   shipments: [Shipment!]!

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -10,7 +10,7 @@ type Box {
   location: Location
   " The number of items the box contains. "
   items: Int!
-  product: Product!
+  product: Product
   # A size from a size range, consider making this enum
   size: String
   state: BoxState!

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -411,4 +411,10 @@ enum ShipmentState {
 type Metrics {
   numberOfFamiliesServed(after: Date): Int
   numberOfSales(after: Date): Int
+  stockOverview: StockOverview
+}
+
+type StockOverview {
+  numberOfBoxes: Int
+  numberOfItems: Int
 }

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -409,5 +409,5 @@ enum ShipmentState {
 }
 
 type Metrics {
-  numberOfFamiliesServed: Int
+  numberOfFamiliesServed(after: Date): Int
 }

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -412,9 +412,11 @@ type Metrics {
   numberOfFamiliesServed(after: Date): Int
   numberOfSales(after: Date): Int
   stockOverview: StockOverview
+  movedStockOverview: [StockOverview]
 }
 
 type StockOverview {
+  productCategoryName: String
   numberOfBoxes: Int
   numberOfItems: Int
 }

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -410,4 +410,5 @@ enum ShipmentState {
 
 type Metrics {
   numberOfFamiliesServed(after: Date): Int
+  numberOfSales(after: Date): Int
 }

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -407,3 +407,7 @@ enum ShipmentState {
   Canceled
   Lost
 }
+
+type Metrics {
+  numberOfFamiliesServed: Int
+}

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -43,7 +43,7 @@ type Product {
   sizeRange: SizeRange!
   " List of sizes for the product. "
   sizes: [String!]!
-  base: Base!
+  base: Base
   price: Float
   gender: ProductGender
   createdBy: User
@@ -118,7 +118,7 @@ The location is part of a specific [`Base`]({{Types.Base}}).
 """
 type Location {
   id: ID!
-  base: Base!
+  base: Base
   name: String
   isShop: Boolean!
   " List of all the [`Boxes`]({{Types.Box}}) in this location "
@@ -203,7 +203,7 @@ type Beneficiary {
   " If dateOfBirth is not set, age will be null. "
   age: Int
   comment: String
-  base: Base!
+  base: Base
   " All members of a family have the same group identifier "
   groupIdentifier: String!
   gender: HumanGender

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -375,9 +375,9 @@ type Shipment {
 
 type ShipmentDetail {
   id: ID!
-  sourceProduct: Product!
+  sourceProduct: Product
   targetProduct: Product
-  sourceLocation: Location!
+  sourceLocation: Location
   targetLocation: Location
   box: Box!
   shipment: Shipment!

--- a/back/boxtribute_server/models/metrics.py
+++ b/back/boxtribute_server/models/metrics.py
@@ -1,5 +1,28 @@
 """Computation of various metrics"""
+from datetime import date
+
+from peewee import JOIN
+
+from .definitions.base import Base
+from .definitions.beneficiary import Beneficiary
+from .definitions.transaction import Transaction
 
 
-def compute_number_of_families_served():
-    return 1
+def compute_number_of_families_served(*, organisation_id, after):
+    after = after or date.today()
+    return (
+        Beneficiary.select()
+        .join(Base)
+        .where(
+            (Base.organisation == organisation_id)
+            & (
+                Beneficiary.id
+                << (
+                    Beneficiary.select()
+                    .join(Transaction, JOIN.LEFT_OUTER)
+                    .where((Transaction.created_on > after) & (Transaction.count > 0))
+                ).distinct()
+            )
+        )
+        .count()
+    )

--- a/back/boxtribute_server/models/metrics.py
+++ b/back/boxtribute_server/models/metrics.py
@@ -1,7 +1,7 @@
 """Computation of various metrics"""
 from datetime import date
 
-from peewee import JOIN
+from peewee import JOIN, fn
 
 from .definitions.base import Base
 from .definitions.beneficiary import Beneficiary
@@ -25,4 +25,18 @@ def compute_number_of_families_served(*, organisation_id, after):
             )
         )
         .count()
+    )
+
+
+def compute_number_of_sales(*, organisation_id, after):
+    after = after or date.today()
+    return (
+        Transaction.select(fn.sum(Transaction.count))
+        .join(Beneficiary)
+        .join(Base)
+        .where(
+            (Transaction.created_on > after) & (Base.organisation == organisation_id)
+        )
+        .scalar()  # returns None if no Transactions selected
+        or 0
     )

--- a/back/boxtribute_server/models/metrics.py
+++ b/back/boxtribute_server/models/metrics.py
@@ -1,0 +1,5 @@
+"""Computation of various metrics"""
+
+
+def compute_number_of_families_served():
+    return 1

--- a/back/boxtribute_server/models/metrics.py
+++ b/back/boxtribute_server/models/metrics.py
@@ -5,6 +5,8 @@ from peewee import JOIN, fn
 
 from .definitions.base import Base
 from .definitions.beneficiary import Beneficiary
+from .definitions.box import Box
+from .definitions.location import Location
 from .definitions.transaction import Transaction
 
 
@@ -40,3 +42,23 @@ def compute_number_of_sales(*, organisation_id, after):
         .scalar()  # returns None if no Transactions selected
         or 0
     )
+
+
+def compute_stock_overview(*, organisation_id):
+    overview = (
+        Box.select(
+            fn.sum(Box.items).alias("number_of_items"),
+            fn.Count(Box.id).alias("number_of_boxes"),
+        )
+        .join(Location)
+        .join(Base)
+        .where(
+            (Base.organisation == organisation_id)
+            & (Location.visible == 1)
+            & (Location.is_lost != 1)
+            & (Location.is_scrap != 1)
+            & (Location.is_donated != 1)
+        )
+        .get()
+    )
+    return {n: getattr(overview, n) for n in ["number_of_boxes", "number_of_items"]}

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -110,8 +110,10 @@ def create_jwt_payload(
             f"{base_prefix}/qr:create",
             f"{base_prefix}/stock:write",
             f"{base_prefix}/transaction:write",
-            "shipment:write",
-            "transfer_agreement:write",
+            "shipment:create",
+            "shipment:edit",
+            "transfer_agreement:create",
+            "transfer_agreement:edit",
         ]
     else:
         payload[f"{JWT_CLAIM_PREFIX}/permissions"] = permissions

--- a/back/test/conftest.py
+++ b/back/test/conftest.py
@@ -19,7 +19,7 @@ from boxtribute_server.db import create_db_interface, db
 
 # Imports fixtures into tests
 from data import *  # noqa: F401,F403
-from data import MODELS, setup_models
+from data import MODELS, setup_box_transfer_models, setup_models
 
 MYSQL_CONNECTION_PARAMETERS = dict(
     # Fixtures require local MySQL server on port 3306 in CircleCI / 32000 on dev
@@ -125,6 +125,10 @@ def dropapp_dev_client():
 
     db.init_app(app)
     with db.database.bind_ctx(MODELS):
+        db.database.create_tables(MODELS)
+        models = setup_box_transfer_models()
+        db.close_db(None)
         with app.app_context():
             yield app.test_client()
+        db.database.drop_tables(models)
     db.close_db(None)

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -139,5 +139,27 @@ def setup_models():
         module.create()
 
 
+def setup_box_transfer_models():
+    """Like `setup_models()` above but only for models related to box-transfer (not
+    present in production database dump). Return relevant model classes.
+    """
+    models = []
+    for module_name in [
+        "transfer_agreement",
+        "shipment",
+        "transfer_agreement_detail",
+        "shipment_detail",
+    ]:
+        module = importlib.import_module(f"data.{module_name}")
+        module.create()
+
+        module = importlib.import_module(
+            f"boxtribute_server.models.definitions.{module_name}"
+        )
+        model_name = "".join(p.capitalize() for p in module_name.split("_"))
+        models.append(getattr(module, model_name))
+    return models
+
+
 # List of all Models in the database, cf. https://stackoverflow.com/a/43820902/3865876
 MODELS = db.Model.__subclasses__()

--- a/back/test/endpoint_tests/test_metrics.py
+++ b/back/test/endpoint_tests/test_metrics.py
@@ -34,3 +34,17 @@ def test_metrics_query(read_only_client, default_transaction, default_boxes):
             "numberOfItems": sum(b["items"] for b in boxes),
         }
     }
+
+    query = """query { metrics { movedStockOverview {
+                productCategoryName numberOfBoxes numberOfItems } } }"""
+    response = assert_successful_request(read_only_client, query, field="metrics")
+    boxes = default_boxes[1:]  # only boxes managed by client's organisation
+    assert response == {
+        "movedStockOverview": [
+            {
+                "productCategoryName": "Underwear / Nightwear",
+                "numberOfBoxes": len(boxes),
+                "numberOfItems": sum(b["items"] for b in boxes),
+            }
+        ]
+    }

--- a/back/test/endpoint_tests/test_metrics.py
+++ b/back/test/endpoint_tests/test_metrics.py
@@ -3,7 +3,7 @@ from datetime import date
 from utils import assert_successful_request
 
 
-def test_metrics_query(read_only_client):
+def test_metrics_query(read_only_client, default_transaction):
     query = "query { metrics { numberOfFamiliesServed } }"
     response = assert_successful_request(read_only_client, query, field="metrics")
     assert response == {"numberOfFamiliesServed": 1}
@@ -14,3 +14,13 @@ def test_metrics_query(read_only_client):
                 numberOfFamiliesServed(after: "{after}") }} }}"""
     response = assert_successful_request(read_only_client, query, field="metrics")
     assert response == {"numberOfFamiliesServed": 0}
+
+    query = "query { metrics { numberOfSales } }"
+    response = assert_successful_request(read_only_client, query, field="metrics")
+    assert response == {"numberOfSales": default_transaction["count"]}
+
+    # Expect no transactions to have been performed in the future
+    after = f"{date.today().year + 1}-01-01"
+    query = f"""query {{ metrics {{ numberOfSales(after: "{after}") }} }}"""
+    response = assert_successful_request(read_only_client, query, field="metrics")
+    assert response == {"numberOfSales": 0}

--- a/back/test/endpoint_tests/test_metrics.py
+++ b/back/test/endpoint_tests/test_metrics.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from utils import assert_successful_request
 
 
@@ -5,3 +7,10 @@ def test_metrics_query(read_only_client):
     query = "query { metrics { numberOfFamiliesServed } }"
     response = assert_successful_request(read_only_client, query, field="metrics")
     assert response == {"numberOfFamiliesServed": 1}
+
+    # Expect no transactions to have been performed in the future
+    after = f"{date.today().year + 1}-01-01"
+    query = f"""query {{ metrics {{
+                numberOfFamiliesServed(after: "{after}") }} }}"""
+    response = assert_successful_request(read_only_client, query, field="metrics")
+    assert response == {"numberOfFamiliesServed": 0}

--- a/back/test/endpoint_tests/test_metrics.py
+++ b/back/test/endpoint_tests/test_metrics.py
@@ -1,0 +1,7 @@
+from utils import assert_successful_request
+
+
+def test_metrics_query(read_only_client):
+    query = "query { metrics { numberOfFamiliesServed } }"
+    response = assert_successful_request(read_only_client, query, field="metrics")
+    assert response == {"numberOfFamiliesServed": 1}

--- a/back/test/endpoint_tests/test_metrics.py
+++ b/back/test/endpoint_tests/test_metrics.py
@@ -3,7 +3,7 @@ from datetime import date
 from utils import assert_successful_request
 
 
-def test_metrics_query(read_only_client, default_transaction):
+def test_metrics_query(read_only_client, default_transaction, default_boxes):
     query = "query { metrics { numberOfFamiliesServed } }"
     response = assert_successful_request(read_only_client, query, field="metrics")
     assert response == {"numberOfFamiliesServed": 1}
@@ -24,3 +24,13 @@ def test_metrics_query(read_only_client, default_transaction):
     query = f"""query {{ metrics {{ numberOfSales(after: "{after}") }} }}"""
     response = assert_successful_request(read_only_client, query, field="metrics")
     assert response == {"numberOfSales": 0}
+
+    query = "query { metrics { stockOverview { numberOfBoxes numberOfItems } } }"
+    response = assert_successful_request(read_only_client, query, field="metrics")
+    boxes = default_boxes[1:]  # only boxes managed by client's organisation
+    assert response == {
+        "stockOverview": {
+            "numberOfBoxes": len(boxes),
+            "numberOfItems": sum(b["items"] for b in boxes),
+        }
+    }

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -192,6 +192,26 @@ def test_invalid_permission_for_base_locations(read_only_client, mocker):
     assert_forbidden_request(read_only_client, query, value={"locations": None})
 
 
+@pytest.mark.parametrize("field", ["sourceBases", "targetBases"])
+def test_invalid_permission_for_agreement_bases(read_only_client, mocker, field):
+    # verify missing base:read permission
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        permissions=["transfer_agreement:read"]
+    )
+    query = f"query {{ transferAgreement(id: 1) {{ {field} {{ id }} }} }}"
+    assert_forbidden_request(read_only_client, query, value={field: None})
+
+
+@pytest.mark.parametrize("field", ["sourceBase", "targetBase"])
+def test_invalid_permission_for_shipment_base(read_only_client, mocker, field):
+    # verify missing base:read permission
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        permissions=["shipment:read"]
+    )
+    query = f"query {{ shipment(id: 1) {{ {field} {{ id }} }} }}"
+    assert_forbidden_request(read_only_client, query, value={field: None})
+
+
 @pytest.mark.parametrize("field", ["location", "product", "qrCode"])
 def test_invalid_permission_for_box_field(read_only_client, mocker, default_box, field):
     # verify missing field:read permission

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -223,6 +223,23 @@ def test_invalid_permission_for_box_field(read_only_client, mocker, default_box,
     assert_forbidden_request(read_only_client, query, value={field: None})
 
 
+@pytest.mark.parametrize(
+    "field", ["sourceLocation", "targetLocation", "sourceProduct", "targetProduct"]
+)
+def test_invalid_permission_for_shipment_details_field(
+    read_only_client, mocker, default_box, field
+):
+    # verify missing field:read permission
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        permissions=["shipment:read"]
+    )
+    query = f"""query {{ shipment(id: 1) {{ details
+                {{ {field} {{ id }} }} }} }}"""
+    assert_forbidden_request(
+        read_only_client, query, value={"details": [{field: None}]}
+    )
+
+
 @pytest.mark.parametrize("resource", ["location", "product", "beneficiary"])
 def test_invalid_permission_for_resource_base(
     read_only_client, mocker, default_product, resource

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -192,14 +192,15 @@ def test_invalid_permission_for_base_locations(read_only_client, mocker):
     assert_forbidden_request(read_only_client, query, value={"locations": None})
 
 
-def test_invalid_permission_for_box_location(read_only_client, mocker, default_box):
-    # verify missing location:read permission
+@pytest.mark.parametrize("field", ["location", "product", "qrCode"])
+def test_invalid_permission_for_box_field(read_only_client, mocker, default_box, field):
+    # verify missing field:read permission
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         permissions=["stock:read"]
     )
     query = f"""query {{ box(labelIdentifier: "{default_box["label_identifier"]}")
-                {{ location {{ id }} }} }}"""
-    assert_forbidden_request(read_only_client, query, value={"location": None})
+                {{ {field} {{ id }} }} }}"""
+    assert_forbidden_request(read_only_client, query, value={field: None})
 
 
 @pytest.mark.parametrize(

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -203,6 +203,19 @@ def test_invalid_permission_for_box_field(read_only_client, mocker, default_box,
     assert_forbidden_request(read_only_client, query, value={field: None})
 
 
+@pytest.mark.parametrize("resource", ["location", "product", "beneficiary"])
+def test_invalid_permission_for_resource_base(
+    read_only_client, mocker, default_product, resource
+):
+    # verify missing base:read permission
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        permissions=[f"{resource}:read"]
+    )
+    query = f"""query {{ {resource}(id: 1)
+                {{ base {{ id }} }} }}"""
+    assert_forbidden_request(read_only_client, query, value={"base": None})
+
+
 @pytest.mark.parametrize(
     "method",
     ["read", "write", "create", "edit"],

--- a/back/test/endpoint_tests/test_simple.py
+++ b/back/test/endpoint_tests/test_simple.py
@@ -1,8 +1,17 @@
-def test_private_endpoint(read_only_client):
-    """example test for private endpoint"""
-    response_data = read_only_client.get("/api/private")
-    assert response_data.status_code == 200
+import pytest
+
+
+@pytest.mark.parametrize("endpoint", ["api", "graphql"])
+def test_private_endpoint(read_only_client, endpoint):
+    response = read_only_client.get(f"/{endpoint}")
+    assert response.status_code == 200
+    assert "GraphQL Playground" in response.data.decode()
+
+
+def test_public_endpoint(read_only_client):
+    response = read_only_client.get("/public")
+    assert response.status_code == 200
     assert (
-        "Hello from a private endpoint! You need to be authenticated to see this."
-        == response_data.json["message"]
+        "Hello from a public endpoint! You don't need to be authenticated to see this."
+        == response.json["message"]
     )

--- a/back/test/integration_tests/test_operations.py
+++ b/back/test/integration_tests/test_operations.py
@@ -1,15 +1,20 @@
+import pytest
 from utils import assert_successful_request
 
 
-def test_queries(auth0_client):
+@pytest.mark.parametrize("endpoint", ["api", "graphql"])
+def test_queries(auth0_client, endpoint):
+    def _assert_successful_request(*args, **kwargs):
+        return assert_successful_request(*args, **kwargs, endpoint=endpoint)
+
     query = """query BoxIdAndItems {
                 qrCode(qrCode: "03a6ad3e5a8677fe350f9849a208552") { box { id } }
             }"""
-    queried_box = assert_successful_request(auth0_client, query)["box"]
+    queried_box = _assert_successful_request(auth0_client, query)["box"]
     assert queried_box == {"id": "67"}
 
     query = """query { box(labelIdentifier: "728544") { state } }"""
-    queried_box = assert_successful_request(auth0_client, query)
+    queried_box = _assert_successful_request(auth0_client, query)
     assert queried_box == {"state": "Donated"}
 
     for resource in [
@@ -22,12 +27,12 @@ def test_queries(auth0_client):
         "shipments",
     ]:
         query = f"query {{ {resource} {{ id }} }}"
-        response = assert_successful_request(auth0_client, query, field=resource)
+        response = _assert_successful_request(auth0_client, query, field=resource)
         assert len(response) > 0
 
     for resource in ["beneficiaries", "products"]:
         query = f"query {{ {resource} {{ elements {{ id }} }} }}"
-        response = assert_successful_request(auth0_client, query, field=resource)
+        response = _assert_successful_request(auth0_client, query, field=resource)
         assert len(response) > 0
 
 

--- a/back/test/utils.py
+++ b/back/test/utils.py
@@ -59,12 +59,12 @@ def assert_internal_server_error(client, query, **kwargs):
     )
 
 
-def assert_successful_request(client, query, field=None):
+def assert_successful_request(client, query, field=None, endpoint="graphql"):
     """Send GraphQL request with query using given client.
     Assert response HTTP code 200, and return main response JSON data field.
     """
     data = {"query": query}
-    response = client.post("/graphql", json=data)
+    response = client.post(f"/{endpoint}", json=data)
     assert response.status_code == 200
 
     field = field or _extract_field(query)

--- a/docs/graphql-api/query-api-config.yml
+++ b/docs/graphql-api/query-api-config.yml
@@ -256,7 +256,9 @@ info:
       url: https://www.boxtribute.org
     # Can be a Title (for the Nav panel) + description (for the Content panel)
     - title: Login to boxtribute web app
-      url: https://www.api.boxtribute.org
+      url: https://www.app.boxtribute.org
+    - title: Query API URL
+      url: https://www.boxtribute.org/api
     - title: Authentication and Authorization
       description: Lorem ipsum explain how to authenticate, and what clients are authorized for
 


### PR DESCRIPTION
This PR brings a `metrics` GraphQL query and type. The supported fields correspond to the 2nd-5th SQL queries listed [here](https://docs.google.com/document/d/10GFOZaWMKJCD4PAt6WSvIiBCWI09319CdLDU1PjZjWk/edit).
- computation of served families incl. filtering
- computation of sales incl. filtering
- computation of stock overview
- computation of moved stock overview

The product list can be fetched via the GraphQL API in a straightforward way.

@aerinsol
1. I settled for the name `metrics` instead of `statistics`. Imho a statistical value is e.g. an average or a variance but not a counted number. Any objections?
1. What is the difference between the first and the second query in the document?
1. When computing the number of sales, should we add `Transaction.tokens > 0` to avoid counting the transactions that actually represent granted tokens?
1. All queries return info for the current client's organisation. Should the god user be capable of fetching data for any organisation?
1. I compared the SQL queries generated by peewee with the ones from the document. They match in functionality I reckon. I still have to perform a sanity comparison by running the SQL queries directly on the production database.

As usual let me know about any remarks :)
