### PR TITLE
Make peewee generate underscore table names

### DIFF
--- a/back/boxtribute_server/box_transfer/agreement.py
+++ b/back/boxtribute_server/box_transfer/agreement.py
@@ -42,6 +42,7 @@ def create_transfer_agreement(
     valid_from=None,
     valid_until=None,
     timezone=None,
+    comment=None,
     user,
 ):
     """Insert information for a new TransferAgreement in the database. Update
@@ -79,6 +80,7 @@ def create_transfer_agreement(
             valid_from=valid_from or utcnow(),
             valid_until=valid_until,
             requested_by=user.id,
+            comment=comment,
         )
 
         # In GraphQL input, base IDs can be omitted, or explicitly be null.

--- a/back/boxtribute_server/graph_ql/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/inputs.graphql
@@ -62,6 +62,7 @@ input TransferAgreementCreationInput {
   timezone: String
   sourceBaseIds: [Int!]
   targetBaseIds: [Int!]
+  comment: String
 }
 
 input ShipmentCreationInput {

--- a/back/boxtribute_server/models/definitions/shipment.py
+++ b/back/boxtribute_server/models/definitions/shipment.py
@@ -36,3 +36,6 @@ class Shipment(db.Model):
     completed_by = UIntForeignKeyField(
         model=User, on_update="CASCADE", on_delete="SET NULL", null=True
     )
+
+    class Meta:
+        legacy_table_names = False

--- a/back/boxtribute_server/models/definitions/shipment_detail.py
+++ b/back/boxtribute_server/models/definitions/shipment_detail.py
@@ -25,3 +25,6 @@ class ShipmentDetail(db.Model):
     deleted_by = UIntForeignKeyField(
         model=User, on_update="CASCADE", on_delete="SET NULL", null=True
     )
+
+    class Meta:
+        legacy_table_names = False

--- a/back/boxtribute_server/models/definitions/transfer_agreement.py
+++ b/back/boxtribute_server/models/definitions/transfer_agreement.py
@@ -44,3 +44,6 @@ class TransferAgreement(db.Model):
     valid_from = DateTimeField(default=utcnow)
     valid_until = DateTimeField(null=True)
     comment = TextField(constraints=[SQL("DEFAULT ''")], default="")
+
+    class Meta:
+        legacy_table_names = False

--- a/back/boxtribute_server/models/definitions/transfer_agreement.py
+++ b/back/boxtribute_server/models/definitions/transfer_agreement.py
@@ -1,4 +1,4 @@
-from peewee import SQL, DateTimeField, TextField
+from peewee import DateTimeField, TextField
 
 from ...db import db
 from ...enums import TransferAgreementState, TransferAgreementType
@@ -43,7 +43,7 @@ class TransferAgreement(db.Model):
     )
     valid_from = DateTimeField(default=utcnow)
     valid_until = DateTimeField(null=True)
-    comment = TextField(constraints=[SQL("DEFAULT ''")], default="")
+    comment = TextField(null=True)
 
     class Meta:
         legacy_table_names = False

--- a/back/boxtribute_server/models/definitions/transfer_agreement_detail.py
+++ b/back/boxtribute_server/models/definitions/transfer_agreement_detail.py
@@ -10,3 +10,6 @@ class TransferAgreementDetail(db.Model):
     )
     source_base = UIntForeignKeyField(model=Base, null=True, on_update="CASCADE")
     target_base = UIntForeignKeyField(model=Base, null=True, on_update="CASCADE")
+
+    class Meta:
+        legacy_table_names = False

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -109,6 +109,7 @@ def test_transfer_agreement_mutations(
                         requestedBy {{ id }}
                         validFrom
                         validUntil
+                        comment
                         sourceBases {{ id }}
                         targetBases {{ id }}
                         shipments {{ id }}
@@ -129,6 +130,7 @@ def test_transfer_agreement_mutations(
         "type": TransferAgreementType.Bidirectional.name,
         "requestedBy": {"id": "8"},
         "validUntil": None,
+        "comment": None,
         "sourceBases": [{"id": "1"}, {"id": "2"}],
         "targetBases": [{"id": "3"}, {"id": "4"}],
         "shipments": [],
@@ -138,10 +140,12 @@ def test_transfer_agreement_mutations(
     # Test case 2.2.2
     valid_from = "2021-12-15"
     valid_until = "2022-06-30"
+    comment = "this is a comment"
     creation_input = f"""targetOrganisationId: {another_organisation['id']},
         type: {TransferAgreementType.Bidirectional.name},
         validFrom: "{valid_from}",
         validUntil: "{valid_until}",
+        comment: "{comment}",
         timezone: "Europe/London",
         sourceBaseIds: [1],
         targetBaseIds: [3]"""
@@ -155,6 +159,7 @@ def test_transfer_agreement_mutations(
         "state": TransferAgreementState.UnderReview.name,
         "type": TransferAgreementType.Bidirectional.name,
         "requestedBy": {"id": "8"},
+        "comment": comment,
         "sourceBases": [{"id": "1"}],
         "targetBases": [{"id": "3"}],
         "shipments": [],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
             - /app/react/node_modules
     db:
         image: mysql/mysql-server:8.0 # We run MySQL 8.0 on the production environment atm
-        command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
+        command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1 --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci
         environment:
             MYSQL_ROOT_PASSWORD: dropapp_root
             MYSQL_ROOT_HOST: "%"


### PR DESCRIPTION
In preparation for the migration scripts coming in dropapp for creating transfer-agreement related tables in the MySQL databases.

FYI @spaudanjo @flisowna when creating a transfer agreement, an optional comment can be passed now.