### PR TITLE
Introduce dataloaders

### DIFF
--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -891,6 +891,16 @@ def resolve_resource_base(obj, _):
     return obj.base
 
 
+@product.field("category")
+def resolve_product_product_category(product_obj, info):
+    return info.context["product_category_loader"].load(product_obj.category_id)
+
+
+@product.field("sizeRange")
+def resolve_product_size_range(product_obj, info):
+    return info.context["size_range_loader"].load(product_obj.size_range_id)
+
+
 @product.field("gender")
 def resolve_product_gender(product_obj, _):
     # Instead of a ProductGender instance return an integer for EnumType conversion

--- a/back/boxtribute_server/loaders.py
+++ b/back/boxtribute_server/loaders.py
@@ -4,7 +4,9 @@ from aiodataloader import DataLoader
 
 from .enums import TaggableObjectType
 from .models.definitions.product import Product
+from .models.definitions.product_category import ProductCategory
 from .models.definitions.size import Size
+from .models.definitions.size_range import SizeRange
 from .models.definitions.tag import Tag
 from .models.definitions.tags_relation import TagsRelation
 
@@ -34,3 +36,15 @@ class TagsForBoxLoader(DataLoader):
 
         # keys are in fact box IDs. Return empty list if box has no tags assigned
         return [tags.get(i, []) for i in keys]
+
+
+class ProductCategoryLoader(DataLoader):
+    async def batch_load_fn(self, keys):
+        categories = {c.id: c for c in ProductCategory.select()}
+        return [categories.get(i) for i in keys]
+
+
+class SizeRangeLoader(DataLoader):
+    async def batch_load_fn(self, keys):
+        ranges = {s.id: s for s in SizeRange.select()}
+        return [ranges.get(i) for i in keys]

--- a/back/boxtribute_server/loaders.py
+++ b/back/boxtribute_server/loaders.py
@@ -1,0 +1,36 @@
+from collections import defaultdict
+
+from aiodataloader import DataLoader
+
+from .enums import TaggableObjectType
+from .models.definitions.product import Product
+from .models.definitions.size import Size
+from .models.definitions.tag import Tag
+from .models.definitions.tags_relation import TagsRelation
+
+
+class ProductLoader(DataLoader):
+    async def batch_load_fn(self, keys):
+        products = {p.id: p for p in Product.select().where(Product.id << keys)}
+        return [products.get(i) for i in keys]
+
+
+class SizeLoader(DataLoader):
+    async def batch_load_fn(self, keys):
+        sizes = {s.id: s for s in Size.select()}
+        return [sizes.get(i) for i in keys]
+
+
+class TagsForBoxLoader(DataLoader):
+    async def batch_load_fn(self, keys):
+        tags = defaultdict(list)
+        # maybe need different join type
+        for relation in (
+            TagsRelation.select()
+            .join(Tag)
+            .where(TagsRelation.object_type == TaggableObjectType.Box)
+        ):
+            tags[relation.object_id].append(relation.tag)
+
+        # keys are in fact box IDs. Return empty list if box has no tags assigned
+        return [tags.get(i, []) for i in keys]

--- a/back/boxtribute_server/models/definitions/product.py
+++ b/back/boxtribute_server/models/definitions/product.py
@@ -58,6 +58,7 @@ class Product(db.Model):
         model=SizeRange,
         on_delete="RESTRICT",
         on_update="CASCADE",
+        object_id_name="size_range_id",
     )
     in_shop = IntegerField(
         column_name="stockincontainer", constraints=[SQL("DEFAULT 0")]

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -1,7 +1,8 @@
 """Construction of routes for web app and API"""
+import asyncio
 import os
 
-from ariadne import graphql_sync
+from ariadne import graphql, graphql_sync
 from ariadne.constants import PLAYGROUND_HTML
 from flask import Blueprint, current_app, jsonify, request
 from flask_cors import cross_origin
@@ -9,6 +10,7 @@ from flask_cors import cross_origin
 from .auth import request_jwt, requires_auth
 from .exceptions import AuthenticationFailed, format_database_errors
 from .graph_ql.schema import full_api_schema, query_api_schema
+from .loaders import ProductLoader, SizeLoader, TagsForBoxLoader
 
 # Blueprint for query-only API. Deployed on the 'api*' subdomains
 api_bp = Blueprint("api_bp", __name__)
@@ -82,15 +84,27 @@ def graphql_playgroud():
 @cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
 @requires_auth
 def graphql_server():
-    # Note: Passing the request to the context is optional.
-    # In Flask, the current request is always accessible as flask.request
-    success, result = graphql_sync(
-        full_api_schema,
-        data=request.get_json(),
-        context_value=request,
-        debug=current_app.debug,
-        introspection=current_app.debug,
-        error_formatter=format_database_errors,
+    # Start async event loop, required for DataLoader construction, cf.
+    # https://github.com/graphql-python/graphql-core/issues/71#issuecomment-620106364
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    # Create DataLoaders and persist them for the time of processing the request
+    context = {
+        "product_loader": ProductLoader(),
+        "size_loader": SizeLoader(),
+        "tags_for_box_loader": TagsForBoxLoader(),
+    }
+
+    success, result = loop.run_until_complete(
+        graphql(
+            full_api_schema,
+            data=request.get_json(),
+            context_value=context,
+            debug=current_app.debug,
+            introspection=current_app.debug,
+            error_formatter=format_database_errors,
+        )
     )
 
     status_code = 200 if success else 400

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -10,7 +10,13 @@ from flask_cors import cross_origin
 from .auth import request_jwt, requires_auth
 from .exceptions import AuthenticationFailed, format_database_errors
 from .graph_ql.schema import full_api_schema, query_api_schema
-from .loaders import ProductLoader, SizeLoader, TagsForBoxLoader
+from .loaders import (
+    ProductCategoryLoader,
+    ProductLoader,
+    SizeLoader,
+    SizeRangeLoader,
+    TagsForBoxLoader,
+)
 
 # Blueprint for query-only API. Deployed on the 'api*' subdomains
 api_bp = Blueprint("api_bp", __name__)
@@ -91,8 +97,10 @@ def graphql_server():
 
     # Create DataLoaders and persist them for the time of processing the request
     context = {
+        "product_category_loader": ProductCategoryLoader(),
         "product_loader": ProductLoader(),
         "size_loader": SizeLoader(),
+        "size_range_loader": SizeRangeLoader(),
         "tags_for_box_loader": TagsForBoxLoader(),
     }
 

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -8,4 +8,5 @@ peewee-moves==2.1.0
 python-dateutil==2.8.2
 python-dotenv==0.20.0
 python-jose==3.3.0
+aiodataloader==0.2.1
 gunicorn

--- a/back/scripts/load-test.js
+++ b/back/scripts/load-test.js
@@ -31,12 +31,15 @@ const payload = JSON.stringify({
   // query: "query { beneficiary(id: 1007) { firstName } }",
 
   // B) Request single field of multiple resources
-  query: "query { beneficiaries { elements { firstName } } }",
+  // query: "query { beneficiaries { elements { firstName } } }",
+
+  // C) All boxes for base
+  // query: "query { base(id: 1) { locations { name boxes { totalCount elements { labelIdentifier state size { id label } product { gender name } tags { name id } items } } } } }",
+  query: "query { location(id: 1) { boxes { elements { product { gender name } } } } }",
 });
 
 export const options = {
   scenarios: {
-    /*
     shared: {
       executor: 'shared-iterations',
 
@@ -45,11 +48,11 @@ export const options = {
       gracefulStop: '5s',
 
       // executor-specific configuration
-      vus: 10,
-      iterations: 100,
+      vus: 1,
+      iterations: 1,
       // maxDuration: '10s',
     },
-    */
+    /*
     ramping: {
       executor: "ramping-vus",
       startVUs: 0,
@@ -60,6 +63,7 @@ export const options = {
       ],
       gracefulRampDown: "0s",
     },
+    */
   },
 };
 
@@ -67,7 +71,7 @@ export default function () {
   const res = http.post(url, payload, params);
 
   // Use in combination with A/B to assert working auth
-  // check(res, { 'is status 200': (r) => r.status === 200, });
+  check(res, { 'is status 200': (r) => r.status === 200, });
 
   // Use in combination with A
   // check(res, { 'has correct firstName': (r) => r.json().data.beneficiary.firstName === "Kailyn", });

--- a/back/scripts/load-test.js
+++ b/back/scripts/load-test.js
@@ -34,9 +34,10 @@ const payload = JSON.stringify({
   // query: "query { beneficiaries { elements { firstName } } }",
 
   // C) All boxes for base
-  query: "query { products(paginationInput: { first: 500 }) { elements { id name gender category { name } sizeRange { label } } } }",
   // query: "query { base(id: 1) { locations { name boxes { totalCount elements { labelIdentifier state size { id label } product { gender name } tags { name id } numberOfItems } } } } }",
-  // query: "query { location(id: 1) { boxes { elements { product { gender name } } } } }",
+
+  // D) Many products and their category and size range
+  query: "query { products(paginationInput: { first: 500 }) { elements { id name gender category { name } sizeRange { label } } } }",
 });
 
 export const options = {

--- a/back/scripts/load-test.js
+++ b/back/scripts/load-test.js
@@ -34,7 +34,8 @@ const payload = JSON.stringify({
   // query: "query { beneficiaries { elements { firstName } } }",
 
   // C) All boxes for base
-  query: "query { base(id: 1) { locations { name boxes { totalCount elements { labelIdentifier state size { id label } product { gender name } tags { name id } numberOfItems } } } } }",
+  query: "query { products(paginationInput: { first: 500 }) { elements { id name gender category { name } sizeRange { label } } } }",
+  // query: "query { base(id: 1) { locations { name boxes { totalCount elements { labelIdentifier state size { id label } product { gender name } tags { name id } numberOfItems } } } } }",
   // query: "query { location(id: 1) { boxes { elements { product { gender name } } } } }",
 });
 

--- a/back/scripts/load-test.js
+++ b/back/scripts/load-test.js
@@ -34,8 +34,8 @@ const payload = JSON.stringify({
   // query: "query { beneficiaries { elements { firstName } } }",
 
   // C) All boxes for base
-  // query: "query { base(id: 1) { locations { name boxes { totalCount elements { labelIdentifier state size { id label } product { gender name } tags { name id } items } } } } }",
-  query: "query { location(id: 1) { boxes { elements { product { gender name } } } } }",
+  query: "query { base(id: 1) { locations { name boxes { totalCount elements { labelIdentifier state size { id label } product { gender name } tags { name id } numberOfItems } } } } }",
+  // query: "query { location(id: 1) { boxes { elements { product { gender name } } } } }",
 });
 
 export const options = {

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -223,7 +223,7 @@ def test_invalid_permission_for_shipment_base(read_only_client, mocker, field):
     assert_forbidden_request(read_only_client, query, value={field: None})
 
 
-@pytest.mark.parametrize("field", ["place", "product", "qrCode"])
+@pytest.mark.parametrize("field", ["place", "qrCode"])
 def test_invalid_permission_for_box_field(read_only_client, mocker, default_box, field):
     # verify missing field:read permission
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(

--- a/back/test/integration_tests/test_operations.py
+++ b/back/test/integration_tests/test_operations.py
@@ -13,9 +13,9 @@ def test_queries(auth0_client, endpoint):
     queried_box = _assert_successful_request(auth0_client, query)["box"]
     assert queried_box == {"id": "735"}
 
-    query = """query { box(labelIdentifier: "177892") { state } }"""
+    query = """query { box(labelIdentifier: "177892") { state size { id } } }"""
     queried_box = _assert_successful_request(auth0_client, query)
-    assert queried_box == {"state": "Donated"}
+    assert queried_box == {"state": "Donated", "size": {"id": "68"}}
 
     query = """query { beneficiary(id: 100000007) { age dateOfBirth } }"""
     queried_beneficiary = _assert_successful_request(auth0_client, query)


### PR DESCRIPTION
After some research I managed to integrate dataloaders provided by the [aiodataloader](https://github.com/syrusakbary/aiodataloader) package.

Under the hood this results in batching of DB queries, and hence a significant speed-up of request processing time.

Using a local testing setup I obtained a decrease of processing time from 4.5s down to 0.7s for the GraphQL request behind the [BoxesView](https://github.com/boxwise/boxtribute/blob/master/react/src/views/Boxes/BoxesView.tsx#L8).

I verified that the database queries are batched using peewee's logger, and also verified data integrity by comparing the result of the query between master and this branch.

As discussed, it is important to deploy this on the staging server to test how the BE behaves with concurrent requests.
