### PR TITLE
Improve performance of boxes-for-base query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ back/test-results
 yarn-error.log
 
 ./public/
+docs/graphql-api/public
 *.zip
 .VSCodeCounter

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log
 docs/graphql-api/public
 *.zip
 .VSCodeCounter
+.DS_Store

--- a/back/.gitignore
+++ b/back/.gitignore
@@ -1,10 +1,5 @@
-.env
-env
-.venv
 *.pyc
 __pycache__
 .eggs
 *.egg-info
-.DS_Store
-.venv
 .pytest_cache

--- a/back/boxtribute_server/graph_ql/pagination.py
+++ b/back/boxtribute_server/graph_ql/pagination.py
@@ -199,7 +199,8 @@ def load_into_page(model, *conditions, selection=None, pagination_input):
     for condition in conditions:
         pagination_condition = (condition) & (pagination_condition)
 
-    selection = selection or model.select()
+    if selection is None:
+        selection = model.select()
     query_result = (
         selection.where(pagination_condition).order_by(model.id).limit(limit + 1)
     )

--- a/react/.gitignore
+++ b/react/.gitignore
@@ -12,13 +12,6 @@
 /build
 
 # misc
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-.env
-
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/react/src/views/Boxes/BoxesView.test.tsx
+++ b/react/src/views/Boxes/BoxesView.test.tsx
@@ -19,6 +19,7 @@ describe("Boxes view", () => {
             locations: [
               {
                 __typename: "Location",
+                name: "Warehouse 1",
                 boxes: {
                   __typename: "BoxPage",
                   totalCount: 27,
@@ -26,9 +27,6 @@ describe("Boxes view", () => {
                     {
                       __typename: "Box",
                       labelIdentifier: "1234",
-                      location: {
-                        name: "Warehouse 1"
-                      },
                       state: "Donated",
                       size: "4",
                       product: {
@@ -41,9 +39,6 @@ describe("Boxes view", () => {
                     {
                       __typename: "Box",
                       labelIdentifier: "1235",
-                      location: {
-                        name: "Warehouse 1"
-                      },
                       state: "Donated",
                       size: "52",
                       product: {
@@ -58,6 +53,7 @@ describe("Boxes view", () => {
               },
               {
                 __typename: "Location",
+                name: "Warehouse 2",
                 boxes: {
                   __typename: "BoxPage",
                   totalCount: 31,
@@ -65,9 +61,6 @@ describe("Boxes view", () => {
                     {
                       __typename: "Box",
                       labelIdentifier: "1236",
-                      location: {
-                        name: "Warehouse 2"
-                      },
                       state: "Lost",
                       size: "54",
                       product: {
@@ -80,9 +73,6 @@ describe("Boxes view", () => {
                     {
                       __typename: "Box",
                       labelIdentifier: "1237",
-                      location: {
-                        name: "Warehouse 2"
-                      },
                       state: "MarkedForShipment",
                       size: "68",
                       product: {
@@ -95,9 +85,6 @@ describe("Boxes view", () => {
                     {
                       __typename: "Box",
                       labelIdentifier: "1238",
-                      location: {
-                        name: "Warehouse 2"
-                      },
                       state: "Lost",
                       size: "118",
                       product: {
@@ -112,6 +99,7 @@ describe("Boxes view", () => {
               },
               {
                 __typename: "Location",
+                name: "Warehouse 3",
                 boxes: {
                   __typename: "BoxPage",
                   totalCount: 16,
@@ -119,9 +107,6 @@ describe("Boxes view", () => {
                     {
                       __typename: "Box",
                       labelIdentifier: "1239",
-                      location: {
-                        name: "Warehouse 3"
-                      },
                       state: "InStock",
                       size: "68",
                       product: {
@@ -134,9 +119,6 @@ describe("Boxes view", () => {
                     {
                       __typename: "Box",
                       labelIdentifier: "1230",
-                      location: {
-                        name: "Warehouse 3"
-                      },
                       state: "InStock",
                       size: "68",
                       product: {

--- a/react/src/views/Boxes/BoxesView.tsx
+++ b/react/src/views/Boxes/BoxesView.tsx
@@ -8,6 +8,7 @@ export const BOXES_FOR_BASE_QUERY = gql`
   query BoxesForBase($baseId: ID!) {
     base(id: $baseId) {
       locations {
+        name
         boxes {
           totalCount
           elements {
@@ -22,9 +23,6 @@ export const BOXES_FOR_BASE_QUERY = gql`
               name
             }
             items
-            location {
-              name
-            }
           }
         }
       }
@@ -44,7 +42,7 @@ const graphqlToTableTransformer = (
         items: element.items,
         size: element.size.label,
         state: element.state,
-        location: element.location?.name,
+        location: location?.name,
       } as BoxRow)) || []
   ) || [];
 


### PR DESCRIPTION
Loading the Boxes view in the FE was reportedly slow. I first looked at the GraphQL query issued by the FE, and then dug into the SQL queries run by peewee in the BE. I could find a redundant `select * from stock` query as a side-effect from peewee objects (still trying to understand the background).

@spaudanjo @flisowna Can you check the performance in the FE on your end?
