### PR TITLE
Set SENTRY_ENVIRONMENT variable when building front-end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
               REACT_APP_LOGOUT_URL=${REACT_APP_LOGOUT_URL}
               REACT_APP_GRAPHQL_SERVER=${REACT_APP_GRAPHQL_SERVER}
               REACT_APP_SENTRY_FE_DSN=${SENTRY_FE_DSN}
+              SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
             " > .env
       # following https://circleci.com/docs/2.0/yarn/
       - restore_cache:

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -123,8 +123,7 @@ if (sentryDsn) {
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production
     tracesSampleRate: 1.0,
-    // TODO: probably we want to later on differentiate 'PRODUCTION' even more - into 'STAGING' and actual 'PRODUCTION'/'LIVE'
-    environment: process.env.SENTRY_ENVIRONMENT,
+    // the 'environment' option is read from the SENTRY_ENVIRONMENT env variable
   });
 }
 


### PR DESCRIPTION
Depending on the CircleCI context, the value is
staging/demo/production. See also
https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#environment
