### PR TITLE
Improve complex GraphQL queries

### DIFF
--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -893,7 +893,7 @@ def resolve_resource_base(obj, _):
 @product.field("gender")
 def resolve_product_gender(product_obj, _):
     # Instead of a ProductGender instance return an integer for EnumType conversion
-    return product_obj.gender.id
+    return product_obj.gender_id
 
 
 @product_category.field("hasGender")

--- a/back/boxtribute_server/models/definitions/product.py
+++ b/back/boxtribute_server/models/definitions/product.py
@@ -40,6 +40,7 @@ class Product(db.Model):
         field="id",
         model=ProductGender,
         on_update="CASCADE",
+        object_id_name="gender_id",
     )
     last_modified_on = DateTimeField(column_name="modified", null=True)
     last_modified_by = UIntForeignKeyField(

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -1342,7 +1342,7 @@ export type BoxesForBaseQueryVariables = Exact<{
 }>;
 
 
-export type BoxesForBaseQuery = { __typename?: 'Query', base?: { __typename?: 'Base', locations: Array<{ __typename?: 'Location', name?: string | null, boxes?: { __typename?: 'BoxPage', totalCount: number, elements: Array<{ __typename?: 'Box', labelIdentifier: string, state: BoxState, items?: number | null, size: { __typename?: 'Size', id: string, label: string }, product?: { __typename?: 'Product', gender?: ProductGender | null, name: string } | null, tags: Array<{ __typename?: 'Tag', name: string, id: string }>, place?: { __typename?: 'DistributionSpot', name?: string | null } | { __typename?: 'Location', name?: string | null } | null }> } | null }> } | null };
+export type BoxesForBaseQuery = { __typename?: 'Query', base?: { __typename?: 'Base', locations: Array<{ __typename?: 'Location', name?: string | null, boxes?: { __typename?: 'BoxPage', totalCount: number, elements: Array<{ __typename?: 'Box', labelIdentifier: string, state: BoxState, items?: number | null, size: { __typename?: 'Size', id: string, label: string }, product?: { __typename?: 'Product', gender?: ProductGender | null, name: string } | null, tags: Array<{ __typename?: 'Tag', name: string, id: string }> }> } | null }> } | null };
 
 export type DistributionSpotQueryVariables = Exact<{
   id: Scalars['ID'];

--- a/react/src/views/Boxes/BoxesView.tsx
+++ b/react/src/views/Boxes/BoxesView.tsx
@@ -28,9 +28,6 @@ export const BOXES_FOR_BASE_QUERY = gql`
               id
             }
             items
-            place {
-              name
-            }
           }
         }
       }
@@ -52,7 +49,7 @@ const graphqlToTableTransformer = (
             items: element.items,
             size: element.size.label,
             state: element.state,
-            place: element.place?.name,
+            place: location.name,
             tags: element.tags?.map(tag => tag.name),
           } as BoxRow)
       ) || []


### PR DESCRIPTION
I had another look at the performance of the BoxesForBase query.
Using a profiler I found three bottlenecks:

- Avoid unnecessary SELECT for product gender ID (this is a peewee caveat, fixed)
- Remove redundant query for box place (was fixed in #292 but re-introduced when renaming happened, fixed)
- resolving `boxes { elements { product { } } }` results in a lot of separated SELECT queries for products (same for size, presumably). I hacked a basic loader (storing a single call of `Product.select()` in a dictionary) which brought down runtime of the product resolver from 1.4s to 0.14s

As a conclusion from the third bottleneck, and because the other slow queries have similar complexity, I think we defs have to look into data loaders.

FYI @aerinsol
