### PR TITLE
Extend createBox mutation to accept tag IDs

### DIFF
--- a/back/boxtribute_server/graph_ql/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/inputs.graphql
@@ -8,6 +8,7 @@ input BoxCreationInput {
   locationId: Int!
   comment: String
   qrCode: String
+  tagIds: [Int!]
 }
 
 input BoxUpdateInput {

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -28,12 +28,14 @@ def create_box(
     comment="",
     number_of_items=None,
     qr_code=None,
+    tag_ids=None,
 ):
     """Insert information for a new Box in the database. Use current datetime
     and box state "InStock" by default. If a location with a box state is passed
     use its box state for the new box. Generate an 8-digit sequence to identify the
     box. If the sequence is not unique, repeat the generation several times. If
     generation still fails, raise a BoxCreationFailed exception.
+    Assign any given tags to the newly created box.
     """
 
     now = utcnow()
@@ -59,6 +61,14 @@ def create_box(
                 state=box_state,
                 qr_code=qr_id,
             )
+
+            for tag_id in tag_ids or []:
+                assign_tag(
+                    user_id=user_id,
+                    id=tag_id,
+                    resource_id=new_box.id,
+                    resource_type=TaggableObjectType.Box,
+                )
             return new_box
         except peewee.IntegrityError as e:
             # peewee throws the same exception for different constraint violations.

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -47,29 +47,31 @@ def create_box(
     )
     for i in range(BOX_LABEL_IDENTIFIER_GENERATION_ATTEMPTS):
         try:
-            new_box = Box.create(
-                comment=comment,
-                created_on=now,
-                created_by=user_id,
-                number_of_items=number_of_items,
-                label_identifier="".join(random.choices("0123456789", k=8)),
-                last_modified_on=now,
-                last_modified_by=user_id,
-                location=location_id,
-                product=product_id,
-                size=size_id,
-                state=box_state,
-                qr_code=qr_id,
-            )
+            new_box = Box()
+            new_box.comment = comment
+            new_box.created_on = now
+            new_box.created_by = user_id
+            new_box.number_of_items = number_of_items
+            new_box.label_identifier = "".join(random.choices("0123456789", k=8))
+            new_box.last_modified_on = now
+            new_box.last_modified_by = user_id
+            new_box.location = location_id
+            new_box.product = product_id
+            new_box.size = size_id
+            new_box.state = box_state
+            new_box.qr_code = qr_id
 
-            for tag_id in tag_ids or []:
-                assign_tag(
-                    user_id=user_id,
-                    id=tag_id,
-                    resource_id=new_box.id,
-                    resource_type=TaggableObjectType.Box,
-                )
-            return new_box
+            with db.database.atomic():
+                new_box.save()
+                for tag_id in tag_ids or []:
+                    assign_tag(
+                        user_id=user_id,
+                        id=tag_id,
+                        resource_id=new_box.id,
+                        resource_type=TaggableObjectType.Box,
+                    )
+                return new_box
+
         except peewee.IntegrityError as e:
             # peewee throws the same exception for different constraint violations.
             # E.g. failing "NOT NULL" constraint shall be directly reported

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -67,7 +67,13 @@ def test_box_query_by_qr_code(read_only_client, default_box, default_qr_code):
 
 
 def test_box_mutations(
-    client, qr_code_without_box, default_size, another_size, products, default_location
+    client,
+    qr_code_without_box,
+    default_size,
+    another_size,
+    products,
+    default_location,
+    tags,
 ):
     # Test case 8.2.1
     size_id = str(default_size["id"])
@@ -111,6 +117,7 @@ def test_box_mutations(
     # Test case 8.2.2
     number_of_items = 3
     comment = "good box"
+    tag_id = str(tags[1]["id"])
     creation_input = f"""{{
                     productId: {product_id},
                     locationId: {location_id},
@@ -118,6 +125,7 @@ def test_box_mutations(
                     numberOfItems: {number_of_items}
                     comment: "{comment}"
                     qrCode: "{qr_code_without_box["code"]}"
+                    tagIds: [{tag_id}]
                 }}"""
     mutation = f"""mutation {{
             createBox( creationInput : {creation_input} ) {{
@@ -127,6 +135,7 @@ def test_box_mutations(
                 size {{ id }}
                 qrCode {{ id }}
                 state
+                tags {{ id }}
             }}
         }}"""
     another_created_box = assert_successful_request(client, mutation)
@@ -137,6 +146,7 @@ def test_box_mutations(
         "size": {"id": size_id},
         "qrCode": {"id": str(qr_code_without_box["id"])},
         "state": BoxState.InStock.name,
+        "tags": [{"id": tag_id}],
     }
 
     # Test case 8.2.11


### PR DESCRIPTION
Please see the attached trello card for context. It's now possible to write a mutation like

```
mutation { createBox(creationInput: {
    ...
    tagIds: [1, 3]
}) { 
    tags { id } 
} }
```

with the response `{"tags": [1, 3]}`