### PR TITLE
Revert "Integrate sentry SDK in backend (#303)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,9 +208,6 @@ jobs:
               MYSQL_DB=${DB_NAME}
               MYSQL_PORT=3306
               MYSQL_SOCKET=${DB_SOCKET}
-              SENTRY_DSN=${SENTRY_DSN}
-              SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
-              SENTRY_RELEASE=${CIRCLE_SHA1}
               " > .env
             if [[ "<< parameters.serviceName >>" != "api-"* ]]; then echo "EXPOSE_FULL_GRAPHQL=1" >> .env; fi
       - run:

--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -6,7 +6,6 @@ from functools import wraps
 
 from flask import g, request
 from jose import JOSEError, jwt
-from sentry_sdk import set_user as set_sentry_user
 
 from .exceptions import AuthenticationFailed
 
@@ -217,7 +216,6 @@ def requires_auth(f):
             audience=os.environ["AUTH0_AUDIENCE"],
         )
         g.user = CurrentUser.from_jwt(payload)
-        set_sentry_user({"id": g.user.id, "jwt_payload": payload})
 
         return f(*args, **kwargs)
 

--- a/back/boxtribute_server/main.py
+++ b/back/boxtribute_server/main.py
@@ -1,17 +1,8 @@
 """Main entry point for web application"""
 import os
 
-import sentry_sdk
-from sentry_sdk.integrations.flask import FlaskIntegration
-
 from .app import configure_app, create_app
 from .routes import api_bp, app_bp
-
-sentry_sdk.init(
-    # dsn/environment/release: reading SENTRY_* environment variables set in CircleCI
-    integrations=[FlaskIntegration()],
-    traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", 1.0)),
-)
 
 app = create_app()
 blueprints = [api_bp] if os.getenv("EXPOSE_FULL_GRAPHQL") is None else [app_bp]

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -1,7 +1,6 @@
 ariadne==0.15.1
 Flask==2.1.3
 Flask-Cors==3.0.10
-sentry-sdk[flask]==1.7.2
 PyMySQL==1.0.2
 peewee==3.15.1
 peewee-moves==2.1.0

--- a/back/setup.cfg
+++ b/back/setup.cfg
@@ -25,8 +25,6 @@ exclude_lines =
     if __name__ == .__main__.:
     except Exception:
     def main()
-omit =
-    */main.py
 
 [coverage:html]
 directory = back/htmlcov


### PR DESCRIPTION
This reverts commit 3bf43fd5d9f31c85dff5f01b02cfb87eb720e00c (which comes from this PR https://github.com/boxwise/boxtribute/pull/303) which introduced a bug that prevents the BE to start (at least in docker). 
@pylipp 