### PR TITLE
Don't store client IP when logging to history table

### DIFF
--- a/back/boxtribute_server/models/utils.py
+++ b/back/boxtribute_server/models/utils.py
@@ -2,7 +2,7 @@
 from datetime import datetime, timezone
 from functools import wraps
 
-from flask import g, request
+from flask import g
 from peewee import ForeignKeyField, IntegerField
 
 from ..db import db
@@ -33,21 +33,13 @@ def save_creation_to_history(f):
             table_name=new_resource._meta.table_name,
             record_id=new_resource.id,
             user=g.user.id,
-            ip=get_client_ip(),
+            ip=None,
             change_date=utcnow(),
         )
 
         return new_resource
 
     return inner
-
-
-def get_client_ip():
-    """Return client's IP address. Take into account that a proxy like nginx is used in
-    production (Google App Engine). Cf. https://stackoverflow.com/a/49052873/3865876
-    `request.remote_addr` would return the server's address.
-    """
-    return request.access_route[-1]
 
 
 def save_update_to_history(*, id_field_name="id", fields):
@@ -89,7 +81,7 @@ def save_update_to_history(*, id_field_name="id", fields):
                 entry.table_name = model._meta.table_name
                 entry.record_id = new_resource.id
                 entry.user = g.user.id
-                entry.ip = get_client_ip()
+                entry.ip = None
                 entry.change_date = now
 
                 if issubclass(field.__class__, (IntegerField, ForeignKeyField)):

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -203,7 +203,7 @@ def test_box_mutations(
             "record_id": box_id,
             "table_name": "stock",
             "user": 8,
-            "ip": "127.0.0.1",
+            "ip": None,
         },
         {
             "changes": "Record created",
@@ -212,7 +212,7 @@ def test_box_mutations(
             "record_id": box_id + 1,
             "table_name": "stock",
             "user": 8,
-            "ip": "127.0.0.1",
+            "ip": None,
         },
         {
             "changes": "product_id",
@@ -221,7 +221,7 @@ def test_box_mutations(
             "record_id": box_id,
             "table_name": "stock",
             "user": 8,
-            "ip": "127.0.0.1",
+            "ip": None,
         },
         {
             "changes": "size_id",
@@ -230,7 +230,7 @@ def test_box_mutations(
             "record_id": box_id,
             "table_name": "stock",
             "user": 8,
-            "ip": "127.0.0.1",
+            "ip": None,
         },
         {
             "changes": "items",
@@ -239,7 +239,7 @@ def test_box_mutations(
             "record_id": box_id,
             "table_name": "stock",
             "user": 8,
-            "ip": "127.0.0.1",
+            "ip": None,
         },
         {
             "changes": f"""comments changed from "" to "{comment}";""",
@@ -248,7 +248,7 @@ def test_box_mutations(
             "record_id": box_id,
             "table_name": "stock",
             "user": 8,
-            "ip": "127.0.0.1",
+            "ip": None,
         },
     ]
 

--- a/docs/graphql-api/query-api-config.yml
+++ b/docs/graphql-api/query-api-config.yml
@@ -253,6 +253,8 @@ info:
       url: https://www.app.boxtribute.org
     - title: Query API
       url: https://api.boxtribute.org
+    - title: Query API changelog
+      url: https://github.com/boxwise/boxtribute/releases
     - title: Terms of Service
       description: |
           In line with the Service Agreement and other related documents as signed with [Boxtribute](https://boxtribute.org) (Stichting Boxwise)


### PR DESCRIPTION
As agreed on [Slack](https://boxwise.slack.com/archives/CB1UYDGLU/p1664879251812689).

Please see the commit message.
