### PR TITLE
Enforce base-specific permissions when resolving base beneficiaries

### DIFF
--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -1032,7 +1032,7 @@ def resolve_distribution_event(*_, id):
 @base.field("beneficiaries")
 @convert_kwargs_to_snake_case
 def resolve_base_beneficiaries(base_obj, _, pagination_input=None, filter_input=None):
-    authorize(permission="beneficiary:read")
+    authorize(permission="beneficiary:read", base_id=base_obj.id)
     base_filter_condition = Beneficiary.base == base_obj.id
     filter_condition = base_filter_condition & derive_beneficiary_filter(filter_input)
     return load_into_page(

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -218,7 +218,7 @@ type Base {
   name: String!
   organisation: Organisation!
   " List of all [`Beneficiaries`]({{Types.Beneficiary}}) registered in this base "
-  beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage!
+  beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage
   currencyName: String
   " List of all [`ClassicLocations`]({{Types.ClassicLocation}}) present in this base "
   locations: [ClassicLocation!]!

--- a/back/test/data/beneficiary.py
+++ b/back/test/data/beneficiary.py
@@ -57,6 +57,21 @@ def another_beneficiary_data():
     }
 
 
+def org2_base3_beneficiary_data():
+    return {
+        "id": 4,
+        "first_name": "No",
+        "last_name": "One",
+        "base": base_data()[2]["id"],
+        "created_on": datetime(2022, 1, 30),
+        "created_by": None,
+        "family_id": 12,
+        "seq": 1,
+        "group_identifier": "999",
+        "gender": "F",
+    }
+
+
 @pytest.fixture
 def default_beneficiaries():
     return [
@@ -81,3 +96,4 @@ def create():
     Beneficiary.create(**default_beneficiary_data())
     Beneficiary.create(**relative_beneficiary_data())
     Beneficiary.create(**another_beneficiary_data())
+    Beneficiary.create(**org2_base3_beneficiary_data())

--- a/back/test/endpoint_tests/test_organisation.py
+++ b/back/test/endpoint_tests/test_organisation.py
@@ -1,20 +1,59 @@
-from utils import assert_successful_request
+from utils import assert_forbidden_request, assert_successful_request
 
 
-def test_organisation_query(read_only_client, default_bases, default_organisation):
+def test_organisation_query(
+    read_only_client,
+    default_bases,
+    default_organisation,
+    default_beneficiaries,
+    another_organisation,
+):
+    # The user is a member of base 1 for default_organisation. They can read name and ID
+    # of the organisation's bases but the beneficiary data of base 1 ONLY
     organisation_id = str(default_organisation["id"])
     query = f"""query {{
                 organisation(id: "{organisation_id}") {{
                     id
                     name
-                    bases {{ id }}
+                    bases {{ id name beneficiaries {{ totalCount }} }}
                 }}
             }}"""
-    queried_organisation = assert_successful_request(read_only_client, query)
-    assert queried_organisation == {
+    response = assert_forbidden_request(read_only_client, query, verify_response=False)
+    assert response.json["data"]["organisation"] == {
         "id": organisation_id,
         "name": default_organisation["name"],
-        "bases": [{"id": str(b["id"])} for b in list(default_bases.values())[:2]],
+        "bases": [
+            {
+                "id": str(default_bases[1]["id"]),
+                "name": default_bases[1]["name"],
+                "beneficiaries": {"totalCount": len(default_beneficiaries)},
+            },
+            {
+                "id": str(default_bases[2]["id"]),
+                "name": default_bases[2]["name"],
+                "beneficiaries": None,
+            },
+        ],
+    }
+
+    # The user is not a member of another_organisation. They can read name and ID of
+    # that organisation's bases but NOT the beneficiary data
+    organisation_id = str(another_organisation["id"])
+    query = f"""query {{
+                organisation(id: "{organisation_id}") {{
+                    id
+                    bases {{ id name beneficiaries {{ totalCount }} }}
+                }}
+            }}"""
+    response = assert_forbidden_request(
+        read_only_client, query, error_count=2, verify_response=False
+    )
+    assert response.json["data"]["organisation"] == {
+        "id": organisation_id,
+        "bases": [
+            {"id": str(base["id"]), "name": base["name"], "beneficiaries": None}
+            for base in [default_bases[3], default_bases[4]]
+        ],
     }
 
 

--- a/back/test/endpoint_tests/test_organisation.py
+++ b/back/test/endpoint_tests/test_organisation.py
@@ -2,8 +2,9 @@ from utils import assert_successful_request
 
 
 def test_organisation_query(read_only_client, default_bases, default_organisation):
+    organisation_id = str(default_organisation["id"])
     query = f"""query {{
-                organisation(id: "{default_organisation['id']}") {{
+                organisation(id: "{organisation_id}") {{
                     id
                     name
                     bases {{ id }}
@@ -11,7 +12,7 @@ def test_organisation_query(read_only_client, default_bases, default_organisatio
             }}"""
     queried_organisation = assert_successful_request(read_only_client, query)
     assert queried_organisation == {
-        "id": str(default_organisation["id"]),
+        "id": organisation_id,
         "name": default_organisation["name"],
         "bases": [{"id": str(b["id"])} for b in list(default_bases.values())[:2]],
     }

--- a/back/test/utils.py
+++ b/back/test/utils.py
@@ -1,14 +1,23 @@
-def _assert_erroneous_request(client, query, *, code, **kwargs):
+def _assert_erroneous_request(
+    client, query, *, code, verify_response=True, error_count=1, **kwargs
+):
     """Assertion utility that posts the given query via a client fixture.
-    Assert presence of error code in response.
-    `kwargs` are forwarded to `_verify_response_data()`.
+    Assert presence of `error_count` errors with specified code in response.
+    By default, the response is verified (`kwargs` are forwarded).
+    For complex responses, set `verify_response=False` and perform the verification in
+    the test function.
     """
     data = {"query": query}
     response = client.post("/graphql", json=data)
     assert response.status_code == 200
-    assert len(response.json["errors"]) == 1
-    assert response.json["errors"][0]["extensions"]["code"] == code
-    _verify_response_data(query=query, response=response, **kwargs)
+
+    assert len(response.json["errors"]) == error_count
+    for i in range(error_count):
+        assert response.json["errors"][i]["extensions"]["code"] == code
+
+    if verify_response:
+        _verify_response_data(query=query, response=response, **kwargs)
+
     return response
 
 


### PR DESCRIPTION
This PR fixes a leak that previously allowed fetching beneficiary data in an unrestricted way.

It's possible to fetch beneficiary data in different ways (comments explain authz implemented on master):

1. `query { beneficiary(id: 1) { } }`: base-specific permission enforced in `resolve_beneficiary`
1. `query { beneficiaries { } }`: base-specific filter applied in `resolve_beneficiaries`
1. `query { base(id: 1) { beneficiaries { } } }`: base-specific permission enforced in `resolve_base`
1. `query { bases { beneficiaries { } } }`: base-specific filter applied in `resolve_bases`
1. `query { organisation(id: 1) { bases { beneficiaries { } } } }`: Any user can access any first-level information of any other organisation (ID, name, and bases). Since `resolve_base_beneficiaries` does not enforce base-specific permissions (I thought any parent resolver would have done so already), beneficiaries of all bases can be listed.
1. `query { organisations { bases { beneficiaries { } } } }`: same as above

The issue described in the final two points is fixed.

I extended the tests for the desired behavior. For an organisation with ID 1 and two bases, and a user who's member of only one of those bases, the request `query { organisation(id: 1) { bases { id beneficiaries { } } } }` now returns a partial response (the data fields for base IDs are available. Base beneficiaries however only contain data for bases that the user is authorized for. Otherwise they're null, and the response errors field indicates forbidden errors)

Note that via the `organisation` root query it's still possible to access any organisation's location and product information (this is not sensitive information and also inevitable for the box-transfer feature).
