### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   checkout-to-workspace:
     docker:
-      - image: cimg/python:3.8.12-node
+      - image: cimg/python:3.10.4-node
     steps:
       - checkout
       - persist_to_workspace:
@@ -15,7 +15,7 @@ jobs:
             - .
   build-flask:
     docker:
-      - image: cimg/python:3.8.12
+      - image: cimg/python:3.10.4
     working_directory: ~/back
     steps:
       - attach_workspace:
@@ -30,23 +30,23 @@ jobs:
             python --version
             pyenv virtualenvs
             pyenv virtualenv --force env
-            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
+            source $(pyenv root)/versions/3.10.4/envs/env/bin/activate
             pip install -e . -r requirements.txt
       # Cache the installed packages
       - save_cache:
           key: webapp-deps-{{ checksum "requirements.txt" }}
           paths:
-            - /home/circleci/.pyenv/versions/3.8.12/envs/env
+            - /home/circleci/.pyenv/versions/3.10.4/envs/env
       # save build to a CircleCI workspace
       - persist_to_workspace:
           root: ~/
           paths:
             - back/*
-            - .pyenv/versions/3.8.12/envs
+            - .pyenv/versions/3.10.4/envs
 
   build-and-test-react:
     docker:
-      - image: cimg/python:3.8.12-node
+      - image: cimg/python:3.10.4-node
     working_directory: ~/react
     steps:
       - attach_workspace:
@@ -101,7 +101,7 @@ jobs:
   # following https://circleci.com/docs/2.0/project-walkthrough/
   test-flask:
     docker:
-      - image: cimg/python:3.8.12
+      - image: cimg/python:3.10.4
       - image: cimg/mysql:8.0.27
         environment:
           MYSQL_ROOT_PASSWORD: dropapp_root
@@ -118,17 +118,17 @@ jobs:
       - run:
           name: install dev dependencies for linting and testing
           command: |
-            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
+            source $(pyenv root)/versions/3.10.4/envs/env/bin/activate
             pip install -r requirements-dev.txt
       - run:
           name: run style checks on Python files
           command: |
-            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
+            source $(pyenv root)/versions/3.10.4/envs/env/bin/activate
             pre-commit run --files **/*.py
       - save_cache:
           key: webapp-dev-deps-{{ checksum "requirements-dev.txt" }}-{{ checksum "../.pre-commit-config.yaml" }}
           paths:
-            - /home/circleci/.pyenv/versions/3.8.12/envs/env
+            - /home/circleci/.pyenv/versions/3.10.4/envs/env
             - ~/.cache/pre-commit
       # https://circleci.com/docs/2.0/postgres-config/#example-mysql-project
       - run:
@@ -151,7 +151,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            source $(pyenv root)/versions/3.8.12/envs/env/bin/activate
+            source $(pyenv root)/versions/3.10.4/envs/env/bin/activate
             pytest --cov-report xml:test-results/coverage.xml --cov=boxtribute_server
       - store_test_results:
           path: test-results
@@ -168,7 +168,7 @@ jobs:
       serviceName:
         type: string
     docker:
-      - image: cimg/python:3.8.12-node
+      - image: cimg/python:3.10.4-node
     working_directory: ~/back
     steps:
       # Attach workspace from build

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Here, is a list of intro tutorials for each technologies / frameworks / language
 
 - [GraphQL](https://graphql.org/learn/)
 - [Ariadne](https://ariadnegraphql.org/docs/flask-integration.html)
-- [Python 3.X](https://devguide.python.org/)
+- [Python 3.10](https://devguide.python.org/)
 - [Flask](https://flask.palletsprojects.com/en/1.1.x/tutorial/layout/)
 - [PeeWee](http://docs.peewee-orm.com/en/latest/peewee/quickstart.html)
 - MySQL

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,7 +1,7 @@
 ARG flask_env
 
 # using alpine for smallest docker image
-FROM python:3.8-alpine AS base
+FROM python:3.10.4-alpine3.15 AS base
 
 WORKDIR /app/back
 # install packages separately to use docker build-caching so we don't need to

--- a/back/README.md
+++ b/back/README.md
@@ -23,7 +23,7 @@ The following steps build on top of each other and have to be performed in corre
 
 ### Install python
 
-Install [Python >=3.6](https://www.python.org/downloads/) on your computer. You will need it to run tests on the back-end and the formatters and linters on both back-end and front-end.
+Install [Python >=3.10](https://www.python.org/downloads/) on your computer. You will need it to run tests on the back-end and the formatters and linters on both back-end and front-end.
 
 ### Create a Python virtual environment
 

--- a/back/app.yaml
+++ b/back/app.yaml
@@ -1,4 +1,4 @@
-runtime: python38
+runtime: python310
 service: v2-staging
 entrypoint: gunicorn -b :$PORT
 handlers:

--- a/back/requirements-dev.txt
+++ b/back/requirements-dev.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 flake8==4.0.1
 isort==5.10.1
-pre-commit==2.17.0
+pre-commit==2.19.0
 pytest>=5.4.3
-pytest-mock==3.6.1
+pytest-mock==3.8.1
 pytest-cov==3.0.0

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -1,5 +1,5 @@
-ariadne==0.14.1
-Flask==2.0.3
+ariadne==0.15.1
+Flask==2.1.2
 Flask-Cors==3.0.10
 PyMySQL==1.0.2
 peewee==3.14.10

--- a/back/setup.py
+++ b/back/setup.py
@@ -9,8 +9,8 @@ setup(
     organisations to source, store and distribute donated goods to people in
     need in a fair and dignified way.""",
     url="https://github.com/boxwise/boxtribute",
-    author="boxwise.co",
-    author_email="hello@boxwise.co",
+    author="Stichting Boxwise",
+    author_email="hello@boxtribute.org",
     license="Apache 2.0",
     packages=find_packages(exclude=["test"]),
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
Dear developers,

this PR is relevant to you if you actively develop in the boxtribute Python code base. With this PR, Python 3.10 is the minimum version that the software supports (older versions might still work), please install it on your system and perform the back-end installation steps. If you only user the docker-compose services, you don't need to take action.

Content of the PR:
- Update Python docker images
- Bump Python dependencies

Opening some PRs in dependencies' repos:
- https://github.com/timster/peewee-moves/pull/17
- https://github.com/benoitc/gunicorn/pull/2805
- https://github.com/corydolphin/flask-cors/pull/314