### PR TITLE
Use google-cloud-logging only in deployed environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           at: ~/
       # Restore cached dependencies
       - restore_cache:
-          key: webapp-deps-{{ checksum "requirements.txt" }}
+          key: webapp-deps-{{ checksum "requirements.txt" }}-{{ checksum "requirements-deploy.txt" }}
       - run:
           name: create the python virtual environment and install non-cached dependencies
           command: |
@@ -31,10 +31,10 @@ jobs:
             pyenv virtualenvs
             pyenv virtualenv --force env
             source $(pyenv root)/versions/3.10.4/envs/env/bin/activate
-            pip install -e . -r requirements.txt
+            pip install -e . -r requirements.txt -r requirements-deploy.txt
       # Cache the installed packages
       - save_cache:
-          key: webapp-deps-{{ checksum "requirements.txt" }}
+          key: webapp-deps-{{ checksum "requirements.txt" }}-{{ checksum "requirements-deploy.txt" }}
           paths:
             - /home/circleci/.pyenv/versions/3.10.4/envs/env
       # save build to a CircleCI workspace
@@ -188,6 +188,10 @@ jobs:
               Branch: ${CIRCLE_BRANCH}
               Git hash: ${CIRCLE_SHA1}" > version.txt
       - run:
+          # GAE only installs dependencies from requirements.txt
+          name: Extend dependencies to be installed in deploy-environment
+          command: cat requirements-deploy.txt >> requirements.txt
+      - run:
           name: Generate .env files
           command: |
             echo "
@@ -253,6 +257,10 @@ jobs:
             elif [ ! -z ${CIRCLE_SHA1} ]; then
               sed -i "s/0.0.1/${CIRCLE_SHA1}/" ../docs/graphql-api/query-api-config.yml
             fi
+      - run:
+          # GAE only installs dependencies from requirements.txt
+          name: Extend dependencies to be installed in deploy-environment
+          command: cat requirements-deploy.txt >> requirements.txt
       - run:
           name: Generate .env files
           command: |

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -2,7 +2,6 @@
 import os
 
 from flask import request
-from google.cloud import logging as gcloud_logging
 
 # Context names
 API_CONTEXT = "api"
@@ -13,6 +12,9 @@ if os.getenv("CI") == "true" or os.getenv("ENVIRONMENT") == "development":
     # development
     request_loggers = None
 else:  # pragma: no cover
+    # Google Cloud Logging is only available in deployed environments
+    from google.cloud import logging as gcloud_logging
+
     # Initializing client requires Google credentials to be set (they automatically are
     # in the GOOGLE_APPLICATION_CREDENTIALS environment variable when the app is
     # deployed on App Engine).

--- a/back/requirements-deploy.txt
+++ b/back/requirements-deploy.txt
@@ -1,0 +1,1 @@
+google-cloud-logging==3.2.5

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -9,5 +9,4 @@ python-dateutil==2.8.2
 python-dotenv==0.21.0
 python-jose==3.3.0
 aiodataloader==0.2.1
-google-cloud-logging==3.2.5
 gunicorn

--- a/react/Dockerfile
+++ b/react/Dockerfile
@@ -1,5 +1,5 @@
 # using alpine for smallest docker image
-FROM node:14.17
+FROM node:14.18
 WORKDIR /app/react
 # install packages seperately to use docker build-caching
 # so we don't need to re-fetch these if code has changed
@@ -10,4 +10,3 @@ ENV GENERATE_SOURCEMAP=false
 RUN yarn install
 
 CMD ["yarn", "start"]
-


### PR DESCRIPTION
Reason:

- it's not used in local development installations anyways, and caused
  trouble to install it on Macs (grcpio package).
- during deploy, the google-cloud-logging package must be explicitly
  added to requirements.txt (cf.
  https://cloud.google.com/appengine/docs/standard/python3/runtime#dependencies)

Follow-up to #442.
