### PR TITLE
Use client IP address for history table

### DIFF
--- a/back/boxtribute_server/models/utils.py
+++ b/back/boxtribute_server/models/utils.py
@@ -33,13 +33,24 @@ def save_creation_to_history(f):
             table_name=new_resource._meta.table_name,
             record_id=new_resource.id,
             user=g.user.id,
-            ip=request.remote_addr,
+            ip=get_client_ip(),
             change_date=utcnow(),
         )
 
         return new_resource
 
     return inner
+
+
+def get_client_ip():
+    """Return client's IP address. Take into account that a proxy like nginx is used in
+    production (Google App Engine). Cf. https://stackoverflow.com/a/49760261/3865876.
+    `request.remote_addr` would return the server's address.
+    """
+    forwarded_ip = request.environ.get("HTTP_X_FORWARDED_FOR")
+    if forwarded_ip is None:
+        return request.environ["REMOTE_ADDR"]
+    return forwarded_ip  # pragma: no cover
 
 
 def save_update_to_history(*, id_field_name="id", fields):
@@ -81,7 +92,7 @@ def save_update_to_history(*, id_field_name="id", fields):
                 entry.table_name = model._meta.table_name
                 entry.record_id = new_resource.id
                 entry.user = g.user.id
-                entry.ip = request.remote_addr
+                entry.ip = get_client_ip()
                 entry.change_date = now
 
                 if issubclass(field.__class__, (IntegerField, ForeignKeyField)):


### PR DESCRIPTION
Previously, creating a box in staging would store the address
127.0.0.1 which is the server's address.
