### PR TITLE
Docs: update license formatting and ToS

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -177,14 +177,14 @@
 
    APPENDIX: How to apply the Apache License to your work.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
 
    Copyright 2019-2022 Stichting Boxwise
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Here, is a list of intro tutorials for each technologies / frameworks / language
 
 ## License
 
-See the LICENSE file for license rights and limitations (Apache 2.0).
+See the [LICENSE file](./LICENSE.md) for license rights and limitations (Apache 2.0).
 
 ## Sponsors
 

--- a/docs/graphql-api/full-api-config.yml
+++ b/docs/graphql-api/full-api-config.yml
@@ -249,7 +249,7 @@ info:
     url: https://www.boxtribute.org
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: 'https://github.com/boxwise/boxtribute/blob/master/LICENSE.md'
 
   # A non-standard array of items to display in your Introduction Area
   x-introItems:

--- a/docs/graphql-api/full-api-config.yml
+++ b/docs/graphql-api/full-api-config.yml
@@ -242,7 +242,6 @@ info:
   # This is non-standard and optional. If omitted, will use "title". Also only relevant
   # when building non-embedded.
   x-htmlTitle: boxtribute GraphQL API documentation
-  termsOfService: https://www.boxtribute.org
   contact:
     name: boxtribute Support
     email: help@boxtribute.org
@@ -259,6 +258,9 @@ info:
     # Can be a Title (for the Nav panel) + description (for the Content panel)
     - title: Login to boxtribute web app
       url: https://www.app.boxtribute.org
+    - title: Terms of Service
+      description: |
+          In line with the Service Agreement and other related documents as signed with [Boxtribute](https://boxtribute.org) (Stichting Boxwise)
     - title: Authentication and Authorization
       description: Lorem ipsum explain how to authenticate, and what clients are authorized for
 

--- a/docs/graphql-api/full-api-config.yml
+++ b/docs/graphql-api/full-api-config.yml
@@ -242,7 +242,7 @@ info:
   # This is non-standard and optional. If omitted, will use "title". Also only relevant
   # when building non-embedded.
   x-htmlTitle: boxtribute GraphQL API documentation
-  termsOfService: 'https://www.boxtribute.org'
+  termsOfService: https://www.boxtribute.org
   contact:
     name: boxtribute Support
     email: help@boxtribute.org

--- a/docs/graphql-api/query-api-config.yml
+++ b/docs/graphql-api/query-api-config.yml
@@ -252,7 +252,7 @@ info:
     url: https://www.boxtribute.org
   license:
     name: Apache 2.0
-    url: 'https://github.com/boxwise/boxtribute/blob/master/LICENSE'
+    url: 'https://github.com/boxwise/boxtribute/blob/master/LICENSE.md'
 
   # A non-standard array of items to display in your Introduction Area
   x-introItems:

--- a/docs/graphql-api/query-api-config.yml
+++ b/docs/graphql-api/query-api-config.yml
@@ -245,7 +245,6 @@ info:
   # This is non-standard and optional. If omitted, will use "title". Also only relevant
   # when building non-embedded.
   x-htmlTitle: boxtribute GraphQL API documentation
-  termsOfService: https://www.boxtribute.org
   contact:
     name: boxtribute Support
     email: help@boxtribute.org
@@ -264,6 +263,9 @@ info:
       url: https://www.app.boxtribute.org
     - title: Query API
       url: https://api.boxtribute.org
+    - title: Terms of Service
+      description: |
+          In line with the Service Agreement and other related documents as signed with [Boxtribute](https://boxtribute.org) (Stichting Boxwise)
     - title: Authentication and Authorization
       description: |
           For using the API, you have to authenticate, and then are given a unique token holding your user information and permissions. You have to pass the token along when requesting data from the API.

--- a/docs/graphql-api/query-api-config.yml
+++ b/docs/graphql-api/query-api-config.yml
@@ -245,7 +245,7 @@ info:
   # This is non-standard and optional. If omitted, will use "title". Also only relevant
   # when building non-embedded.
   x-htmlTitle: boxtribute GraphQL API documentation
-  termsOfService: In line with the Service Agreement, and other related documents as signed with Boxtribute (Stichting Boxwise)
+  termsOfService: https://www.boxtribute.org
   contact:
     name: boxtribute Support
     email: help@boxtribute.org


### PR DESCRIPTION
License is now rendered as markdown: https://github.com/boxwise/boxtribute/blob/docs/833-update-license-and-tos/LICENSE.md