### PR TITLE
Repair gcloud deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - save_cache:
           key: flask-deps-{{ checksum "requirements.txt" }}
           paths:
-            - $(pyenv root)/versions/3.8.12/envs/env
+            - /home/circleci/.pyenv/versions/3.8.12/envs/env
       # save build to a CircleCI workspace
       - persist_to_workspace:
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ jobs:
           command: |
             pyenv root
             python --version
-            pyenv virtualenv env
             pyenv virtualenvs
+            pyenv virtualenv --force env
             source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             pip install -e . -r requirements.txt
       # Cache the installed packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      # Restore cached dependencies
+      - restore_cache:
+          key: webapp-deps-{{ checksum "requirements.txt" }}
       - run:
           name: create the python virtual environment and install non-cached dependencies
           command: |
@@ -256,7 +259,7 @@ workflows:
             - build-and-test-react
           filters:
             branches:
-              only: /^.*-gcloud-deploy/
+              only: master
 
       # deploy to demo
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      # Restore cached dependencies
-      - restore_cache:
-          key: flask-deps-{{ checksum "requirements.txt" }}
       - run:
           name: create the python virtual environment and install non-cached dependencies
           command: |
@@ -36,7 +33,7 @@ jobs:
       - save_cache:
           key: flask-deps-{{ checksum "requirements.txt" }}
           paths:
-            - env
+            - $(pyenv root)/versions/3.8.12/envs/env
       # save build to a CircleCI workspace
       - persist_to_workspace:
           root: ~/
@@ -259,7 +256,7 @@ workflows:
             - build-and-test-react
           filters:
             branches:
-              only: master
+              only: /^.*-gcloud-deploy/
 
       # deploy to demo
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,27 +117,22 @@ jobs:
       # Attach workspace from build
       - attach_workspace:
           at: ~/
-      # - restore_cache:
-      #     key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
+      - restore_cache:
+          key: webapp-dev-deps-{{ checksum "requirements-dev.txt" }}-{{ checksum "../.pre-commit-config.yaml" }}
       - run:
           name: install dev dependencies for linting and testing
           command: |
             source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             pip install -r requirements-dev.txt
-      # - save_cache:
-      #     key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
-      #     paths:
-      #       - env
-      - restore_cache:
-          key: precommit-deps-{{ checksum "../.pre-commit-config.yaml" }}
       - run:
           name: run style checks on Python files
           command: |
             source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
             pre-commit run --files **/*.py
       - save_cache:
-          key: precommit-deps-{{ checksum "../.pre-commit-config.yaml" }}
+          key: webapp-dev-deps-{{ checksum "requirements-dev.txt" }}-{{ checksum "../.pre-commit-config.yaml" }}
           paths:
+            - /home/circleci/.pyenv/versions/3.8.12/envs/env
             - ~/.cache/pre-commit
       # https://circleci.com/docs/2.0/postgres-config/#example-mysql-project
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             pip install -e . -r requirements.txt
       # Cache the installed packages
       - save_cache:
-          key: flask-deps-{{ checksum "requirements.txt" }}
+          key: webapp-deps-{{ checksum "requirements.txt" }}
           paths:
             - /home/circleci/.pyenv/versions/3.8.12/envs/env
       # save build to a CircleCI workspace


### PR DESCRIPTION
Previously, the deploy-job failed when merging to master ([example](https://app.circleci.com/pipelines/github/boxwise/boxtribute/850/workflows/02e09815-0d3b-4122-bdd2-842f50eaf215/jobs/3606)). This was due to an outdated cache path for the Python virtualenv. I updated the path and also made caching in the test-flask job more efficient.
I tested the successful deploy by triggering a deploy from this branch (hardcoding the `filters.branches` field).
