### PR TITLE
Tag GraphQL API and data models

### DIFF
--- a/back/boxtribute_server/enums.py
+++ b/back/boxtribute_server/enums.py
@@ -10,6 +10,12 @@ class TransferAgreementState(enum.IntEnum):
     Expired = enum.auto()
 
 
+class TagType(enum.Enum):
+    Box = "Stock"
+    Beneficiary = "People"
+    All = "All"
+
+
 class TransferAgreementType(enum.IntEnum):
     Unidirectional = 1
     Bidirectional = enum.auto()

--- a/back/boxtribute_server/graph_ql/enums.py
+++ b/back/boxtribute_server/graph_ql/enums.py
@@ -6,6 +6,7 @@ from ..enums import (
     Language,
     ProductGender,
     ShipmentState,
+    TagType,
     TransferAgreementState,
     TransferAgreementType,
 )
@@ -16,6 +17,7 @@ enum_types = [
     EnumType("HumanGender", HumanGender),
     EnumType("Language", Language),
     EnumType("ShipmentState", ShipmentState),
+    EnumType("TagType", TagType),
     EnumType("TransferAgreementState", TransferAgreementState),
     EnumType("TransferAgreementType", TransferAgreementType),
 ]

--- a/back/boxtribute_server/graph_ql/queries.graphql
+++ b/back/boxtribute_server/graph_ql/queries.graphql
@@ -4,14 +4,6 @@ type Query {
   TODO: Give proper Description here
   """
   tags(tagType: TagType): [Tag!]!
-  # """
-  # TODO: Give proper Description here
-  # """
-  # beneficiaryTags: [BeneficiaryTag!]!
-  # """
-  # TODO: Give proper Description here
-  # """
-  # boxTags: [BoxTag!]!
 
   " Return all [`Bases`]({{Types.Base}}) that the client is authorized to view. "
   bases: [Base!]!

--- a/back/boxtribute_server/graph_ql/queries.graphql
+++ b/back/boxtribute_server/graph_ql/queries.graphql
@@ -1,4 +1,18 @@
 type Query {
+
+  """
+  TODO: Give proper Description here
+  """
+  tags: [Tag!]!
+  """
+  TODO: Give proper Description here
+  """
+  beneficiaryTags: [BeneficiaryTag!]!
+  """
+  TODO: Give proper Description here
+  """
+  boxTags: [BoxTag!]!
+
   " Return all [`Bases`]({{Types.Base}}) that the client is authorized to view. "
   bases: [Base!]!
   base(id: ID!): Base

--- a/back/boxtribute_server/graph_ql/queries.graphql
+++ b/back/boxtribute_server/graph_ql/queries.graphql
@@ -3,15 +3,15 @@ type Query {
   """
   TODO: Give proper Description here
   """
-  tags: [Tag!]!
-  """
-  TODO: Give proper Description here
-  """
-  beneficiaryTags: [BeneficiaryTag!]!
-  """
-  TODO: Give proper Description here
-  """
-  boxTags: [BoxTag!]!
+  tags(tagType: TagType): [Tag!]!
+  # """
+  # TODO: Give proper Description here
+  # """
+  # beneficiaryTags: [BeneficiaryTag!]!
+  # """
+  # TODO: Give proper Description here
+  # """
+  # boxTags: [BoxTag!]!
 
   " Return all [`Bases`]({{Types.Base}}) that the client is authorized to view. "
   bases: [Base!]!

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -29,7 +29,7 @@ from ..box_transfer.shipment import (
     send_shipment,
     update_shipment,
 )
-from ..enums import HumanGender, TransferAgreementType
+from ..enums import HumanGender, TagType, TransferAgreementType
 from ..models.crud import (
     create_beneficiary,
     create_box,
@@ -295,6 +295,11 @@ def resolve_metrics(*_, organisation_id=None):
 
     # Pass organisation ID to child resolvers
     return {"organisation_id": organisation_id}
+
+
+@tag.field("type")
+def resolve_tag_type(tag_obj, _):
+    return TagType(tag_obj.type)
 
 
 @tag.field("taggedResources")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -49,6 +49,7 @@ from ..models.definitions.shipment import Shipment
 from ..models.definitions.shipment_detail import ShipmentDetail
 from ..models.definitions.size import Size
 from ..models.definitions.tag import Tag
+from ..models.definitions.tags_relation import TagsRelation
 from ..models.definitions.transaction import Transaction
 from ..models.definitions.transfer_agreement import TransferAgreement
 from ..models.definitions.user import User
@@ -303,14 +304,16 @@ def resolve_tag_type(tag_obj, _):
 
 
 @tag.field("taggedResources")
-def resolve_tag_taggable_resources(tag_obj, _):
+def resolve_tag_tagged_resources(tag_obj, _):
     # # TODO Add correct permissions herer
     # # authorize(permission="tag:read")
-    # return (
-    #     QUERY FOR GETTING TAGGABLE RESOURCES
-    # )
-    # return [Box.get_by_id(1)]
-    return []
+    beneficiary_relations = TagsRelation.select(TagsRelation.object_id).where(
+        (TagsRelation.tag == tag_obj.id)
+        & (TagsRelation.object_type == TagType.Beneficiary.value)
+    )
+    return Beneficiary.select().where(
+        Beneficiary.id << [r.object_id for r in beneficiary_relations]
+    )
 
 
 @beneficiary.field("tokens")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -92,26 +92,6 @@ transfer_agreement = _register_object_type("TransferAgreement")
 user = _register_object_type("User")
 
 
-# query {
-#     taggableResources {
-#         id
-#         __typename
-#         ... on Box {
-#             labelIdentifier
-#             product {
-#                 ...
-#             }
-#         }
-#         ... on Beneficiary {
-#             name
-#             ...
-#         }
-
-
-#     }
-# }
-
-
 @query.field("tags")
 def resolve_tags(*_):
     # TODO: Add correct permissions here

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -1,7 +1,7 @@
 """GraphQL resolver functionality"""
 from datetime import date
 
-from ariadne import MutationType, ObjectType, QueryType, convert_kwargs_to_snake_case
+from ariadne import MutationType, ObjectType, QueryType, UnionType, convert_kwargs_to_snake_case
 from flask import g
 from peewee import fn
 
@@ -78,8 +78,43 @@ product_category = _register_object_type("ProductCategory")
 qr_code = _register_object_type("QrCode")
 shipment = _register_object_type("Shipment")
 shipment_detail = _register_object_type("ShipmentDetail")
+tag = _register_object_type("Tag")
 transfer_agreement = _register_object_type("TransferAgreement")
 user = _register_object_type("User")
+tag_type = UnionType("TaggableResource", resolve_taggable_resource_type)
+
+
+
+
+# query {
+#     taggableResources {
+#         id
+#         __typename
+#         ... on Box {
+#             labelIdentifier
+#             product {
+#                 ...
+#             }
+#         }
+#         ... on Beneficiary {
+#             name
+#             ...
+#         }
+
+
+#     }
+# }
+
+
+
+
+
+
+@query.field("tags")
+def resolve_tags(*_): 
+    # TODO: Add correct permissions here
+    # authorize(permission="tags:read")
+    return Tag.select()
 
 
 @user.field("bases")
@@ -259,6 +294,29 @@ def resolve_metrics(*_, organisation_id=None):
 
     # Pass organisation ID to child resolvers
     return {"organisation_id": organisation_id}
+
+
+
+
+@tag.field("taggableResources")
+def resolve_tag_taggable_resources(tag_obj, _): 
+    # TODO Add correct permissions herer
+    # authorize(permission="tag:read")
+    return (
+        QUERY FOR GETTING TAGGABLE RESOURCES
+    )
+
+
+def resolve_taggable_resource_type(obj, *_):
+    if isinstance(obj, Box):
+        return "Box"
+    if isinstance(obj, Beneficiary):
+        return "Beneficiary"
+    else:
+        return None
+
+
+
 
 
 @beneficiary.field("tokens")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -59,6 +59,7 @@ from .pagination import load_into_page
 query = QueryType()
 mutation = MutationType()
 object_types = []
+union_types = []
 
 
 def _register_object_type(name):
@@ -81,7 +82,6 @@ shipment_detail = _register_object_type("ShipmentDetail")
 tag = _register_object_type("Tag")
 transfer_agreement = _register_object_type("TransferAgreement")
 user = _register_object_type("User")
-tag_type = UnionType("TaggableResource", resolve_taggable_resource_type)
 
 
 
@@ -296,26 +296,15 @@ def resolve_metrics(*_, organisation_id=None):
     return {"organisation_id": organisation_id}
 
 
-
-
-@tag.field("taggableResources")
+@tag.field("taggedResources")
 def resolve_tag_taggable_resources(tag_obj, _): 
-    # TODO Add correct permissions herer
-    # authorize(permission="tag:read")
-    return (
-        QUERY FOR GETTING TAGGABLE RESOURCES
-    )
-
-
-def resolve_taggable_resource_type(obj, *_):
-    if isinstance(obj, Box):
-        return "Box"
-    if isinstance(obj, Beneficiary):
-        return "Beneficiary"
-    else:
-        return None
-
-
+    # # TODO Add correct permissions herer
+    # # authorize(permission="tag:read")
+    # return (
+    #     QUERY FOR GETTING TAGGABLE RESOURCES
+    # )
+    # return [Box.get_by_id(1)]
+    return []
 
 
 
@@ -710,3 +699,15 @@ def resolve_transfer_agreement_shipments(transfer_agreement_obj, _):
 @user.field("organisation")
 def resolve_user_organisation(*_):
     return Organisation.get_by_id(g.user.organisation_id)
+
+
+def resolve_taggable_resource_type(obj, *_):
+    if isinstance(obj, Box):
+        return "Box"
+    if isinstance(obj, Beneficiary):
+        return "Beneficiary"
+    else:
+        return None
+
+
+union_types.append(UnionType("TaggableResource", resolve_taggable_resource_type))

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -278,11 +278,6 @@ def resolve_metrics(*_, organisation_id=None):
     return {"organisation_id": organisation_id}
 
 
-@tag.field("type")
-def resolve_tag_type(tag_obj, _):
-    return TagType(tag_obj.type)
-
-
 @tag.field("taggedResources")
 def resolve_tag_tagged_resources(tag_obj, _):
     # # TODO Add correct permissions herer

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -48,6 +48,7 @@ from ..models.definitions.qr_code import QrCode
 from ..models.definitions.shipment import Shipment
 from ..models.definitions.shipment_detail import ShipmentDetail
 from ..models.definitions.size import Size
+from ..models.definitions.tag import Tag
 from ..models.definitions.transaction import Transaction
 from ..models.definitions.transfer_agreement import TransferAgreement
 from ..models.definitions.user import User

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -1,7 +1,13 @@
 """GraphQL resolver functionality"""
 from datetime import date
 
-from ariadne import MutationType, ObjectType, QueryType, UnionType, convert_kwargs_to_snake_case
+from ariadne import (
+    MutationType,
+    ObjectType,
+    QueryType,
+    UnionType,
+    convert_kwargs_to_snake_case,
+)
 from flask import g
 from peewee import fn
 
@@ -84,8 +90,6 @@ transfer_agreement = _register_object_type("TransferAgreement")
 user = _register_object_type("User")
 
 
-
-
 # query {
 #     taggableResources {
 #         id
@@ -106,12 +110,8 @@ user = _register_object_type("User")
 # }
 
 
-
-
-
-
 @query.field("tags")
-def resolve_tags(*_): 
+def resolve_tags(*_):
     # TODO: Add correct permissions here
     # authorize(permission="tags:read")
     return Tag.select()
@@ -297,7 +297,7 @@ def resolve_metrics(*_, organisation_id=None):
 
 
 @tag.field("taggedResources")
-def resolve_tag_taggable_resources(tag_obj, _): 
+def resolve_tag_taggable_resources(tag_obj, _):
     # # TODO Add correct permissions herer
     # # authorize(permission="tag:read")
     # return (
@@ -305,7 +305,6 @@ def resolve_tag_taggable_resources(tag_obj, _):
     # )
     # return [Box.get_by_id(1)]
     return []
-
 
 
 @beneficiary.field("tokens")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -311,9 +311,15 @@ def resolve_tag_tagged_resources(tag_obj, _):
         (TagsRelation.tag == tag_obj.id)
         & (TagsRelation.object_type == TagType.Beneficiary.value)
     )
-    return Beneficiary.select().where(
-        Beneficiary.id << [r.object_id for r in beneficiary_relations]
+    box_relations = TagsRelation.select(TagsRelation.object_id).where(
+        (TagsRelation.tag == tag_obj.id)
+        & (TagsRelation.object_type == TagType.Box.value)
     )
+    return list(
+        Beneficiary.select().where(
+            Beneficiary.id << [r.object_id for r in beneficiary_relations]
+        )
+    ) + list(Box.select().where(Box.id << [r.object_id for r in box_relations]))
 
 
 @beneficiary.field("tokens")

--- a/back/boxtribute_server/graph_ql/schema.py
+++ b/back/boxtribute_server/graph_ql/schema.py
@@ -2,7 +2,7 @@ from ariadne import make_executable_schema, snake_case_fallback_resolvers
 
 from .definitions import definitions, query_api_definitions
 from .enums import enum_types
-from .resolvers import mutation, object_types, union_types, query
+from .resolvers import mutation, object_types, query, union_types
 from .scalars import date_scalar, datetime_scalar
 
 full_api_schema = make_executable_schema(
@@ -14,20 +14,13 @@ full_api_schema = make_executable_schema(
         datetime_scalar,
         *object_types,
         *enum_types,
-        *union_types
+        *union_types,
     ],
     snake_case_fallback_resolvers,
 )
 
 query_api_schema = make_executable_schema(
     query_api_definitions,
-    [
-        query,
-        date_scalar,
-        datetime_scalar,
-        *object_types,
-        *enum_types,
-        *union_types
-    ],
+    [query, date_scalar, datetime_scalar, *object_types, *enum_types, *union_types],
     snake_case_fallback_resolvers,
 )

--- a/back/boxtribute_server/graph_ql/schema.py
+++ b/back/boxtribute_server/graph_ql/schema.py
@@ -2,7 +2,7 @@ from ariadne import make_executable_schema, snake_case_fallback_resolvers
 
 from .definitions import definitions, query_api_definitions
 from .enums import enum_types
-from .resolvers import mutation, object_types, query
+from .resolvers import mutation, object_types, union_types, query
 from .scalars import date_scalar, datetime_scalar
 
 full_api_schema = make_executable_schema(
@@ -14,6 +14,7 @@ full_api_schema = make_executable_schema(
         datetime_scalar,
         *object_types,
         *enum_types,
+        *union_types
     ],
     snake_case_fallback_resolvers,
 )
@@ -26,6 +27,7 @@ query_api_schema = make_executable_schema(
         datetime_scalar,
         *object_types,
         *enum_types,
+        *union_types
     ],
     snake_case_fallback_resolvers,
 )

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -1,6 +1,38 @@
 # GraphQL basic types as returned by queries and mutations, and input types for queries.
 
 """
+TODO: Give proper Description here
+"""
+interface Tag {
+  id: ID!
+  name: String!
+  description: String
+  color: String!
+}
+
+type BoxTag implements Tag {
+  id: ID!
+  name: String!
+  description: String
+  color: String!
+  boxes: [Box!]!
+}
+
+type BeneficiaryTag implements Tag {
+  id: ID!
+  name: String!
+  description: String
+  color: String!
+  beneficiaries: [Beneficiary!]!
+}
+
+"""
+TODO: Give proper Description here
+"""
+union Tag = BoxTag | BeneficaryTag
+
+
+"""
 Representation of a box storing items of a [`Product`]({{Types.Product}}) in a [`Location`]({{Types.Location}})
 """
 type Box {
@@ -20,6 +52,7 @@ type Box {
   lastModifiedBy: User
   lastModifiedOn: Datetime
   comment: String
+  tags: [BoxTag!]!
 }
 
 """
@@ -224,6 +257,7 @@ type Beneficiary {
   createdOn: Datetime
   lastModifiedBy: User
   lastModifiedOn: Datetime
+  tags: [BeneficaryTag!]!
 }
 
 """

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -1,9 +1,9 @@
 # GraphQL basic types as returned by queries and mutations, and input types for queries.
 
 enum TagType {
-  BOX
-  BENEFICIARY
-  ALL
+  Box
+  Beneficiary
+  All
 }
 
 union TaggableResource = Box | Beneficiary
@@ -20,7 +20,7 @@ type Tag {
 """
 Representation of a box storing items of a [`Product`]({{Types.Product}}) in a [`Location`]({{Types.Location}})
 """
-type Box implements TaggableResource{
+type Box {
   id: ID!
   " Sequence of numbers for identifying the box, usually written on box label "
   labelIdentifier: String!
@@ -213,7 +213,7 @@ type BeneficiaryPage {
 Representation of a beneficiary.
 The beneficiary is registered in a specific [`Base`]({{Types.Base}}).
 """
-type Beneficiary implements TaggableResource {
+type Beneficiary {
   id: ID!
   firstName: String!
   lastName: String!

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -1,71 +1,12 @@
 # GraphQL basic types as returned by queries and mutations, and input types for queries.
 
-# """
-# TODO: Give proper Description here
-# """
-# interface GenericTag {
-#   id: ID!
-#   name: String!
-#   description: String
-#   color: String!
-# }
-
-"""
-TODO: Give proper Description here
-"""
-# type BoxTag implements Tag {
-# type BoxTag {
-#   id: ID!
-#   name: String!
-#   description: String
-#   color: String!
-#   taggedResources: [Box!]!
-# }
-
 enum TagType {
   BOX
   BENEFICIARY
   ALL
 }
 
-# type Tag {
-#   ...
-#   applicableRessourceTypes: [TaggableType!]!
-#   resources: [Taggable!]!
-# }
-
-
-"""
-TODO: Give proper Description here
-"""
-# type BeneficiaryTag implements Tag {
-# type BoxAndBeneficaryTag {
-#   id: ID!
-#   name: String!
-#   description: String
-#   color: String!
-#   taggedResources: [TaggableResource!]!
-# }
-
-"""
-TODO: Give proper Description here
-"""
-# type BeneficiaryTag implements Tag {
-# type BeneficaryTag {
-#   id: ID!
-#   name: String!
-#   description: String
-#   color: String!
-#   taggedResources: [Beneficiary!]!
-# }
-
-"""
-TODO: Give proper Description here
-"""
-# union Tag = BoxTag | BeneficaryTag | BoxAndBeneficaryTag
-
 union TaggableResource = Box | Beneficiary
-
 
 type Tag {
   id: ID!
@@ -75,18 +16,6 @@ type Tag {
   tagType: TagType!
   taggedResources: [TaggableResource!]!
 }
-
-
-
-# """
-# TODO: Give proper Description here
-# """
-# interface TaggableResource {
-#   id: ID!
-#   tags: [Tag!]!
-# }
-
-
 
 """
 Representation of a box storing items of a [`Product`]({{Types.Product}}) in a [`Location`]({{Types.Location}})

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -14,52 +14,78 @@
 TODO: Give proper Description here
 """
 # type BoxTag implements Tag {
-type BoxTag {
-  id: ID!
-  name: String!
-  description: String
-  color: String!
-  taggedResources: [Box!]!
+# type BoxTag {
+#   id: ID!
+#   name: String!
+#   description: String
+#   color: String!
+#   taggedResources: [Box!]!
+# }
+
+enum TagType {
+  BOX
+  BENEFICIARY
+  ALL
 }
+
+# type Tag {
+#   ...
+#   applicableRessourceTypes: [TaggableType!]!
+#   resources: [Taggable!]!
+# }
+
 
 """
 TODO: Give proper Description here
 """
 # type BeneficiaryTag implements Tag {
-type BoxAndBeneficaryTag {
+# type BoxAndBeneficaryTag {
+#   id: ID!
+#   name: String!
+#   description: String
+#   color: String!
+#   taggedResources: [TaggableResource!]!
+# }
+
+"""
+TODO: Give proper Description here
+"""
+# type BeneficiaryTag implements Tag {
+# type BeneficaryTag {
+#   id: ID!
+#   name: String!
+#   description: String
+#   color: String!
+#   taggedResources: [Beneficiary!]!
+# }
+
+"""
+TODO: Give proper Description here
+"""
+# union Tag = BoxTag | BeneficaryTag | BoxAndBeneficaryTag
+
+union TaggableResource = Box | Beneficiary
+
+
+type Tag {
   id: ID!
   name: String!
   description: String
-  color: String!
+  color: String
+  tagType: TagType!
   taggedResources: [TaggableResource!]!
 }
 
-"""
-TODO: Give proper Description here
-"""
-# type BeneficiaryTag implements Tag {
-type BeneficaryTag {
-  id: ID!
-  name: String!
-  description: String
-  color: String!
-  taggedResources: [Beneficiary!]!
-}
-
-"""
-TODO: Give proper Description here
-"""
-union Tag = BoxTag | BeneficaryTag | BoxAndBeneficaryTag
 
 
+# """
+# TODO: Give proper Description here
+# """
+# interface TaggableResource {
+#   id: ID!
+#   tags: [Tag!]!
+# }
 
-"""
-TODO: Give proper Description here
-"""
-interface TaggableResource {
-  id: ID!
-  tags: [Tag!]!
-}
 
 
 """

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -13,7 +13,7 @@ type Tag {
   name: String!
   description: String
   color: String
-  tagType: TagType!
+  type: TagType!
   taggedResources: [TaggableResource!]!
 }
 

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -1,41 +1,71 @@
 # GraphQL basic types as returned by queries and mutations, and input types for queries.
 
+# """
+# TODO: Give proper Description here
+# """
+# interface GenericTag {
+#   id: ID!
+#   name: String!
+#   description: String
+#   color: String!
+# }
+
 """
 TODO: Give proper Description here
 """
-interface Tag {
+# type BoxTag implements Tag {
+type BoxTag {
   id: ID!
   name: String!
   description: String
   color: String!
-}
-
-type BoxTag implements Tag {
-  id: ID!
-  name: String!
-  description: String
-  color: String!
-  boxes: [Box!]!
-}
-
-type BeneficiaryTag implements Tag {
-  id: ID!
-  name: String!
-  description: String
-  color: String!
-  beneficiaries: [Beneficiary!]!
+  taggedResources: [Box!]!
 }
 
 """
 TODO: Give proper Description here
 """
-union Tag = BoxTag | BeneficaryTag
+# type BeneficiaryTag implements Tag {
+type BoxAndBeneficaryTag {
+  id: ID!
+  name: String!
+  description: String
+  color: String!
+  taggedResources: [TaggableResource!]!
+}
+
+"""
+TODO: Give proper Description here
+"""
+# type BeneficiaryTag implements Tag {
+type BeneficaryTag {
+  id: ID!
+  name: String!
+  description: String
+  color: String!
+  taggedResources: [Beneficiary!]!
+}
+
+"""
+TODO: Give proper Description here
+"""
+union Tag = BoxTag | BeneficaryTag | BoxAndBeneficaryTag
+
+
+
+"""
+TODO: Give proper Description here
+"""
+interface TaggableResource {
+  id: ID!
+  tags: [Tag!]!
+}
 
 
 """
 Representation of a box storing items of a [`Product`]({{Types.Product}}) in a [`Location`]({{Types.Location}})
 """
-type Box {
+type Box implements TaggableResource{
   id: ID!
   " Sequence of numbers for identifying the box, usually written on box label "
   labelIdentifier: String!
@@ -52,7 +82,7 @@ type Box {
   lastModifiedBy: User
   lastModifiedOn: Datetime
   comment: String
-  tags: [BoxTag!]!
+  tags: [Tag!]!
 }
 
 """
@@ -228,7 +258,7 @@ type BeneficiaryPage {
 Representation of a beneficiary.
 The beneficiary is registered in a specific [`Base`]({{Types.Base}}).
 """
-type Beneficiary {
+type Beneficiary implements TaggableResource {
   id: ID!
   firstName: String!
   lastName: String!
@@ -257,7 +287,7 @@ type Beneficiary {
   createdOn: Datetime
   lastModifiedBy: User
   lastModifiedOn: Datetime
-  tags: [BeneficaryTag!]!
+  tags: [Tag!]!
 }
 
 """

--- a/back/boxtribute_server/models/definitions/tag.py
+++ b/back/boxtribute_server/models/definitions/tag.py
@@ -1,7 +1,8 @@
 from peewee import SQL, CharField, DateTimeField, IntegerField, TextField
 
 from ...db import db
-from ..fields import UIntForeignKeyField
+from ...enums import TagType
+from ..fields import EnumCharField, UIntForeignKeyField
 from .base import Base
 from .user import User
 
@@ -21,7 +22,9 @@ class Tag(db.Model):
         column_name="modified_by", field="id", model=User, null=True
     )
     seq = IntegerField(null=True)
-    type = CharField(constraints=[SQL("DEFAULT 'People'")], index=True, null=True)
+    type = EnumCharField(
+        choices=TagType, constraints=[SQL("DEFAULT 'People'")], index=True, null=True
+    )
 
     class Meta:
         table_name = "tags"

--- a/back/boxtribute_server/models/definitions/tag.py
+++ b/back/boxtribute_server/models/definitions/tag.py
@@ -23,7 +23,11 @@ class Tag(db.Model):
     )
     seq = IntegerField(null=True)
     type = EnumCharField(
-        choices=TagType, constraints=[SQL("DEFAULT 'People'")], index=True, null=True
+        choices=TagType,
+        default=TagType.Beneficiary,
+        constraints=[SQL(f"DEFAULT '{TagType.Beneficiary.value}'")],
+        index=True,
+        null=True,
     )
 
     class Meta:

--- a/back/boxtribute_server/models/definitions/tag.py
+++ b/back/boxtribute_server/models/definitions/tag.py
@@ -1,0 +1,27 @@
+from peewee import SQL, CharField, DateTimeField, IntegerField, TextField
+
+from ...db import db
+from ..fields import UIntForeignKeyField
+from .base import Base
+from .user import User
+
+
+class Tag(db.Model):
+    base = UIntForeignKeyField(column_name="camp_id", field="id", model=Base)
+    color = CharField()
+    created = DateTimeField(null=True)
+    created_by = UIntForeignKeyField(
+        column_name="created_by", field="id", model=User, null=True
+    )
+    deleted = DateTimeField(null=True)
+    description = TextField()
+    name = CharField(column_name="label")
+    modified = DateTimeField(null=True)
+    modified_by = UIntForeignKeyField(
+        column_name="modified_by", field="id", model=User, null=True
+    )
+    seq = IntegerField(null=True)
+    type = CharField(constraints=[SQL("DEFAULT 'People'")], index=True, null=True)
+
+    class Meta:
+        table_name = "tags"

--- a/back/boxtribute_server/models/definitions/tags_relation.py
+++ b/back/boxtribute_server/models/definitions/tags_relation.py
@@ -1,0 +1,15 @@
+from peewee import SQL, CharField, CompositeKey, ForeignKeyField, IntegerField
+
+from ...db import db
+from .tag import Tag
+
+
+class TagsRelation(db.Model):
+    object_id = IntegerField()
+    object_type = CharField(constraints=[SQL("DEFAULT 'People'")], null=True)
+    tag = ForeignKeyField(column_name="tag_id", field="id", model=Tag)
+
+    class Meta:
+        table_name = "tags_relations"
+        indexes = ((("object_id", "tag"), True),)
+        primary_key = CompositeKey("object_id", "tag")

--- a/back/boxtribute_server/models/definitions/tags_relation.py
+++ b/back/boxtribute_server/models/definitions/tags_relation.py
@@ -1,13 +1,14 @@
-from peewee import SQL, CharField, CompositeKey, ForeignKeyField, IntegerField
+from peewee import SQL, CharField, CompositeKey, IntegerField
 
 from ...db import db
+from ..fields import UIntForeignKeyField
 from .tag import Tag
 
 
 class TagsRelation(db.Model):
     object_id = IntegerField()
     object_type = CharField(constraints=[SQL("DEFAULT 'People'")], null=True)
-    tag = ForeignKeyField(column_name="tag_id", field="id", model=Tag)
+    tag = UIntForeignKeyField(column_name="tag_id", field="id", model=Tag)
 
     class Meta:
         table_name = "tags_relations"

--- a/back/boxtribute_server/models/fields.py
+++ b/back/boxtribute_server/models/fields.py
@@ -1,15 +1,24 @@
 """Custom peewee field types for data model definitions."""
+import enum
+
 from peewee import CharField, DateTimeField, ForeignKeyField
 
 
 class EnumCharField(CharField):
-    """Custom class to store name of Python enum item (enum class passed as the
+    """Custom class to store name OR value of Python enum item (enum class passed as the
     `choices` argument during initialization) in a `varchar` field.
     Two methods are provided to convert between application and database layer.
     The conversion is defined by the `choices` attribute.
     Cf. suggestions in https://github.com/coleifer/peewee/issues/630
 
     Note that this class does not represent the MySQL ENUM type.
+
+    If the GraphQL enum values are not identical to the values used on database level
+    (the Python enum class derives from `enum.Enum`), a mapping is performed, e.g.
+        -  GraphQL TagType.Box
+        -> Python  TagType.Box
+        -> MySQL   "Stock"
+    Otherwise (for `IntEnum` classes) the enum value is irrelevant.
     """
 
     def __init__(self, *args, **kwargs):
@@ -18,18 +27,22 @@ class EnumCharField(CharField):
 
     def db_value(self, value):
         """Convert from application to database layer. Accept Python enum member as
-        value, and return the corresponding enum member name. This way, two scenarios
-        are supported:
+        value, and return the corresponding enum member name OR value. This way, two
+        scenarios are supported:
         1. storing the value of a GraphQL Enum input field
         2. assigning a Python enum member to a peewee model field
         """
-        return value.name
+        return value.name if issubclass(self.enum_class, enum.IntEnum) else value.value
 
     def python_value(self, name):
         """Convert from database to application layer. Return Python enum member (which
         in the GraphQL layer is converted to an Enum field).
         """
-        return getattr(self.enum_class, name)
+        return (
+            getattr(self.enum_class, name)  # e.g. "Lost" -> BoxState.Lost
+            if issubclass(self.enum_class, enum.IntEnum)
+            else self.enum_class(name)  # e.g. "Stock" -> TagType.Box
+        )
 
 
 class UIntForeignKeyField(ForeignKeyField):

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -47,6 +47,7 @@ from .shipment_detail import (
 )
 from .size import another_size, default_size
 from .size_range import default_size_range
+from .tag import tags
 from .transaction import default_transaction, relative_transaction
 from .transfer_agreement import (
     default_transfer_agreement,
@@ -104,6 +105,7 @@ __all__ = [
     "reviewed_transfer_agreement",
     "sent_shipment",
     "shipments",
+    "tags",
     "transfer_agreements",
     "unidirectional_transfer_agreement",
 ]

--- a/back/test/data/tag.py
+++ b/back/test/data/tag.py
@@ -22,6 +22,14 @@ def data():
             "name": "pallet1",
             "type": TagType.Box.value,
         },
+        {
+            "id": 3,
+            "base": base_data()[0]["id"],
+            "color": "green",
+            "description": "for everything",
+            "name": "tag-name",
+            "type": TagType.All.value,
+        },
     ]
 
 

--- a/back/test/data/tag.py
+++ b/back/test/data/tag.py
@@ -1,4 +1,5 @@
 import pytest
+from boxtribute_server.enums import TagType
 from boxtribute_server.models.definitions.tag import Tag
 from data.base import data as base_data
 
@@ -11,6 +12,15 @@ def data():
             "color": "red",
             "description": "important",
             "name": "group1",
+            "type": TagType.Beneficiary.value,
+        },
+        {
+            "id": 2,
+            "base": base_data()[0]["id"],
+            "color": "blue",
+            "description": "the description",
+            "name": "pallet1",
+            "type": TagType.Box.value,
         },
     ]
 

--- a/back/test/data/tag.py
+++ b/back/test/data/tag.py
@@ -12,7 +12,7 @@ def data():
             "color": "red",
             "description": "important",
             "name": "group1",
-            "type": TagType.Beneficiary.value,
+            "type": TagType.Beneficiary,
         },
         {
             "id": 2,
@@ -20,7 +20,7 @@ def data():
             "color": "blue",
             "description": "the description",
             "name": "pallet1",
-            "type": TagType.Box.value,
+            "type": TagType.Box,
         },
         {
             "id": 3,
@@ -28,7 +28,7 @@ def data():
             "color": "green",
             "description": "for everything",
             "name": "tag-name",
-            "type": TagType.All.value,
+            "type": TagType.All,
         },
     ]
 

--- a/back/test/data/tag.py
+++ b/back/test/data/tag.py
@@ -1,15 +1,16 @@
 import pytest
 from boxtribute_server.models.definitions.tag import Tag
+from data.base import data as base_data
 
 
 def data():
     return [
         {
             "id": 1,
-            "base": 1,
+            "base": base_data()[0]["id"],
             "color": "red",
             "description": "important",
-            "name": "pallet1",
+            "name": "group1",
         },
     ]
 

--- a/back/test/data/tag.py
+++ b/back/test/data/tag.py
@@ -1,0 +1,23 @@
+import pytest
+from boxtribute_server.models.definitions.tag import Tag
+
+
+def data():
+    return [
+        {
+            "id": 1,
+            "base": 1,
+            "color": "red",
+            "description": "important",
+            "name": "pallet1",
+        },
+    ]
+
+
+@pytest.fixture
+def tags():
+    return data()
+
+
+def create():
+    Tag.insert_many(data()).execute()

--- a/back/test/data/tags_relation.py
+++ b/back/test/data/tags_relation.py
@@ -2,6 +2,7 @@ import pytest
 from boxtribute_server.enums import TagType
 from boxtribute_server.models.definitions.tags_relation import TagsRelation
 from data.beneficiary import default_beneficiary_data
+from data.box import default_box_data
 from data.tag import data as tag_data
 
 
@@ -11,6 +12,11 @@ def data():
             "object_id": default_beneficiary_data()["id"],
             "object_type": TagType.Beneficiary.value,
             "tag": tag_data()[0]["id"],
+        },
+        {
+            "object_id": default_box_data()["id"],
+            "object_type": TagType.Box.value,
+            "tag": tag_data()[1]["id"],
         },
     ]
 

--- a/back/test/data/tags_relation.py
+++ b/back/test/data/tags_relation.py
@@ -2,7 +2,7 @@ import pytest
 from boxtribute_server.enums import TagType
 from boxtribute_server.models.definitions.tags_relation import TagsRelation
 from data.beneficiary import default_beneficiary_data
-from data.box import default_box_data
+from data.box import box_without_qr_code_data, default_box_data
 from data.tag import data as tag_data
 
 
@@ -17,6 +17,16 @@ def data():
             "object_id": default_box_data()["id"],
             "object_type": TagType.Box.value,
             "tag": tag_data()[1]["id"],
+        },
+        {
+            "object_id": default_beneficiary_data()["id"],
+            "object_type": TagType.Beneficiary.value,
+            "tag": tag_data()[2]["id"],
+        },
+        {
+            "object_id": box_without_qr_code_data()["id"],
+            "object_type": TagType.Box.value,
+            "tag": tag_data()[2]["id"],
         },
     ]
 

--- a/back/test/data/tags_relation.py
+++ b/back/test/data/tags_relation.py
@@ -1,0 +1,24 @@
+import pytest
+from boxtribute_server.enums import TagType
+from boxtribute_server.models.definitions.tags_relation import TagsRelation
+from data.beneficiary import default_beneficiary_data
+from data.tag import data as tag_data
+
+
+def data():
+    return [
+        {
+            "object_id": default_beneficiary_data()["id"],
+            "object_type": TagType.Beneficiary.value,
+            "tag": tag_data()[0]["id"],
+        },
+    ]
+
+
+@pytest.fixture
+def tags_relations():
+    return data()
+
+
+def create():
+    TagsRelation.insert_many(data()).execute()

--- a/back/test/endpoint_tests/test_tag.py
+++ b/back/test/endpoint_tests/test_tag.py
@@ -2,7 +2,8 @@ from utils import assert_successful_request
 
 
 def test_tags_query(read_only_client, tags):
-    query = """query { tags { id name } }"""
+    query = """query { tags { id name type } }"""
     queried_tag = assert_successful_request(read_only_client, query)[0]
     assert queried_tag["name"] == tags[0]["name"]
     assert int(queried_tag["id"]) == tags[0]["id"]
+    assert queried_tag["type"] == "Beneficiary"

--- a/back/test/endpoint_tests/test_tag.py
+++ b/back/test/endpoint_tests/test_tag.py
@@ -1,0 +1,8 @@
+from utils import assert_successful_request
+
+
+def test_tags_query(read_only_client, tags):
+    query = """query { tags { id name } }"""
+    queried_tag = assert_successful_request(read_only_client, query)[0]
+    assert queried_tag["name"] == tags[0]["name"]
+    assert int(queried_tag["id"]) == tags[0]["id"]

--- a/back/test/endpoint_tests/test_tag.py
+++ b/back/test/endpoint_tests/test_tag.py
@@ -2,7 +2,9 @@ from boxtribute_server.enums import TagType
 from utils import assert_successful_request
 
 
-def test_tags_query(read_only_client, tags, default_beneficiary, default_box):
+def test_tags_query(
+    read_only_client, tags, default_beneficiary, default_box, box_without_qr_code
+):
     query = """query { tags {
                 id
                 name
@@ -33,6 +35,21 @@ def test_tags_query(read_only_client, tags, default_beneficiary, default_box):
                 {
                     "__typename": "Box",
                     "id": str(default_box["id"]),
+                },
+            ],
+        },
+        {
+            "id": str(tags[2]["id"]),
+            "name": tags[2]["name"],
+            "type": TagType(tags[2]["type"]).name,
+            "taggedResources": [
+                {
+                    "__typename": "Beneficiary",
+                    "id": str(default_beneficiary["id"]),
+                },
+                {
+                    "__typename": "Box",
+                    "id": str(box_without_qr_code["id"]),
                 },
             ],
         },

--- a/back/test/endpoint_tests/test_tag.py
+++ b/back/test/endpoint_tests/test_tag.py
@@ -1,9 +1,27 @@
+from boxtribute_server.enums import TagType
 from utils import assert_successful_request
 
 
-def test_tags_query(read_only_client, tags):
-    query = """query { tags { id name type } }"""
-    queried_tag = assert_successful_request(read_only_client, query)[0]
-    assert queried_tag["name"] == tags[0]["name"]
-    assert int(queried_tag["id"]) == tags[0]["id"]
-    assert queried_tag["type"] == "Beneficiary"
+def test_tags_query(read_only_client, tags, default_beneficiary):
+    query = """query { tags {
+                id
+                name
+                type
+                taggedResources {
+                    __typename
+                    ...on Beneficiary { id }
+                } } }"""
+    queried_tags = assert_successful_request(read_only_client, query)
+    assert queried_tags == [
+        {
+            "id": str(tags[0]["id"]),
+            "name": tags[0]["name"],
+            "type": TagType.Beneficiary.name,
+            "taggedResources": [
+                {
+                    "__typename": "Beneficiary",
+                    "id": str(default_beneficiary["id"]),
+                },
+            ],
+        },
+    ]

--- a/back/test/endpoint_tests/test_tag.py
+++ b/back/test/endpoint_tests/test_tag.py
@@ -2,7 +2,7 @@ from boxtribute_server.enums import TagType
 from utils import assert_successful_request
 
 
-def test_tags_query(read_only_client, tags, default_beneficiary):
+def test_tags_query(read_only_client, tags, default_beneficiary, default_box):
     query = """query { tags {
                 id
                 name
@@ -10,17 +10,29 @@ def test_tags_query(read_only_client, tags, default_beneficiary):
                 taggedResources {
                     __typename
                     ...on Beneficiary { id }
+                    ...on Box { id }
                 } } }"""
     queried_tags = assert_successful_request(read_only_client, query)
     assert queried_tags == [
         {
             "id": str(tags[0]["id"]),
             "name": tags[0]["name"],
-            "type": TagType.Beneficiary.name,
+            "type": TagType(tags[0]["type"]).name,
             "taggedResources": [
                 {
                     "__typename": "Beneficiary",
                     "id": str(default_beneficiary["id"]),
+                },
+            ],
+        },
+        {
+            "id": str(tags[1]["id"]),
+            "name": tags[1]["name"],
+            "type": TagType(tags[1]["type"]).name,
+            "taggedResources": [
+                {
+                    "__typename": "Box",
+                    "id": str(default_box["id"]),
                 },
             ],
         },


### PR DESCRIPTION
This PR brings
- an extension of the GraphQL API for Tags
- two new data models for Tag and TagsRelation
- test data extension
- improvements for Python enum usage in the application layer
