### PR TITLE
Base switcher

### DIFF
--- a/react/.prettierignore
+++ b/react/.prettierignore
@@ -1,0 +1,2 @@
+src/generated/
+*.d.ts

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,36 +1,63 @@
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import { Route, Routes } from "react-router-dom";
-import { useAuth0, withAuthenticationRequired } from "@auth0/auth0-react";
-import Home from "views/Home";
 import Boxes from "views/boxes/Boxes";
 import Locations from "views/locations/Locations";
 import BTLocation from "views/locations/BTLocation";
 import Layout from "Layout";
+import AutomaticBaseSwitcher from "views/automatic-base-switcher/AutomaticBaseSwitcher";
+import { gql, useLazyQuery } from "@apollo/client";
+import { BasesQuery } from "generated/graphql";
+import { GlobalPreferencesContext } from "GlobalPreferencesProvider";
 
-const AuthenticationProtected = ({ element, ...props }) =>
-  withAuthenticationRequired(element, {
-    onRedirecting: () => <p>Loading ...</p>,
-  })(props);
+const useLoadAndSetAvailableBases = () => {
+  const BASES_QUERY = gql`
+    query Bases {
+      bases {
+        id
+        name
+      }
+    }
+  `;
 
-export default function App() {
-  const { isLoading: auth0Loading } = useAuth0();
+  const [runBaseQuery, { loading, data }] = useLazyQuery<BasesQuery>(BASES_QUERY);
+  const { globalPreferences, dispatch } = useContext(GlobalPreferencesContext);
 
-  if (auth0Loading) {
-    return <p>Loading...</p>;
-  }
+  useEffect(() => {
+    if (globalPreferences.availableBases == null) {
+      runBaseQuery();
+    }
+  }, [runBaseQuery, globalPreferences.availableBases]);
 
+  useEffect(() => {
+    if (!loading && data != null) {
+      const bases = data.bases;
+      dispatch({
+        type: "setAvailableBases",
+        payload: bases,
+      });
+    }
+  }, [data, loading, dispatch]);
+};
+
+const App = () => {
+  useLoadAndSetAvailableBases();
   return (
-    <>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Home />}></Route>
-          <Route path="boxes" element={<AuthenticationProtected element={Boxes} />} />
-          <Route path="locations">
-            <Route index element={<AuthenticationProtected element={Locations} />} />
-            <Route path=":locationId" element={<AuthenticationProtected element={BTLocation} />} />
+    <Routes>
+      <Route path="/">
+        <Route index element={<AutomaticBaseSwitcher />}></Route>
+        <Route path="bases" element={<Layout />}>
+          <Route index element={<AutomaticBaseSwitcher />}></Route>
+          <Route path=":baseId">
+            <Route path="locations">
+              <Route index element={<Locations />} />
+              <Route path=":locationId" element={<BTLocation />} />
+            </Route>
+            <Route path="boxes" element={<Boxes />} />
           </Route>
         </Route>
-      </Routes>
-    </>
+      </Route>
+    </Routes>
   );
-}
+};
+
+export default App;

--- a/react/src/GlobalPreferencesProvider.tsx
+++ b/react/src/GlobalPreferencesProvider.tsx
@@ -1,0 +1,52 @@
+import React, { Context, createContext, useReducer } from "react";
+
+interface BaseIdAndNameTuple { id: string, name: string }
+
+interface GlobalPreferences {
+  availableBases?: BaseIdAndNameTuple[];
+}
+
+interface IGlobalPreferencesContext {
+  globalPreferences: GlobalPreferences;
+  dispatch: React.Dispatch<SetGlobalPreferencesAction>;
+}
+
+const GlobalPreferencesContext: Context<IGlobalPreferencesContext> = createContext(
+  {} as IGlobalPreferencesContext,
+);
+
+interface SetAvailableBasesAction {
+  type: "setAvailableBases";
+  payload: BaseIdAndNameTuple[];
+}
+
+interface SetSelectedBaseIdAction {
+  type: "setSelectedBaseId";
+  payload: string;
+}
+
+type SetGlobalPreferencesAction = SetAvailableBasesAction | SetSelectedBaseIdAction;
+
+const globalPreferencesReduer = (state: GlobalPreferences, action: SetGlobalPreferencesAction) => {
+  switch (action.type) {
+    case "setAvailableBases":
+      return { ...state, availableBases: action.payload };
+    case "setSelectedBaseId":
+      return { ...state, selectedBaseId: action.payload };
+    default:
+      return state;
+  }
+}
+
+const GlobalPreferencesProvider = ({ children }) => {
+ 
+  const [globalPreferences, dispatch] = useReducer(globalPreferencesReduer, {});
+
+  return (
+    <GlobalPreferencesContext.Provider value={{ globalPreferences, dispatch }}>
+      {children}
+    </GlobalPreferencesContext.Provider>
+  );
+}
+
+export { GlobalPreferencesContext, GlobalPreferencesProvider };

--- a/react/src/components/HeaderMenu.tsx
+++ b/react/src/components/HeaderMenu.tsx
@@ -1,9 +1,25 @@
-import { useState } from "react";
-import { NavLink } from "react-router-dom";
+import { useContext, useState } from "react";
+import { Link, NavLink, useParams } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
-import { Box, Text, Button, Stack, Flex, Image, IconButton } from "@chakra-ui/react";
+import {
+  Box,
+  Text,
+  Button,
+  Stack,
+  Flex,
+  Image,
+  IconButton,
+  Img,
+  Menu,
+  MenuButton,
+  MenuDivider,
+  MenuGroup,
+  MenuItem,
+  MenuList,
+} from "@chakra-ui/react";
 import { AiFillCloseCircle, AiOutlineMenu } from "react-icons/ai";
 import BoxtributeLogo from "../Assets/images/boxtribute-logo.png";
+import { GlobalPreferencesContext } from "GlobalPreferencesProvider";
 
 const MenuToggle = ({ toggle, isOpen, ...props }) => (
   <IconButton
@@ -14,22 +30,67 @@ const MenuToggle = ({ toggle, isOpen, ...props }) => (
   />
 );
 
-const Logo = (props) => (
+const Logo = () => (
   <NavLink to="/">
     <Image src={BoxtributeLogo} maxH={"4em"} />
   </NavLink>
 );
 
-const LoginLogoutButton = () => {
-  const { isAuthenticated, logout, loginWithRedirect } = useAuth0();
+const BaseSwitcher = () => {
+  const { globalPreferences } = useContext(GlobalPreferencesContext);
+  const baseId = useParams<{ baseId: string }>().baseId;
   return (
-    <Button onClick={() => (isAuthenticated ? logout() : loginWithRedirect())}>
-      {isAuthenticated ? "Logout" : "Login"}
-    </Button>
+    <MenuGroup title="Bases">
+      {globalPreferences.availableBases?.map((base, i) => (
+        <MenuItem key={base.id}>
+          <Link
+            style={baseId === base.id ? { fontWeight: "bold" } : {}}
+            to={`/bases/${base.id}/locations`}
+          >
+            {base.name}
+          </Link>
+        </MenuItem>
+      ))}
+    </MenuGroup>
+  );
+};
+
+const UserMenu = () => {
+  const { logout, user } = useAuth0();
+
+  return (
+    <Menu>
+      <MenuButton
+        as={IconButton}
+        icon={<Img src={user?.picture} variant="outline" width={"10"} height={"10"} />}
+      />
+      <MenuList>
+        <BaseSwitcher />
+        <MenuDivider />
+        <MenuGroup>
+          <MenuItem>Profile</MenuItem>
+          <MenuItem>Change Organisation</MenuItem>
+        </MenuGroup>
+        <MenuDivider />
+        <MenuGroup>
+          <MenuItem onClick={() => logout()}>Logout</MenuItem>
+        </MenuGroup>
+      </MenuList>
+    </Menu>
+  );
+};
+
+const LoginOrUserMenuButton = () => {
+  const { isAuthenticated, logout, loginWithRedirect } = useAuth0();
+  return isAuthenticated ? (
+    <UserMenu />
+  ) : (
+    <Button onClick={() => (isAuthenticated ? logout() : loginWithRedirect())}>Login</Button>
   );
 };
 
 const MenuLinks = ({ isOpen, onLinkClick, ...props }) => {
+  const baseId = useParams<{ baseId: string }>().baseId;
   const MenuItem = ({ to, text, ...props }) => (
     <NavLink
       onClick={onLinkClick}
@@ -50,10 +111,9 @@ const MenuLinks = ({ isOpen, onLinkClick, ...props }) => {
         direction={["column", "row", "row", "row"]}
         pt={[4, 4, 0, 0]}
       >
-        <LoginLogoutButton />
-        <MenuItem to="/" text="Home" />
-        <MenuItem to="/locations" text="Locations" />
-        <MenuItem to="/boxes" text="Boxes" />
+        <LoginOrUserMenuButton />
+        <MenuItem to={`/bases/${baseId}/locations`} text="Locations" />
+        <MenuItem to={`/bases/${baseId}/boxes`} text="Boxes" />
       </Stack>
     </Box>
   );
@@ -82,7 +142,7 @@ const Header = () => {
 
   return (
     <NavBarContainer>
-      <Logo maxHeight="10px" visibility={isMenuOpen ? "hidden" : "visible"} />
+      <Logo/>
       <MenuToggle
         toggle={toggle}
         isOpen={isMenuOpen}

--- a/react/src/generated/graphql.tsx
+++ b/react/src/generated/graphql.tsx
@@ -76,12 +76,45 @@ export type Beneficiary = {
   transactions?: Maybe<Array<Transaction>>;
 };
 
+export type BeneficiaryCreationInput = {
+  baseId: Scalars['Int'];
+  comment?: InputMaybe<Scalars['String']>;
+  dateOfBirth: Scalars['Date'];
+  dateOfSignature?: InputMaybe<Scalars['Date']>;
+  familyHeadId?: InputMaybe<Scalars['Int']>;
+  firstName: Scalars['String'];
+  gender: HumanGender;
+  groupIdentifier: Scalars['String'];
+  isVolunteer: Scalars['Boolean'];
+  languages?: InputMaybe<Array<Language>>;
+  lastName: Scalars['String'];
+  registered: Scalars['Boolean'];
+  signature?: InputMaybe<Scalars['String']>;
+};
+
 /** Utility type holding a page of [`Beneficiaries`]({{Types.Beneficiary}}). */
 export type BeneficiaryPage = {
   __typename?: 'BeneficiaryPage';
   elements?: Maybe<Array<Beneficiary>>;
   pageInfo: PageInfo;
   totalCount: Scalars['Int'];
+};
+
+export type BeneficiaryUpdateInput = {
+  baseId?: InputMaybe<Scalars['Int']>;
+  comment?: InputMaybe<Scalars['String']>;
+  dateOfBirth?: InputMaybe<Scalars['Date']>;
+  dateOfSignature?: InputMaybe<Scalars['Date']>;
+  familyHeadId?: InputMaybe<Scalars['Int']>;
+  firstName?: InputMaybe<Scalars['String']>;
+  gender?: InputMaybe<HumanGender>;
+  groupIdentifier?: InputMaybe<Scalars['String']>;
+  id: Scalars['ID'];
+  isVolunteer?: InputMaybe<Scalars['Boolean']>;
+  languages?: InputMaybe<Array<Language>>;
+  lastName?: InputMaybe<Scalars['String']>;
+  registered?: InputMaybe<Scalars['Boolean']>;
+  signature?: InputMaybe<Scalars['String']>;
 };
 
 /** Representation of a box storing items of a [`Product`]({{Types.Product}}) in a [`Location`]({{Types.Location}}) */
@@ -104,6 +137,16 @@ export type Box = {
   state: BoxState;
 };
 
+/** GraphQL input types for mutations **only**. */
+export type BoxCreationInput = {
+  comment: Scalars['String'];
+  items: Scalars['Int'];
+  locationId: Scalars['Int'];
+  productId: Scalars['Int'];
+  qrCode?: InputMaybe<Scalars['String']>;
+  sizeId: Scalars['Int'];
+};
+
 /** Utility type holding a page of [`Boxes`]({{Types.Box}}). */
 export type BoxPage = {
   __typename?: 'BoxPage';
@@ -122,30 +165,13 @@ export enum BoxState {
   Scrap = 'Scrap'
 }
 
-export type BeneficiaryCreationInput = {
-  baseId: Scalars['Int'];
+export type BoxUpdateInput = {
   comment?: InputMaybe<Scalars['String']>;
-  dateOfBirth: Scalars['Date'];
-  dateOfSignature?: InputMaybe<Scalars['Date']>;
-  familyHeadId?: InputMaybe<Scalars['Int']>;
-  firstName: Scalars['String'];
-  gender: HumanGender;
-  groupIdentifier: Scalars['String'];
-  isVolunteer: Scalars['Boolean'];
-  languages?: InputMaybe<Array<Language>>;
-  lastName: Scalars['String'];
-  registered: Scalars['Boolean'];
-  signature?: InputMaybe<Scalars['String']>;
-};
-
-/** GraphQL input types for mutations **only**. */
-export type BoxCreationInput = {
-  comment: Scalars['String'];
-  items: Scalars['Int'];
-  locationId: Scalars['Int'];
-  productId: Scalars['Int'];
-  qrCode?: InputMaybe<Scalars['String']>;
-  sizeId: Scalars['Int'];
+  items?: InputMaybe<Scalars['Int']>;
+  labelIdentifier: Scalars['String'];
+  locationId?: InputMaybe<Scalars['Int']>;
+  productId?: InputMaybe<Scalars['Int']>;
+  sizeId?: InputMaybe<Scalars['Int']>;
 };
 
 /**
@@ -202,12 +228,12 @@ export enum Language {
 export type Location = {
   __typename?: 'Location';
   base?: Maybe<Base>;
-  /**  Default state for boxes in this location  */
-  defaultBoxState?: Maybe<BoxState>;
   /**  List of all the [`Boxes`]({{Types.Box}}) in this location  */
   boxes?: Maybe<BoxPage>;
   createdBy?: Maybe<User>;
   createdOn?: Maybe<Scalars['Datetime']>;
+  /**  Default state for boxes in this location  */
+  defaultBoxState?: Maybe<BoxState>;
   id: Scalars['ID'];
   isShop: Scalars['Boolean'];
   lastModifiedBy?: Maybe<User>;
@@ -274,6 +300,11 @@ export type MetricsNumberOfSalesArgs = {
   before?: InputMaybe<Scalars['Date']>;
 };
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type Mutation = {
   __typename?: 'Mutation';
   acceptTransferAgreement?: Maybe<TransferAgreement>;
@@ -292,66 +323,131 @@ export type Mutation = {
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationAcceptTransferAgreementArgs = {
   id: Scalars['ID'];
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationCancelShipmentArgs = {
   id: Scalars['ID'];
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationCancelTransferAgreementArgs = {
   id: Scalars['ID'];
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationCreateBeneficiaryArgs = {
   creationInput?: InputMaybe<BeneficiaryCreationInput>;
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationCreateBoxArgs = {
   creationInput?: InputMaybe<BoxCreationInput>;
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationCreateQrCodeArgs = {
   boxLabelIdentifier?: InputMaybe<Scalars['String']>;
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationCreateShipmentArgs = {
   creationInput?: InputMaybe<ShipmentCreationInput>;
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationCreateTransferAgreementArgs = {
   creationInput?: InputMaybe<TransferAgreementCreationInput>;
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationRejectTransferAgreementArgs = {
   id: Scalars['ID'];
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationSendShipmentArgs = {
   id: Scalars['ID'];
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationUpdateBeneficiaryArgs = {
   updateInput?: InputMaybe<BeneficiaryUpdateInput>;
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationUpdateBoxArgs = {
   updateInput?: InputMaybe<BoxUpdateInput>;
 };
 
 
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationUpdateShipmentArgs = {
   updateInput?: InputMaybe<ShipmentUpdateInput>;
 };
@@ -726,32 +822,6 @@ export enum TransferAgreementType {
   Unidirectional = 'Unidirectional'
 }
 
-export type BeneficiaryUpdateInput = {
-  baseId?: InputMaybe<Scalars['Int']>;
-  comment?: InputMaybe<Scalars['String']>;
-  dateOfBirth?: InputMaybe<Scalars['Date']>;
-  dateOfSignature?: InputMaybe<Scalars['Date']>;
-  familyHeadId?: InputMaybe<Scalars['Int']>;
-  firstName?: InputMaybe<Scalars['String']>;
-  gender?: InputMaybe<HumanGender>;
-  groupIdentifier?: InputMaybe<Scalars['String']>;
-  id: Scalars['ID'];
-  isVolunteer?: InputMaybe<Scalars['Boolean']>;
-  languages?: InputMaybe<Array<Language>>;
-  lastName?: InputMaybe<Scalars['String']>;
-  registered?: InputMaybe<Scalars['Boolean']>;
-  signature?: InputMaybe<Scalars['String']>;
-};
-
-export type BoxUpdateInput = {
-  comment?: InputMaybe<Scalars['String']>;
-  items?: InputMaybe<Scalars['Int']>;
-  labelIdentifier: Scalars['String'];
-  locationId?: InputMaybe<Scalars['Int']>;
-  productId?: InputMaybe<Scalars['Int']>;
-  sizeId?: InputMaybe<Scalars['Int']>;
-};
-
 /**
  * Representation of a user signed up for the web application.
  * The user is a member of a specific [`Organisation`]({{Types.Organisation}}).
@@ -770,6 +840,11 @@ export type User = {
   validLastDay?: Maybe<Scalars['Date']>;
 };
 
+export type BasesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type BasesQuery = { __typename?: 'Query', bases: Array<{ __typename?: 'Base', id: string, name: string }> };
+
 export type BoxesForBaseQueryVariables = Exact<{
   baseId: Scalars['ID'];
 }>;
@@ -784,7 +859,9 @@ export type LocationQueryVariables = Exact<{
 
 export type LocationQuery = { __typename?: 'Query', location?: { __typename?: 'Location', id: string, name?: string | null, defaultBoxState?: BoxState | null, boxes?: { __typename?: 'BoxPage', totalCount: number, elements: Array<{ __typename?: 'Box', id: string, items: number, product?: { __typename?: 'Product', name: string, price?: number | null, category: { __typename?: 'ProductCategory', name: string } } | null }> } | null } | null };
 
-export type Unnamed_1_QueryVariables = Exact<{ [key: string]: never; }>;
+export type LocationsForBaseQueryVariables = Exact<{
+  baseId: Scalars['ID'];
+}>;
 
 
-export type Unnamed_1_Query = { __typename?: 'Query', locations: Array<{ __typename?: 'Location', id: string, name?: string | null }> };
+export type LocationsForBaseQuery = { __typename?: 'Query', base?: { __typename?: 'Base', locations?: Array<{ __typename?: 'Location', id: string, name?: string | null }> | null } | null };

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -6,8 +6,9 @@ import ApolloWrapper from "./ApolloWrapper";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 import { ChakraProvider, CSSReset, extendTheme } from "@chakra-ui/react";
+import { withAuthenticationRequired } from "@auth0/auth0-react";
+import { GlobalPreferencesProvider } from "GlobalPreferencesProvider";
 
-// 2. Extend the theme to include custom colors, fonts, etc
 const colors = {
   brand: {
     900: "#1a365d",
@@ -22,13 +23,17 @@ const colors = {
 
 const theme = extendTheme({ colors });
 
+const AuthenticationProtectedApp = withAuthenticationRequired(App);
+
 ReactDOM.render(
   <ChakraProvider theme={theme}>
     <CSSReset />
     <BrowserRouter>
       <Auth0ProviderWithHistory>
         <ApolloWrapper>
-          <App />
+          <GlobalPreferencesProvider>
+            <AuthenticationProtectedApp />
+          </GlobalPreferencesProvider>
         </ApolloWrapper>
       </Auth0ProviderWithHistory>
     </BrowserRouter>

--- a/react/src/utils/test-utils.tsx
+++ b/react/src/utils/test-utils.tsx
@@ -1,20 +1,28 @@
-import React, { FunctionComponent } from "react";
+import React from "react";
 import { render as rtlRender } from "@testing-library/react";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
-import { MemoryRouter, Router } from "react-router-dom";
+import { MemoryRouter, Routes } from "react-router-dom";
 import "mutationobserver-shim";
 
-// function render(ui, { mocks, history, ...renderOptions }: { mocks: Array<MockedResponse>, history: any }) {
-function render(ui, { mocks, ...renderOptions }: { mocks: Array<MockedResponse> }) {
+function render(
+  ui,
+  {
+    mocks,
+    initialUrl,
+    ...renderOptions
+  }: { mocks: Array<MockedResponse>; initialUrl: string },
+) {
   const Wrapper: React.FC = ({ children }) => {
     return (
       <>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <MemoryRouter>{children}</MemoryRouter>
+          <MemoryRouter initialEntries={[initialUrl]}>
+            <Routes>{children}</Routes>
+          </MemoryRouter>
         </MockedProvider>
       </>
     );
-  }
+  };
   return rtlRender(ui, {
     wrapper: Wrapper,
     ...renderOptions,

--- a/react/src/views/Home.tsx
+++ b/react/src/views/Home.tsx
@@ -1,8 +1,0 @@
-import { Heading } from "@chakra-ui/react";
-import React from "react";
-
-const Home = () => {
-  return <Heading>Home</Heading>;
-};
-
-export default Home;

--- a/react/src/views/automatic-base-switcher/AutomaticBaseSwitcher.tsx
+++ b/react/src/views/automatic-base-switcher/AutomaticBaseSwitcher.tsx
@@ -1,0 +1,33 @@
+import React, { useContext, useEffect, useState } from "react";
+import { GlobalPreferencesContext } from "GlobalPreferencesProvider";
+import { useNavigate } from "react-router-dom";
+
+const AutomaticBaseSwitcher = () => {
+  const navigate = useNavigate();
+  const { globalPreferences } = useContext(GlobalPreferencesContext);
+
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  useEffect(() => {
+    const bases = globalPreferences.availableBases;
+    if (bases != null) {
+      if (bases.length > 0) {
+        const newBaseId = bases[0].id;
+        navigate(`/bases/${newBaseId}/locations`);
+      } else {
+        setErrorMessage("This user doesn't have access to any bases");
+      }
+    }
+  }, [navigate, globalPreferences.availableBases]);
+
+
+  if (errorMessage) {
+    return <>{errorMessage}</>;
+  }
+
+  return (
+    <></>
+  );
+};
+
+export default AutomaticBaseSwitcher;

--- a/react/src/views/boxes/Boxes.tsx
+++ b/react/src/views/boxes/Boxes.tsx
@@ -6,6 +6,7 @@ import { TriangleDownIcon, TriangleUpIcon } from "@chakra-ui/icons";
 import { GlobalFilter } from "./GlobalFilter";
 import { SelectColumnFilter } from "./SelectColumnFilter";
 import { BoxesForBaseQuery } from "../../generated/graphql";
+import { useParams } from "react-router-dom";
 
 const BOXES_FOR_BASE_QUERY = gql`
   query BoxesForBase($baseId: ID!) {
@@ -166,7 +167,7 @@ const graphqlToTableTransformer = (boxesQueryResult: BoxesForBaseQuery | undefin
   ) || [];
 
 const Boxes = () => {
-  const baseId = 1;
+  const baseId = useParams<{ baseId: string }>().baseId;
 
   const { loading, error, data } = useQuery<BoxesForBaseQuery>(BOXES_FOR_BASE_QUERY, {
     variables: {

--- a/react/src/views/locations/Locations.test.tsx
+++ b/react/src/views/locations/Locations.test.tsx
@@ -2,36 +2,45 @@ import { screen, waitFor} from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Locations, { LOCATIONS_QUERY } from "./Locations";
 import { render } from "utils/test-utils";
+import { Route } from "react-router-dom";
 
 describe("Locations view", () => {
   const mocks = [
     {
       request: {
         query: LOCATIONS_QUERY,
+        variables: {
+          baseId: "123"
+        },
       },
       result: {
         data: {
-          locations: [
-            {
-              __typename: "Location",
-              id: 1,
-              name: "Shop",
-              boxes: [],
-            },
-            {
-              __typename: "Location",
-              id: 2,
-              name: "LOST",
-              boxes: [],
-            }
-          ]
-        }
-      }
-    }
+          base: {
+            locations: [
+              {
+                __typename: "Location",
+                id: 1,
+                name: "Shop",
+                boxes: [],
+              },
+              {
+                __typename: "Location",
+                id: 2,
+                name: "LOST",
+                boxes: [],
+              },
+            ],
+          },
+        },
+      },
+    },
   ];
   beforeEach(() => {
-    render(<Locations />, { mocks });
-  })
+    render(<Route path="/bases/:baseId/locations" element={<Locations />}></Route>, {
+      mocks,
+      initialUrl: "/bases/123/locations",
+    });
+  });
   it("renders with an initial 'Loading...'", async () => {
     const loadingInfo = screen.getByText("Loading...");
     expect(loadingInfo).toBeInTheDocument();


### PR DESCRIPTION
Closes https://trello.com/c/byffqWJL/865-enable-switching-between-bases-for-new-frontend

Also it adds
* a automatic base switcher: for root urls like `http://domain.xyz/`, the first base of the list of all bases where the user has access to will be selected (OR, in the future, we can implement a 'go to latest used base from previous session' - see next point)
* a global preference context (also things like the most recently used base can be stored there, if the same user comes back to the app in the future, it can be used to automatically go to this base; we can leverage the localStorage for that)
