### PR TITLE
Handle authz for god users

### DIFF
--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -124,9 +124,10 @@ class CurrentUser:
         that the permission is granted for, or to None if the permission is granted for
         all bases. However it is never exposed directly to avoid accidental
         manipulation.
+        The `organisation_id` field is set to None for god users.
         """
         self._id = id
-        self._organisation_id = organisation_id
+        self._organisation_id = None if is_god else organisation_id
         self._is_god = is_god
         self._base_ids = base_ids or {}
 
@@ -140,6 +141,9 @@ class CurrentUser:
         - base_1/product:read    -> {"product:read": [1]}
         - base_2-3/stock:write   -> {"stock:write": [2, 3], "stock:read": [2, 3]}
         - beneficiary:edit       -> {"beneficiary:edit": None, "beneficiary:read": None}
+
+        If the permissions custom claim is a list with a single entry "*", it indicates
+        that the current user is a god user.
         """
         is_god = payload[f"{JWT_CLAIM_PREFIX}/permissions"] == ["*"]
         base_ids = {}

--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -169,6 +169,8 @@ class CurrentUser:
         return name in self._base_ids
 
     def authorized_base_ids(self, permission):
+        if self.is_god:
+            return None
         return self._base_ids[permission]
 
     @property

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -5,7 +5,11 @@ from ariadne import MutationType, ObjectType, QueryType, convert_kwargs_to_snake
 from flask import g
 from peewee import fn
 
-from ..authz import authorize
+from ..authz import (
+    agreement_organisation_filter_condition,
+    authorize,
+    base_filter_condition,
+)
 from ..box_transfer.agreement import (
     accept_transfer_agreement,
     cancel_transfer_agreement,
@@ -78,33 +82,11 @@ transfer_agreement = _register_object_type("TransferAgreement")
 user = _register_object_type("User")
 
 
-def _base_filter_condition(permission):
-    """Derive filter condition for given permission depending the current user's
-    base-specific permissions. See also `auth.requires_auth()`.
-    """
-    base_ids = g.user.authorized_base_ids(permission)
-    if base_ids is None:
-        # Permission granted for all bases
-        return True
-    return Base.id << base_ids
-
-
-def _agreement_organisation_filter_condition():
-    """Derive filter condition for accessing transfer agreements depending on the user's
-    organisation. The god user may access any agreement.
-    """
-    if g.user.is_god:
-        return True
-    return (TransferAgreement.source_organisation == g.user.organisation_id) | (
-        TransferAgreement.target_organisation == g.user.organisation_id
-    )
-
-
 @user.field("bases")
 @query.field("bases")
 def resolve_bases(*_):
     authorize(permission="base:read")
-    return Base.select().where(_base_filter_condition("base:read"))
+    return Base.select().where(base_filter_condition("base:read"))
 
 
 @query.field("base")
@@ -219,7 +201,7 @@ def resolve_organisations(*_):
 @query.field("locations")
 def resolve_locations(*_):
     authorize(permission="location:read")
-    return Location.select().join(Base).where(_base_filter_condition("location:read"))
+    return Location.select().join(Base).where(base_filter_condition("location:read"))
 
 
 @query.field("products")
@@ -228,7 +210,7 @@ def resolve_products(*_, pagination_input=None):
     authorize(permission="product:read")
     return load_into_page(
         Product,
-        _base_filter_condition("product:read"),
+        base_filter_condition("product:read"),
         selection=Product.select().join(Base),
         pagination_input=pagination_input,
     )
@@ -241,7 +223,7 @@ def resolve_beneficiaries(*_, pagination_input=None, filter_input=None):
     filter_condition = derive_beneficiary_filter(filter_input)
     return load_into_page(
         Beneficiary,
-        _base_filter_condition("beneficiary:read") & filter_condition,
+        base_filter_condition("beneficiary:read") & filter_condition,
         selection=Beneficiary.select().join(Base),
         pagination_input=pagination_input,
     )
@@ -253,7 +235,7 @@ def resolve_transfer_agreements(*_, states=None):
     # No state filter by default
     state_filter = TransferAgreement.state << states if states else True
     return TransferAgreement.select().where(
-        _agreement_organisation_filter_condition() & (state_filter)
+        agreement_organisation_filter_condition() & (state_filter)
     )
 
 
@@ -263,7 +245,7 @@ def resolve_shipments(*_):
     return (
         Shipment.select()
         .join(TransferAgreement)
-        .where(_agreement_organisation_filter_condition())
+        .where(agreement_organisation_filter_condition())
     )
 
 

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -29,7 +29,7 @@ from .location import (
 )
 from .log import default_log
 from .organisation import another_organisation, default_organisation
-from .product import another_product, default_product
+from .product import another_product, default_product, products
 from .product_category import default_product_category
 from .product_gender import default_product_gender
 from .qr_code import default_qr_code, qr_code_without_box
@@ -38,6 +38,7 @@ from .shipment import (
     canceled_shipment,
     default_shipment,
     sent_shipment,
+    shipments,
 )
 from .shipment_detail import (
     another_shipment_detail,
@@ -96,11 +97,13 @@ __all__ = [
     "non_default_box_state_location",
     "null_box_state_location",
     "prepared_shipment_detail",
+    "products",
     "qr_code_without_box",
     "relative_beneficiary",
     "relative_transaction",
     "reviewed_transfer_agreement",
     "sent_shipment",
+    "shipments",
     "transfer_agreements",
     "unidirectional_transfer_agreement",
 ]

--- a/back/test/data/product.py
+++ b/back/test/data/product.py
@@ -43,5 +43,10 @@ def another_product():
     return another_product_data()
 
 
+@pytest.fixture
+def products():
+    return data()
+
+
 def create():
     Product.insert_many(data()).execute()

--- a/back/test/data/shipment.py
+++ b/back/test/data/shipment.py
@@ -71,5 +71,10 @@ def sent_shipment():
     return data()[3]
 
 
+@pytest.fixture
+def shipments():
+    return data()
+
+
 def create():
     Shipment.insert_many(data()).execute()

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -272,8 +272,17 @@ def test_permission_scope(read_only_client, mocker, default_bases, method):
     assert len(bases) == len(default_bases)
 
 
-def test_permission_for_god_user(read_only_client, mocker, default_users, products):
-    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(permissions=["*"])
+def test_permission_for_god_user(
+    read_only_client,
+    mocker,
+    default_users,
+    products,
+    shipments,
+    transfer_agreements,
+):
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
+        permissions=["*"], organisation_id=None
+    )
     query = "query { users { id } }"
     users = assert_successful_request(read_only_client, query)
     assert len(users) == len(default_users)
@@ -281,3 +290,11 @@ def test_permission_for_god_user(read_only_client, mocker, default_users, produc
     query = "query { products { totalCount } }"
     nr_products = assert_successful_request(read_only_client, query)["totalCount"]
     assert nr_products == len(products)
+
+    query = "query { shipments { id } }"
+    nr_shipments = len(assert_successful_request(read_only_client, query))
+    assert nr_shipments == len(shipments)
+
+    query = "query { transferAgreements { id } }"
+    agreements = assert_successful_request(read_only_client, query)
+    assert len(agreements) == len(transfer_agreements)

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -272,8 +272,12 @@ def test_permission_scope(read_only_client, mocker, default_bases, method):
     assert len(bases) == len(default_bases)
 
 
-def test_permission_for_god_user(read_only_client, mocker, default_users):
+def test_permission_for_god_user(read_only_client, mocker, default_users, products):
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(permissions=["*"])
     query = "query { users { id } }"
     users = assert_successful_request(read_only_client, query)
     assert len(users) == len(default_users)
+
+    query = "query { products { totalCount } }"
+    nr_products = assert_successful_request(read_only_client, query)["totalCount"]
+    assert nr_products == len(products)


### PR DESCRIPTION
Regardless of the value of the `organisation_id` claim in the JWT, set the internal `CurrentUser.organisation_id` to None for god users, and update involved filtering logic accordingly.
