### PR TITLE
First test of logging in Google Cloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,7 @@ workflows:
             branches:
               only:
                 - master
+                - feature/976-logging-of-graphql-queries-in-google
                 - production
 
       # staging
@@ -376,6 +377,7 @@ workflows:
             branches:
               only:
                 - master
+                - feature/976-logging-of-graphql-queries-in-google
 
       # demo - runs on any commit to the production branch
       - build-and-test-react:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,6 @@ workflows:
             branches:
               only:
                 - master
-                - feature/976-logging-of-graphql-queries-in-google
                 - production
 
       # staging
@@ -377,7 +376,6 @@ workflows:
             branches:
               only:
                 - master
-                - feature/976-logging-of-graphql-queries-in-google
 
       # demo - runs on any commit to the production branch
       - build-and-test-react:

--- a/back/app-api.yaml
+++ b/back/app-api.yaml
@@ -1,4 +1,4 @@
-runtime: python38
+runtime: python310
 service: api-staging
 entrypoint: gunicorn -b :$PORT boxtribute_server.api_main:app
 handlers:

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -8,7 +8,7 @@ if os.getenv("CI") == "true" or os.getenv("environment") == "development":
     # Skip logger initialization when running tests in CircleCI, or during local
     # development
     request_logger = None
-else:
+else:  # pragma: no cover
     # Initializing client requires Google credentials to be set (they automatically are
     # in the GOOGLE_APPLICATION_CREDENTIALS environment variable when the app is
     # deployed on App Engine).
@@ -23,4 +23,4 @@ def log_request_to_gcloud():
         # Render function ineffective if logger not defined
         return
 
-    request_logger.log_struct(request.get_json(), severity="INFO")
+    request_logger.log_struct(request.get_json(), severity="INFO")  # pragma: no cover

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -1,5 +1,4 @@
 """Setup for logging in Google Cloud."""
-import logging
 import os
 
 from flask import request
@@ -24,6 +23,4 @@ def log_request_to_gcloud():
         # Render function ineffective if logger not defined
         return
 
-    request_logger.log_struct(request.get_json(), severity=logging.INFO)
-    request_logger.log_struct(request.get_json(), severity=logging.WARN)
-    request_logger.log_struct(request.get_json(), severity=logging.ERROR)
+    request_logger.log_struct(request.get_json(), severity="INFO")

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -1,10 +1,26 @@
 """Setup for logging in Google Cloud."""
+import os
+
+from flask import request
 from google.cloud import logging as gcloud_logging
 
-logging_client = gcloud_logging.Client()
-# Retrieve a Cloud Logging handler based on the environment the app is run in and
-# integrate the handler with the Python logging module. By default this captures all
-# logs at INFO level and higher
-# logging_client.setup_logging()
+if os.getenv("CI") == "true" or os.getenv("environment") == "development":
+    # Skip logger initialization when running tests in CircleCI, or during local
+    # development
+    request_logger = None
+else:
+    # Initializing client requires Google credentials to be set (they automatically are
+    # in the GOOGLE_APPLICATION_CREDENTIALS environment variable when the app is
+    # deployed on App Engine).
+    # Otherwise raising a `google.auth.exceptions.DefaultCredentialsError`
+    _logging_client = gcloud_logging.Client()
+    request_logger = _logging_client.logger("requests")
 
-request_logger = logging_client.logger("requests")
+
+def log_request_to_gcloud():
+    """Log the query field of the current request's JSON body to Google Cloud."""
+    if request_logger is None:
+        # Render function ineffective if logger not defined
+        return
+
+    request_logger.log_struct(request.get_json()["query"])

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -1,4 +1,5 @@
 """Setup for logging in Google Cloud."""
+import logging
 import os
 
 from flask import request
@@ -23,4 +24,6 @@ def log_request_to_gcloud():
         # Render function ineffective if logger not defined
         return
 
-    request_logger.log_struct(request.get_json())
+    request_logger.log_struct(request.get_json(), severity=logging.INFO)
+    request_logger.log_struct(request.get_json(), severity=logging.WARN)
+    request_logger.log_struct(request.get_json(), severity=logging.ERROR)

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -4,23 +4,34 @@ import os
 from flask import request
 from google.cloud import logging as gcloud_logging
 
+# Context names
+API_CONTEXT = "api"
+WEBAPP_CONTEXT = "webapp"
+
 if os.getenv("CI") == "true" or os.getenv("environment") == "development":
     # Skip logger initialization when running tests in CircleCI, or during local
     # development
-    request_logger = None
+    request_loggers = None
 else:  # pragma: no cover
     # Initializing client requires Google credentials to be set (they automatically are
     # in the GOOGLE_APPLICATION_CREDENTIALS environment variable when the app is
     # deployed on App Engine).
     # Otherwise raising a `google.auth.exceptions.DefaultCredentialsError`
     _logging_client = gcloud_logging.Client()
-    request_logger = _logging_client.logger("requests")
+
+    # Store logs in "projects/dropapp-******/logs/api-requests" or ".../webapp-requests"
+    request_loggers = {
+        context: _logging_client.logger(f"{context}-requests")
+        for context in [API_CONTEXT, WEBAPP_CONTEXT]
+    }
 
 
-def log_request_to_gcloud():
-    """Log the current request's JSON body to Google Cloud."""
-    if request_logger is None:
-        # Render function ineffective if logger not defined
+def log_request_to_gcloud(*, context):
+    """Log the current request's JSON body to Google Cloud, depending on context."""
+    if request_loggers is None:
+        # Render function ineffective if loggers not defined
         return
 
-    request_logger.log_struct(request.get_json(), severity="INFO")  # pragma: no cover
+    request_loggers[context].log_struct(
+        request.get_json(), severity="INFO"
+    )  # pragma: no cover

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -18,9 +18,9 @@ else:
 
 
 def log_request_to_gcloud():
-    """Log the query field of the current request's JSON body to Google Cloud."""
+    """Log the current request's JSON body to Google Cloud."""
     if request_logger is None:
         # Render function ineffective if logger not defined
         return
 
-    request_logger.log_struct(request.get_json()["query"])
+    request_logger.log_struct(request.get_json())

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -1,0 +1,10 @@
+"""Setup for logging in Google Cloud."""
+from google.cloud import logging as gcloud_logging
+
+logging_client = gcloud_logging.Client()
+# Retrieve a Cloud Logging handler based on the environment the app is run in and
+# integrate the handler with the Python logging module. By default this captures all
+# logs at INFO level and higher
+# logging_client.setup_logging()
+
+request_logger = logging_client.logger("requests")

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -18,6 +18,7 @@ from .loaders import (
     SizesForSizeRangeLoader,
     TagsForBoxLoader,
 )
+from .logging import API_CONTEXT, WEBAPP_CONTEXT, log_request_to_gcloud
 
 # Blueprint for query-only API. Deployed on the 'api*' subdomains
 api_bp = Blueprint("api_bp", __name__)
@@ -52,10 +53,7 @@ def query_api_playground():
 @cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
 @requires_auth
 def query_api_server():
-    from .logging import log_request_to_gcloud
-
-    log_request_to_gcloud()
-
+    log_request_to_gcloud(context=API_CONTEXT)
     return execute_async(schema=query_api_schema, introspection=True)
 
 
@@ -86,6 +84,7 @@ def graphql_playgroud():
 @cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
 @requires_auth
 def graphql_server():
+    log_request_to_gcloud(context=WEBAPP_CONTEXT)
     return execute_async(schema=full_api_schema)
 
 

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -56,7 +56,7 @@ def query_api_server():
 
     log_request_to_gcloud()
 
-    return execute_async(schema=query_api_schema)
+    return execute_async(schema=query_api_schema, introspection=True)
 
 
 @api_bp.route("/token", methods=["POST"])
@@ -89,7 +89,7 @@ def graphql_server():
     return execute_async(schema=full_api_schema)
 
 
-def execute_async(*, schema):
+def execute_async(*, schema, introspection=None):
     """Create coroutine and execute it with high-level `asyncio.run` which takes care of
     managing the asyncio event loop, finalizing asynchronous generators, and closing
     the threadpool.
@@ -113,7 +113,7 @@ def execute_async(*, schema):
             data=request.get_json(),
             context_value=context,
             debug=current_app.debug,
-            introspection=current_app.debug,
+            introspection=current_app.debug if introspection is None else introspection,
             error_formatter=format_database_errors,
         )
         return results

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -52,6 +52,9 @@ def query_api_playground():
 @cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
 @requires_auth
 def query_api_server():
+    from .logging import request_logger
+
+    request_logger.log_struct(request.get_json()["query"])
     return execute_async(schema=query_api_schema)
 
 

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -52,9 +52,10 @@ def query_api_playground():
 @cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
 @requires_auth
 def query_api_server():
-    from .logging import request_logger
+    from .logging import log_request_to_gcloud
 
-    request_logger.log_struct(request.get_json()["query"])
+    log_request_to_gcloud()
+
     return execute_async(schema=query_api_schema)
 
 

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -9,4 +9,5 @@ python-dateutil==2.8.2
 python-dotenv==0.21.0
 python-jose==3.3.0
 aiodataloader==0.2.1
+google-cloud-logging==3.2.5
 gunicorn


### PR DESCRIPTION
Please see the attached trello cards for all findings. In summary: Google Cloud Logging should be cheap, fast, and convenient :)

You might want to verify the functionality by opening the [Log Explorer](https://console.cloud.google.com/logs/query;query=resource.type%3D%22gae_app%22%0Aresource.labels.module_id%3D%22api-staging%22;cursorTimestamp=2022-10-20T19:18:45.741484728Z?project=dropapp-242214) and filtering for the `api-requests` log.

Further changes:
- when using GraphQL playground, the `Server cannot be reached` message has disappeared, and query auto-completion works. Schema and docs can be viewed in tabs on the right edge. This is possible through enabled GraphQL introspection (meaning users can pull metadata of the schema, like underlying GraphQL object types)
- the API is deployed on Python 3.10 (previously 3.8)