### PR TITLE
Add entries in history table when running box mutation

### DIFF
--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -69,15 +69,14 @@ def create_box(
 
 
 @save_update_to_history(
-    model=Box,
     id_field_name="label_identifier",
-    field_names=[
-        "label_identifier",
-        "product",
-        "size",
-        "number_of_items",
-        "location",
-        "comment",
+    fields=[
+        Box.label_identifier,
+        Box.product,
+        Box.size,
+        Box.number_of_items,
+        Box.location,
+        Box.comment,
     ],
 )
 def update_box(

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -14,7 +14,7 @@ from .definitions.qr_code import QrCode
 from .definitions.tag import Tag
 from .definitions.tags_relation import TagsRelation
 from .definitions.x_beneficiary_language import XBeneficiaryLanguage
-from .utils import utcnow
+from .utils import save_update_to_history, utcnow
 
 BOX_LABEL_IDENTIFIER_GENERATION_ATTEMPTS = 10
 
@@ -67,6 +67,18 @@ def create_box(
     raise BoxCreationFailed()
 
 
+@save_update_to_history(
+    model=Box,
+    id_field_name="label_identifier",
+    field_names=[
+        "label_identifier",
+        "product",
+        "size",
+        "number_of_items",
+        "location",
+        "comment",
+    ],
+)
 def update_box(
     label_identifier,
     user_id,

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -14,11 +14,12 @@ from .definitions.qr_code import QrCode
 from .definitions.tag import Tag
 from .definitions.tags_relation import TagsRelation
 from .definitions.x_beneficiary_language import XBeneficiaryLanguage
-from .utils import save_update_to_history, utcnow
+from .utils import save_creation_to_history, save_update_to_history, utcnow
 
 BOX_LABEL_IDENTIFIER_GENERATION_ATTEMPTS = 10
 
 
+@save_creation_to_history
 def create_box(
     product_id,
     location_id,

--- a/back/boxtribute_server/models/utils.py
+++ b/back/boxtribute_server/models/utils.py
@@ -90,7 +90,7 @@ def save_update_to_history(*, id_field_name="id", fields):
                     entry.changes = field.column_name
                 else:
                     entry.changes = f"""{field.column_name} changed from "{old_value}" \
-to "{new_value}"."""
+to "{new_value}";"""
                 entries.append(entry)
 
             with db.database.atomic():

--- a/back/boxtribute_server/models/utils.py
+++ b/back/boxtribute_server/models/utils.py
@@ -1,5 +1,12 @@
 """Utility functions to support data model definitions."""
 from datetime import datetime, timezone
+from functools import wraps
+
+from flask import g, request
+from peewee import ForeignKeyField, IntegerField
+
+from ..db import db
+from .definitions.history import DbChangeHistory
 
 
 def utcnow():
@@ -7,3 +14,63 @@ def utcnow():
     configured to not store any fractional seconds).
     """
     return datetime.now(tz=timezone.utc).replace(microsecond=0)
+
+
+def save_update_to_history(*, model, id_field_name="id", field_names):
+    """Utility for writing information about modifying a resource to the history table,
+    intended to decorate a function that modifies a database resource (e.g. a box).
+
+    The type of the modified resource is indicated by `model`, the relevant field names
+    by `field_names`. `id_field_name` refers to the field name used to identify the
+    model instance that is being modified. In the signature of the decorated function an
+    argument with identical name must exist. The decorated function must return the
+    modified resource.
+
+    The function fetches the resource (i.e. the old database row) first, and then runs
+    the decorated function, effectively executing the modification. For each of the
+    fields that were actually modified an entry in the history table is created.
+    """
+
+    def decorator(f):
+        @wraps(f)
+        def inner(*args, **kwargs):
+            # e.g. Box.label_identifier
+            id_field = getattr(model, id_field_name)
+            # e.g. Box.get(Box.label_identifier == "123456")
+            old_resource = model.get(id_field == kwargs[id_field_name])
+            new_resource = f(*args, **kwargs)
+
+            now = utcnow()
+            entries = []
+            for field_name in field_names:
+                old_value = getattr(old_resource, field_name)
+                new_value = getattr(new_resource, field_name)
+
+                if old_value == new_value:
+                    continue  # no change in value, hence no need for history entry
+
+                entry = DbChangeHistory()
+                entry.table_name = model._meta.table_name
+                entry.record_id = new_resource.id
+                entry.user = g.user.id
+                entry.ip = request.remote_addr
+                entry.change_date = now
+
+                field = getattr(model, field_name)
+                if issubclass(field.__class__, (IntegerField, ForeignKeyField)):
+                    entry.from_int = old_value
+                    entry.to_int = new_value
+                    entry.changes = field.column_name
+                else:
+                    entry.changes = f"""{field.column_name} changed from "{old_value}" \
+to "{new_value}"."""
+                entries.append(entry)
+
+            with db.database.atomic():
+                DbChangeHistory.bulk_create(entries)
+
+            return new_resource
+
+        return inner
+
+    return decorator

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -182,7 +182,7 @@ def test_box_mutations(
             "ip": "127.0.0.1",
         },
         {
-            "changes": f"""comments changed from "" to "{comment}".""",
+            "changes": f"""comments changed from "" to "{comment}";""",
             "from_int": None,
             "to_int": None,
             "record_id": box_id,

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -145,6 +145,15 @@ def test_box_mutations(
     box_id = int(updated_box["id"])
     assert history[1:] == [
         {
+            "changes": "Record created",
+            "from_int": None,
+            "to_int": None,
+            "record_id": box_id,
+            "table_name": "stock",
+            "user": 8,
+            "ip": "127.0.0.1",
+        },
+        {
             "changes": "product_id",
             "from_int": int(product_id),
             "to_int": int(new_product_id),

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -1,25 +1,7 @@
 import peewee
 import pytest
-from boxtribute_server.exceptions import BoxCreationFailed
-from boxtribute_server.models.crud import (
-    BOX_LABEL_IDENTIFIER_GENERATION_ATTEMPTS,
-    create_box,
-    create_qr_code,
-)
+from boxtribute_server.models.crud import create_qr_code
 from boxtribute_server.models.definitions.qr_code import QrCode
-
-
-def test_create_box_with_incorrect_data(
-    default_location, default_size, default_product
-):
-    non_existent_user_id = 99999
-    with pytest.raises(peewee.IntegrityError, match="foreign key constraint fails"):
-        create_box(
-            user_id=non_existent_user_id,
-            location_id=default_location["id"],
-            product_id=default_product["id"],
-            size_id=default_size["id"],
-        )
 
 
 def test_create_qr_code_for_nonexisting_box():
@@ -32,33 +14,3 @@ def test_create_qr_code_for_nonexisting_box():
 
     # The nr of rows in the QrCode table should be unchanged
     assert nr_qr_codes == len(QrCode.select())
-
-
-def test_box_label_identifier_generation(
-    mocker, default_box, default_location, default_product, default_user, default_size
-):
-    rng_function = mocker.patch("random.choices")
-    data = {
-        "number_of_items": 10,
-        "location_id": default_location["id"],
-        "product_id": default_product["id"],
-        "size_id": default_size["id"],
-        "user_id": default_user["id"],
-    }
-
-    # Verify that create_box() fails after several attempts if newly generated
-    # identifier is never unique
-    rng_function.return_value = default_box["label_identifier"]
-    with pytest.raises(BoxCreationFailed):
-        create_box(**data)
-    assert rng_function.call_count == BOX_LABEL_IDENTIFIER_GENERATION_ATTEMPTS
-
-    # Verify that create_box() succeeds even if an existing identifier happens to be
-    # generated once
-    new_identifier = "11112222"
-    side_effect = [default_box["label_identifier"], new_identifier]
-    rng_function.reset_mock(return_value=True)
-    rng_function.side_effect = side_effect
-    new_box = create_box(**data)
-    assert rng_function.call_count == len(side_effect)
-    assert new_box.label_identifier == new_identifier

--- a/back/test/model_tests/test_crud.py
+++ b/back/test/model_tests/test_crud.py
@@ -1,12 +1,10 @@
 import peewee
 import pytest
-from boxtribute_server.enums import BoxState
 from boxtribute_server.exceptions import BoxCreationFailed
 from boxtribute_server.models.crud import (
     BOX_LABEL_IDENTIFIER_GENERATION_ATTEMPTS,
     create_box,
     create_qr_code,
-    update_box,
 )
 from boxtribute_server.models.definitions.qr_code import QrCode
 
@@ -64,51 +62,3 @@ def test_box_label_identifier_generation(
     new_box = create_box(**data)
     assert rng_function.call_count == len(side_effect)
     assert new_box.label_identifier == new_identifier
-
-
-def test_boxstate_update(
-    default_user,
-    default_product,
-    null_box_state_location,
-    non_default_box_state_location,
-    default_size,
-):
-    # creating a box in a location with box_state=NULL should set the box's location to
-    # InStock
-    box = create_box(
-        product_id=default_product["id"],
-        user_id=default_user["id"],
-        location_id=null_box_state_location["id"],
-        size_id=default_size["id"],
-    )
-    assert box.state.id == BoxState.InStock
-
-    # updating to a location with box_state!=NULL should set the box state on the box
-    # too
-    box = update_box(
-        location_id=non_default_box_state_location["id"],
-        label_identifier=box.label_identifier,
-        user_id=default_user["id"],
-    )
-    assert box.state.id == non_default_box_state_location["box_state"]
-
-    # setting it back to a location with a box_state=NULL should NOT change the box's
-    # box_state
-    box = update_box(
-        location_id=null_box_state_location["id"],
-        label_identifier=box.label_identifier,
-        user_id=default_user["id"],
-    )
-    assert box.state.id != BoxState.InStock
-    assert box.state.id == non_default_box_state_location["box_state"]
-
-    # creating a box with an explicit box_state in a location with box_state=NULL should
-    # set the box_state to that explicit box_state
-    box2 = create_box(
-        product_id=default_product["id"],
-        user_id=default_user["id"],
-        location_id=non_default_box_state_location["id"],
-        size_id=default_size["id"],
-    )
-
-    assert box2.state.id == non_default_box_state_location["box_state"]


### PR DESCRIPTION
This PR adds two utility decorators that shall be applied on the data-operational level to any function that creates or updated a resource.

Please see the function docstrings for information. The implemented functionality is identical to the dropapp functionality (in the formhandler module). See also [this section](https://github.com/boxwise/dropapp/blob/master/include/stock_edit.php#L30)

The decorators are applied to the `create_box` and `update_box` functions since they are the only relevant ones for the upcoming deploy. Two unit tests had to be converted into endpoint tests because the new decorators require access to an actual Flask app context (for fetching client information).

For local testing try the following:

1. Start docker-compose services `docker-compose up webapp db`
1. Open GraphQL playground on `localhost:5005`
1. Fetch JWT and insert it
1. Create a box

```
mutation { createBox (creationInput: {
  locationId: 1 
  sizeId: 1 
  productId: 1 
}) { labelIdentifier } }
```

1. Connect to the local `dropapp_dev` database and display the `history` table
1. You should see a `Record created` entry as most recent one.

1. Update the box

```
mutation { updateBox(updateInput: {labelIdentifier: "XXXX" comment: "hallo"}){comment}}
```

1. You should see a `comments changed from "" to "hallo".` entry as most recent one.
1. Play around with updating different box fields (e.g. `productId: 2`).
