### PR TITLE
Remove permission check for GraphQL organisation query

### DIFF
--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -172,7 +172,6 @@ def resolve_location(obj, _, id=None):
 
 @query.field("organisation")
 def resolve_organisation(*_, id):
-    authorize(organisation_id=int(id))
     return Organisation.get_by_id(id)
 
 

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -59,14 +59,13 @@ def test_invalid_permission(unauthorized, read_only_client, query):
     "query",
     [
         """base( id: 0 ) { id }""",
-        """organisation( id: 0 ) { id }""",
         """location( id: 2 ) { id }""",  # ID of another_location fixture
     ],
     ids=operation_name,
 )
 def test_invalid_permission_for_given_resource_id(read_only_client, mocker, query):
     """Verify missing resource:read permission, or missing permission to access
-    specified resource (base or organisation).
+    specified resource (i.e. base).
     """
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         permissions=["base_1/base:read"], organisation_id=1


### PR DESCRIPTION
E.g. in the context of box transfer it's necessary to query information
for an organisation that the client does not belong to
