### PR TITLE
Fix Auth0 configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,8 +200,9 @@ jobs:
           command: |
             echo "
               AUTH0_DOMAIN=${AUTH0_DOMAIN}
-              AUTH0_CLIENT_ID=${AUTH0_CLIENT_ID}
-              AUTH0_CLIENT_SECRET=${AUTH0_CLIENT_SECRET}
+              AUTH0_AUDIENCE=${AUTH0_AUDIENCE}
+              AUTH0_CLIENT_ID=${QUERY_API_AUTH0_CLIENT_ID}
+              AUTH0_CLIENT_SECRET=${QUERY_API_AUTH0_CLIENT_SECRET}
               MYSQL_HOST=127.0.0.1
               MYSQL_USER=${DB_NAME}
               MYSQL_PASSWORD=${DB_PASS}
@@ -210,7 +211,6 @@ jobs:
               MYSQL_SOCKET=${DB_SOCKET}
               FLASK_URL_PREFIX=/v2
               " > .env
-            if [ ! -z ${AUTH0_AUDIENCE+x} ]; then echo "AUTH0_AUDIENCE=${AUTH0_AUDIENCE}" >> .env; fi
       - run:
           name: Generate GAE app.yaml file
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*
 .env
 .envrc
 

--- a/back/README.md
+++ b/back/README.md
@@ -74,13 +74,13 @@ Install the dependencies of the app in the activated virtual environment
 
     pip install -U -e back -r back/requirements-dev.txt
 
-For the integration tests authentication information is fetched from the [Auth0](https://auth0.com) website. Log in and select `Applications` -> `Applications` from the side bar menu. Select `boxtribute-dev-api`. Copy the `Client Secret` into the `.env` file as the `AUTH0_CLIENT_SECRET_TEST` variables.
+For the integration tests authentication information is fetched from the [Auth0](https://auth0.com) website. Log in and select `Applications` -> `Applications` from the side bar menu. Select `boxtribute-dev-api`. Copy the `Client Secret` into the `.env` file as the `TEST_AUTH0_CLIENT_SECRET` variables.
 
 We're subject to a rate limit for tokens from Auth0. In order to avoid fetching tokens over and over again for every test run, do the following once before you start your development session:
 
 1. Activate the virtual environment
 1. Run `./fetch_token --test`
-1. Paste the displayed token as `AUTH0_TEST_JWT=` into the `.env` file
+1. Paste the displayed token as `TEST_AUTH0_JWT=` into the `.env` file
 
 After 24h the token expires, so you have to repeat the procedure.
 

--- a/back/README.md
+++ b/back/README.md
@@ -266,7 +266,7 @@ You can experiment with the API in the GraphQL playground.
 1. Set `export FLASK_ENV=development`
 1. Start the required services by `docker-compose up webapp db`
 1. Open `localhost:5005/graphql` (or `/` for the query-only API)
-1. Simulate being a valid, logged-in user by fetching an authorization token (internally the variables of the `.env` file are used, use `--help` for more info): `./fetch_token --test`
+1. Simulate being a valid, logged-in user by fetching an authorization token: `./fetch_token --test`
 1. Copy the displayed token
 1. Insert the access token in the following format on the playground in the section on the bottom left of the playground called HTTP Headers.
 

--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -126,11 +126,11 @@ def requires_auth(f):
     def decorated(*args, **kwargs):
         token = get_token_from_auth_header(get_auth_string_from_header())
         domain = os.environ["AUTH0_DOMAIN"]
-        # Auth0 demo and production tenants have no audience, fall back to client ID
-        audience = os.getenv("AUTH0_AUDIENCE") or os.environ["AUTH0_CLIENT_ID"]
-        public_key = get_public_key(domain)
         payload = decode_jwt(
-            token=token, public_key=public_key, domain=domain, audience=audience
+            token=token,
+            public_key=get_public_key(domain),
+            domain=domain,
+            audience=os.environ["AUTH0_AUDIENCE"],
         )
 
         # The user's organisation ID is listed in the JWT under the custom claim (added
@@ -170,13 +170,10 @@ def request_jwt(*, client_id, client_secret, audience, domain, username, passwor
         "client_id": client_id,
         "client_secret": client_secret,
         "grant_type": "password",
+        "audience": audience,
         "username": username,
         "password": password,
     }
-    if audience is not None:  # pragma: no cover
-        # Only staging and dev tenants have an audience set
-        parameters["audience"] = audience
-
     headers = {"Content-Type": "application/json"}
     data = json.dumps(parameters).encode("utf-8")
     url = f"https://{domain}/oauth/token"

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -62,7 +62,7 @@ def api_token():
         **request.get_json(),  # must contain username and password
         client_id=os.environ["AUTH0_CLIENT_ID"],
         client_secret=os.environ["AUTH0_CLIENT_SECRET"],
-        audience=os.getenv("AUTH0_AUDIENCE"),
+        audience=os.environ["AUTH0_AUDIENCE"],
         domain=os.environ["AUTH0_DOMAIN"],
     )
     status_code = 200 if success else 400

--- a/back/scripts/load-test.js
+++ b/back/scripts/load-test.js
@@ -6,7 +6,7 @@
 //    FLASK_ENV=production docker-compose up --build webapp
 // 3. Fetch a JWT for authorization
 //    ./fetch_token
-// 4. Store the value of `access_token` as `AUTH0_TEST_JWT` in the .env file
+// 4. Store the value of `access_token` as `TEST_AUTH0_JWT` in the .env file
 // 5. Run the script with effective loading of variables from the .env file
 //    dotenv run k6 run back/scripts/load-test.js
 // 6. Consider k6 options (e.g. number of virtual users via -u)
@@ -20,7 +20,7 @@ const url = "http://0.0.0.0:5000/graphql";
 const params = {
   headers: {
     "Content-Type": "application/json",
-    Authorization: `Bearer ${__ENV.AUTH0_TEST_JWT}`,
+    Authorization: `Bearer ${__ENV.TEST_AUTH0_JWT}`,
   },
 };
 const payload = JSON.stringify({

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -4,6 +4,8 @@ from boxtribute_server.auth import JWT_CLAIM_PREFIX, request_jwt
 
 TEST_AUTH0_DOMAIN = "boxtribute-dev.eu.auth0.com"
 TEST_AUTH0_AUDIENCE = "boxtribute-dev-api"
+TEST_AUTH0_USERNAME = "dev_coordinator@boxaid.org"
+TEST_AUTH0_PASSWORD = "Browser_tests"
 
 
 def memoize(function):
@@ -24,9 +26,7 @@ def memoize(function):
 
 
 def get_user_token():
-    """Grabs a user token for Auth0
-    Data structure as described here
-    https://manage.auth0.com/dashboard/eu/boxtribute-dev/apis/5ef3760527b0da00215e6209/test"""  # line too long # noqa: E501
+    """Grabs a test user access token for Auth0."""
     token = os.getenv("TEST_AUTH0_JWT")
     if token is not None:
         return token
@@ -36,8 +36,8 @@ def get_user_token():
         client_secret=os.getenv("TEST_AUTH0_CLIENT_SECRET"),
         audience=TEST_AUTH0_AUDIENCE,
         domain=TEST_AUTH0_DOMAIN,
-        username=os.getenv("AUTH0_USERNAME"),
-        password=os.getenv("AUTH0_PASSWORD"),
+        username=TEST_AUTH0_USERNAME,
+        password=TEST_AUTH0_PASSWORD,
     )
     return response["access_token"]
 

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -27,13 +27,13 @@ def get_user_token():
     """Grabs a user token for Auth0
     Data structure as described here
     https://manage.auth0.com/dashboard/eu/boxtribute-dev/apis/5ef3760527b0da00215e6209/test"""  # line too long # noqa: E501
-    token = os.getenv("AUTH0_TEST_JWT")
+    token = os.getenv("TEST_AUTH0_JWT")
     if token is not None:
         return token
 
     success, response = request_jwt(
-        client_id=os.getenv("AUTH0_CLIENT_TEST_ID"),
-        client_secret=os.getenv("AUTH0_CLIENT_SECRET_TEST"),
+        client_id=os.getenv("TEST_AUTH0_CLIENT_ID"),
+        client_secret=os.getenv("TEST_AUTH0_CLIENT_SECRET"),
         audience=TEST_AUTH0_AUDIENCE,
         domain=TEST_AUTH0_DOMAIN,
         username=os.getenv("AUTH0_USERNAME"),

--- a/back/test/integration_tests/test_jwt.py
+++ b/back/test/integration_tests/test_jwt.py
@@ -46,8 +46,8 @@ def test_decode_valid_jwt():
 
 
 def test_request_jwt(dropapp_dev_client, monkeypatch, mocker):
-    monkeypatch.setenv("AUTH0_CLIENT_ID", os.environ["AUTH0_CLIENT_TEST_ID"])
-    monkeypatch.setenv("AUTH0_CLIENT_SECRET", os.environ["AUTH0_CLIENT_SECRET_TEST"])
+    monkeypatch.setenv("AUTH0_CLIENT_ID", os.environ["TEST_AUTH0_CLIENT_ID"])
+    monkeypatch.setenv("AUTH0_CLIENT_SECRET", os.environ["TEST_AUTH0_CLIENT_SECRET"])
     response = dropapp_dev_client.post(
         "/token",
         json={

--- a/back/test/integration_tests/test_jwt.py
+++ b/back/test/integration_tests/test_jwt.py
@@ -6,7 +6,13 @@ import os
 import urllib
 
 import pytest
-from auth import TEST_AUTH0_AUDIENCE, TEST_AUTH0_DOMAIN, get_user_token_string
+from auth import (
+    TEST_AUTH0_AUDIENCE,
+    TEST_AUTH0_DOMAIN,
+    TEST_AUTH0_PASSWORD,
+    TEST_AUTH0_USERNAME,
+    get_user_token_string,
+)
 from boxtribute_server.auth import (
     decode_jwt,
     get_public_key,
@@ -51,8 +57,8 @@ def test_request_jwt(dropapp_dev_client, monkeypatch, mocker):
     response = dropapp_dev_client.post(
         "/token",
         json={
-            "username": os.environ["AUTH0_USERNAME"],
-            "password": os.environ["AUTH0_PASSWORD"],
+            "username": TEST_AUTH0_USERNAME,
+            "password": TEST_AUTH0_PASSWORD,
         },
     )
     assert response.status_code == 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
             PYTHONUNBUFFERED: 1
             AUTH0_DOMAIN: ${AUTH0_DOMAIN:?auth0 config not set in .env file}
             AUTH0_AUDIENCE: ${AUTH0_AUDIENCE:?auth0 config not set in .env file}
-            AUTH0_CLIENT_ID: ${AUTH0_CLIENT_TEST_ID}
-            AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET_TEST}
+            AUTH0_CLIENT_ID: ${TEST_AUTH0_CLIENT_ID}
+            AUTH0_CLIENT_SECRET: ${TEST_AUTH0_CLIENT_SECRET}
             MYSQL_HOST: db
             MYSQL_USER: root
             MYSQL_PASSWORD: dropapp_root

--- a/example.env
+++ b/example.env
@@ -7,5 +7,3 @@ AUTH0_AUDIENCE=boxtribute-dev-api
 # https://app.circleci.com/settings/project/github/boxwise/boxtribute/environment-variables
 TEST_AUTH0_CLIENT_ID=Zksvh5NP42CGN12YhgaYf0Wf2LSAM2Ph
 TEST_AUTH0_CLIENT_SECRET=
-AUTH0_USERNAME=dev_coordinator@boxaid.org
-AUTH0_PASSWORD=Browser_tests

--- a/example.env
+++ b/example.env
@@ -1,8 +1,11 @@
 AUTH0_CLIENT_ID=ni9ZdcoIv3HU10kyc4t1qxOMxjVyxcbS
 AUTH0_DOMAIN=boxtribute-dev.eu.auth0.com
 AUTH0_AUDIENCE=boxtribute-dev-api
+
 # Variables for back-end tests
-AUTH0_CLIENT_TEST_ID=Zksvh5NP42CGN12YhgaYf0Wf2LSAM2Ph
-AUTH0_CLIENT_SECRET_TEST=
+# In CircleCI, these are set on a project-level (instead of a context-level) in
+# https://app.circleci.com/settings/project/github/boxwise/boxtribute/environment-variables
+TEST_AUTH0_CLIENT_ID=Zksvh5NP42CGN12YhgaYf0Wf2LSAM2Ph
+TEST_AUTH0_CLIENT_SECRET=
 AUTH0_USERNAME=dev_coordinator@boxaid.org
 AUTH0_PASSWORD=Browser_tests

--- a/fetch_token
+++ b/fetch_token
@@ -8,7 +8,13 @@ another .env file to load.
 import argparse
 import logging
 import os
+import sys
+from pathlib import Path
 
+SCRIPT_DIRPATH = Path(__file__).resolve().parent
+TEST_DATA_DIRPATH = SCRIPT_DIRPATH / "back" / "test"
+sys.path.insert(0, str(TEST_DATA_DIRPATH))
+from auth import TEST_AUTH0_PASSWORD, TEST_AUTH0_USERNAME
 from boxtribute_server.auth import request_jwt
 from dotenv import load_dotenv
 
@@ -25,7 +31,10 @@ def _parse_cli():
         "-v", "--verbose", action="store_true", help="show env variables"
     )
     parser.add_argument(
-        "-t", "--test", action="store_true", help="fetch JWT for test user"
+        "-t",
+        "--test",
+        action="store_true",
+        help="fetch JWT for test user, ignoring -u and -p options",
     )
     return parser.parse_args()
 
@@ -40,21 +49,28 @@ def main():
         load_dotenv(options.dotenv_filepath, override=True)
 
     for k, v in sorted(os.environ.items()):
-        if k.startswith("AUTH0"):
+        if "AUTH0" in k:
             logger.debug(f"{k}={v}")
 
     parameters = dict(
-        username=options.username or os.environ["AUTH0_USERNAME"],
-        password=options.password or os.environ["AUTH0_PASSWORD"],
         audience=os.environ["AUTH0_AUDIENCE"],
         domain=os.environ["AUTH0_DOMAIN"],
     )
     if options.test:
-        parameters["client_id"] = os.environ["TEST_AUTH0_CLIENT_ID"]
-        parameters["client_secret"] = os.environ["TEST_AUTH0_CLIENT_SECRET"]
+        extras = dict(
+            client_id=os.environ["TEST_AUTH0_CLIENT_ID"],
+            client_secret=os.environ["TEST_AUTH0_CLIENT_SECRET"],
+            username=TEST_AUTH0_USERNAME,
+            password=TEST_AUTH0_PASSWORD,
+        )
     else:
-        parameters["client_id"] = os.environ["AUTH0_CLIENT_ID"]
-        parameters["client_secret"] = os.environ["AUTH0_CLIENT_SECRET"]
+        extras = dict(
+            client_id=os.environ["AUTH0_CLIENT_ID"],
+            client_secret=os.environ["AUTH0_CLIENT_SECRET"],
+            username=options.username or os.environ["AUTH0_USERNAME"],
+            password=options.password or os.environ["AUTH0_PASSWORD"],
+        )
+    parameters.update(extras)
 
     success, result = request_jwt(**parameters)
 

--- a/fetch_token
+++ b/fetch_token
@@ -50,8 +50,8 @@ def main():
         domain=os.environ["AUTH0_DOMAIN"],
     )
     if options.test:
-        parameters["client_id"] = os.environ["AUTH0_CLIENT_TEST_ID"]
-        parameters["client_secret"] = os.environ["AUTH0_CLIENT_SECRET_TEST"]
+        parameters["client_id"] = os.environ["TEST_AUTH0_CLIENT_ID"]
+        parameters["client_secret"] = os.environ["TEST_AUTH0_CLIENT_SECRET"]
     else:
         parameters["client_id"] = os.environ["AUTH0_CLIENT_ID"]
         parameters["client_secret"] = os.environ["AUTH0_CLIENT_SECRET"]


### PR DESCRIPTION
- added dedicated API and application in Auth0
- introduce QUERY_API_* env variables in CircleCI (distinguish from
  those for the webapp backend)

This avoids returning an ID token on the `/token` endpoint. Instead only an access token is returned, and acc. to convention only such a token should be used to convey user authorization information (cf. https://auth0.com/blog/id-token-access-token-what-is-the-difference/)

Successfully tested with `POST /token` and api.boxtribute.org.