### PR TITLE
Adjust query API URL in docs depending on context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,9 @@ jobs:
                 name: Generate GraphQL documentation
                 command: |
                   cd ../docs/graphql-api
+                  if [[ "<< parameters.serviceName >>" != api-production ]]; then
+                      sed -i 's/api.boxtribute/<< parameters.serviceName >>.boxtribute/g' query-api-config.yml
+                  fi
                   npm install
                   npx spectaql query-api-config.yml
                   sed -i 's|stylesheets|docs/stylesheets|g' public/index.html

--- a/docs/graphql-api/query-api-config.yml
+++ b/docs/graphql-api/query-api-config.yml
@@ -200,7 +200,7 @@ servers:
   # same format as for OpenAPI Specification https://swagger.io/specification/#server-object
 
   - url: https://api.boxtribute.org
-    description: Production Server
+    description: Query API
     # Indicates to use this server's URL as the typical GraphQL request base in the documentation
     # If no server entries have this indicator, the first server's URL will be used.
     # If no server entries are defined at all, the Introspection URL will be used.


### PR DESCRIPTION
The URL for the respective query API is updated (both in the right and left column, and in the auth/authz section).

Please see https://api-staging.boxtribute.org/docs and https://api-demo.boxtribute.org/docs
