### PR TITLE
Make authorize() function even more robust

### DIFF
--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -2,6 +2,7 @@
 import json
 import os
 import urllib
+from collections import defaultdict
 from functools import wraps
 
 from flask import g, request
@@ -130,13 +131,21 @@ class CurrentUser:
     def from_jwt(cls, payload):
         """Extract user information from custom claims in JWT payload. The prefix and
         the claim names are set by an Action script in Auth0.
+
         The `permissions` custom claim contains entries of form
         '[base_X[-Y...]/]resource:method'. If no base prefix is given, the value from
-        the `base_ids` custom claim is used.
-        Any write/edit permission implies read permission on the same resource. E.g.
+        the `base_ids` custom claim is used (this occurs for the Head-of-Ops user role).
+
+        If a user has multiple roles, their base-specific permissions are aggregated.
+
+        Any write/edit permission implies read permission on the same resource.
+
+        Examples:
         - base_1/product:read    -> {"product:read": [1]}
         - base_2-3/stock:write   -> {"stock:write": [2, 3], "stock:read": [2, 3]}
         - beneficiary:edit       -> {"beneficiary:edit": [], "beneficiary:read": []}
+        - base_1/stock:read, stock:read, base_ids = [2]
+                                 -> {"stock:read": [1, 2]}
 
         If the permissions custom claim is a list with a single entry "*", it indicates
         that the current user is a god user.
@@ -152,28 +161,28 @@ class CurrentUser:
                 },
             )
 
-        base_ids = {}
+        base_ids = defaultdict(list)
         if not is_god:
             for raw_permission in payload[f"{JWT_CLAIM_PREFIX}/permissions"]:
                 try:
                     base_prefix, permission = raw_permission.split("/")
                     ids = [int(b) for b in base_prefix[5:].split("-")]
                 except ValueError:
-                    # Organisation admins don't have base_ prefixes, permission granted
-                    # for all bases indicated by custom 'base_ids' claim
+                    # Organisation Head-of-Ops don't have base_ prefixes, permission
+                    # granted for all bases indicated by custom 'base_ids' claim
                     permission = raw_permission
                     ids = payload[f"{JWT_CLAIM_PREFIX}/base_ids"]
-                base_ids[permission] = ids
+                base_ids[permission].extend(ids)
 
                 resource, method = permission.split(":")
                 if method in ["write", "create", "edit"]:
-                    base_ids[f"{resource}:read"] = ids
+                    base_ids[f"{resource}:read"].extend(ids)
 
         return cls(
             organisation_id=payload[f"{JWT_CLAIM_PREFIX}/organisation_id"],
             id=int(payload["sub"].replace("auth0|", "")),
             is_god=is_god,
-            base_ids=base_ids,
+            base_ids=dict(base_ids),
         )
 
     def authorized_base_ids(self, permission):

--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -117,9 +117,8 @@ class CurrentUser:
 
     def __init__(self, *, id, organisation_id=None, is_god=False, base_ids=None):
         """The `base_ids` field is a mapping of a permission name to a list of base IDs
-        that the permission is granted for, or to None if the permission is granted for
-        all bases. However it is never exposed directly to avoid accidental
-        manipulation.
+        that the permission is granted for. However it is never exposed directly to
+        avoid accidental manipulation.
         The `organisation_id` field is set to None for god users.
         """
         self._id = id
@@ -132,11 +131,12 @@ class CurrentUser:
         """Extract user information from custom claims in JWT payload. The prefix and
         the claim names are set by an Action script in Auth0.
         The `permissions` custom claim contains entries of form
-        '[base_X[-Y...]/]resource:method'. Any write/edit permission implies read
-        permission on the same resource. E.g.
+        '[base_X[-Y...]/]resource:method'. If no base prefix is given, the value from
+        the `base_ids` custom claim is used.
+        Any write/edit permission implies read permission on the same resource. E.g.
         - base_1/product:read    -> {"product:read": [1]}
         - base_2-3/stock:write   -> {"stock:write": [2, 3], "stock:read": [2, 3]}
-        - beneficiary:edit       -> {"beneficiary:edit": None, "beneficiary:read": None}
+        - beneficiary:edit       -> {"beneficiary:edit": [], "beneficiary:read": []}
 
         If the permissions custom claim is a list with a single entry "*", it indicates
         that the current user is a god user.

--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -176,9 +176,6 @@ class CurrentUser:
             base_ids=base_ids,
         )
 
-    def has_permission(self, name):
-        return name in self._base_ids
-
     def authorized_base_ids(self, permission):
         return self._base_ids[permission]
 

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -29,11 +29,23 @@ def authorize(
     if current_user.is_god:
         return True
 
+    authorized = False
     if permission is not None:
-        authorized = current_user.has_permission(permission)
+        base_ids = []
+        try:
+            # Look up base IDs for given permission
+            base_ids = current_user.authorized_base_ids(permission)
+            authorized = True
+        except KeyError:
+            # Permission not granted for user
+            authorized = False
+
+        if not base_ids:
+            # Permission field exists but no access for any base granted
+            authorized = False
+
         if authorized and base_id is not None:
             # Enforce base-specific permission
-            base_ids = current_user.authorized_base_ids(permission)
             authorized = int(base_id) in base_ids
     elif organisation_id is not None:
         authorized = organisation_id == current_user.organisation_id

--- a/back/test/auth_tests/test_authz.py
+++ b/back/test/auth_tests/test_authz.py
@@ -3,25 +3,25 @@ from boxtribute_server.auth import CurrentUser
 from boxtribute_server.authz import authorize
 from boxtribute_server.exceptions import Forbidden, UnknownResource
 
-ALL_PERMISSIONS = [
-    "base:read",
-    "beneficiary:read",
-    "category:read",
-    "location:read",
-    "product:read",
-    "shipment:read",
-    "stock:read",
-    "transaction:read",
-    "transfer_agreement:read",
-    "user:read",
-    "qr:read",
-    "beneficiary:create",
-    "beneficiary:edit",
-    "shipment:write",
-    "stock:write",
-    "transfer_agreement:write",
-    "qr:create",
-]
+ALL_PERMISSIONS = {
+    "base:read": [1],
+    "beneficiary:read": [1],
+    "category:read": [1],
+    "location:read": [1],
+    "product:read": [1],
+    "shipment:read": [1],
+    "stock:read": [1],
+    "transaction:read": [1],
+    "transfer_agreement:read": [1],
+    "user:read": [1],
+    "qr:read": [1],
+    "beneficiary:create": [1],
+    "beneficiary:edit": [1],
+    "shipment:write": [1],
+    "stock:write": [1],
+    "transfer_agreement:write": [1],
+    "qr:create": [1],
+}
 
 
 def test_authorized_user():
@@ -74,9 +74,17 @@ def test_user_with_insufficient_permissions():
         id=3, organisation_id=2, base_ids={"beneficiary:create": [2], "stock:write": []}
     )
     with pytest.raises(Forbidden):
+        # The permission field exists but access granted for different base
         authorize(user, permission="beneficiary:create", base_id=1)
     with pytest.raises(Forbidden):
+        # The permission field exists but holds no bases
         authorize(user, permission="stock:write", base_id=1)
+    with pytest.raises(Forbidden):
+        # The permission field exists but holds no bases
+        authorize(user, permission="stock:write")
+    with pytest.raises(Forbidden):
+        # The permission field does not exist
+        authorize(user, permission="product:read")
 
 
 def test_user_unauthorized_for_organisation():


### PR DESCRIPTION
As a follow-up to #374.

- assign authorized=False and empty base IDs to User object by default
- handle edge case: resource-permission given but no bases assigned
