### PR TITLE
Make resource based permission being enforced for bases by default, part I

### DIFF
--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -137,3 +137,12 @@ def agreement_organisation_filter_condition():
     return (TransferAgreement.source_organisation == g.user.organisation_id) | (
         TransferAgreement.target_organisation == g.user.organisation_id
     )
+
+
+def authorize_for_organisation_bases():
+    """This is an exceptional use for ignoring missing base info. It must be possible to
+    read organisations' bases information for anyone. The resolvers for base fields
+    (e.g. beneficiaries, products) are guarded with base-specific permission
+    enforcement.
+    """
+    _authorize(permission="base:read", ignore_missing_base_info=True)

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -35,14 +35,13 @@ def authorize(
         try:
             # Look up base IDs for given permission
             base_ids = current_user.authorized_base_ids(permission)
-            authorized = True
         except KeyError:
             # Permission not granted for user
             authorized = False
 
-        if not base_ids:
-            # Permission field exists but no access for any base granted
-            authorized = False
+        if base_ids:
+            # Permission field exists and access for at least one base granted
+            authorized = True
 
         if authorized and base_id is not None:
             # Enforce base-specific permission

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -5,6 +5,23 @@ from .exceptions import Forbidden, UnknownResource
 from .models.definitions.base import Base
 from .models.definitions.transfer_agreement import TransferAgreement
 
+BASE_AGNOSTIC_RESOURCES = (
+    "box_state",
+    "category",
+    "gender",
+    "history",
+    "language",
+    "organisation",
+    "qr",
+    "shipment",  # temporary
+    "size",
+    "size_range",
+    "tag_relation",  # temporary
+    "transaction",
+    "transfer_agreement",  # temporary
+    "user",
+)
+
 
 def authorize(
     current_user=None,
@@ -31,6 +48,10 @@ def authorize(
 
     authorized = False
     if permission is not None:
+        resource = permission.split(":")[0]
+        if resource not in BASE_AGNOSTIC_RESOURCES and base_id is None:
+            raise ValueError(f"Missing base_id for base-related resource '{resource}'.")
+
         base_ids = []
         try:
             # Look up base IDs for given permission

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -67,7 +67,7 @@ def authorize(
         raise Forbidden(resource, value, current_user.__dict__)
 
 
-def base_filter_condition(model=Base):
+def authorized_bases_filter(model=Base):
     """Derive base filter condition for given resource model depending the current
     user's base-specific permissions. The resource model must have a 'base' field, and
     the lower-case model name must match the permission resource name.

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -77,6 +77,7 @@ def authorized_bases_filter(model=Base):
         return True
 
     permission = f"{model.__name__.lower()}:read"
+    authorize(permission=permission)
     base_ids = g.user.authorized_base_ids(permission)
     pattern = Base.id if model is Base else model.base
     return pattern << base_ids

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -41,13 +41,6 @@ class AuthenticationFailed(Exception):
 # cf. https://github.com/mirumee/ariadne/issues/339#issuecomment-604380881
 # Re-use error codes proposed by Apollo-Server
 # cf. https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes
-class UnknownResource(Exception):
-    extensions = {
-        "code": "INTERNAL_SERVER_ERROR",
-        "description": "This resource is not known",
-    }
-
-
 class BoxCreationFailed(Exception):
     extensions = {
         "code": "INTERNAL_SERVER_ERROR",

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -18,6 +18,7 @@ from flask import g
 from peewee import fn
 
 from ..authz import (
+    _authorize,
     agreement_organisation_filter_condition,
     authorize,
     authorized_bases_filter,
@@ -183,7 +184,7 @@ def resolve_packing_list_entry(*_, id):
 @packing_list_entry.field("matchingPackedItemsCollections")
 def resolve_packing_list_entry_matching_packed_items_collections(obj, *_):
     mobile_distro_feature_flag_check(user_id=g.user.id)
-    authorize(permission="stock:read")
+    authorize(permission="stock:read", base_id=obj.product.base_id)
     distribution_event_id = obj.distribution_event
     boxes = Box.select().where(
         Box.distribution_event == distribution_event_id,
@@ -306,7 +307,6 @@ def resolve_qr_code(obj, _, qr_code=None):
 
 @box.field("tags")
 def resolve_box_tags(box_obj, info):
-    authorize(permission="tag:read")
     return info.context["tags_for_box_loader"].load(box_obj.id)
 
 
@@ -320,12 +320,7 @@ def resolve_product(*_, id):
 @box.field("product")
 @unboxed_items_collection.field("product")
 def resolve_box_product(obj, info):
-    product = info.context["product_loader"].load(obj.product_id)
-    # Base-specific authz can be omitted here since it was enforced in the box
-    # parent-resolver. It's not possible that the box's product is assigned to a
-    # different base than the box is in
-    authorize(permission="product:read")
-    return product
+    return info.context["product_loader"].load(obj.product_id)
 
 
 @box.field("size")
@@ -373,14 +368,22 @@ def resolve_product_category(*_, id):
 
 @query.field("transferAgreement")
 def resolve_transfer_agreement(*_, id):
-    authorize(permission="transfer_agreement:read")
-    return TransferAgreement.get_by_id(id)
+    agreement = TransferAgreement.get_by_id(id)
+    bases = retrieve_transfer_agreement_bases(
+        transfer_agreement=agreement, kind="source"
+    ) + retrieve_transfer_agreement_bases(transfer_agreement=agreement, kind="target")
+    authorize(permission="transfer_agreement:read", base_ids=[b.id for b in bases])
+    return agreement
 
 
 @query.field("shipment")
 def resolve_shipment(*_, id):
-    authorize(permission="shipment:read")
-    return Shipment.get_by_id(id)
+    shipment = Shipment.get_by_id(id)
+    authorize(
+        permission="shipment:read",
+        base_ids=[shipment.source_base_id, shipment.target_base_id],
+    )
+    return shipment
 
 
 @query.field("productCategories")
@@ -404,7 +407,7 @@ def resolve_locations(*_):
 @base.field("products")
 @convert_kwargs_to_snake_case
 def resolve_products_for_base(obj, *_):
-    authorize(permission="product:read")
+    authorize(permission="product:read", base_id=obj.id)
     return Product.select().where(Product.base == obj.id)
 
 
@@ -431,7 +434,6 @@ def resolve_beneficiaries(*_, pagination_input=None, filter_input=None):
 
 @query.field("transferAgreements")
 def resolve_transfer_agreements(*_, states=None):
-    authorize(permission="transfer_agreement:read")
     # No state filter by default
     state_filter = TransferAgreement.state << states if states else True
     return TransferAgreement.select().where(
@@ -441,11 +443,9 @@ def resolve_transfer_agreements(*_, states=None):
 
 @query.field("shipments")
 def resolve_shipments(*_):
-    authorize(permission="shipment:read")
-    return (
-        Shipment.select()
-        .join(TransferAgreement)
-        .where(agreement_organisation_filter_condition())
+    return Shipment.select().orwhere(
+        authorized_bases_filter(Shipment, base_fk_field_name="source_base"),
+        authorized_bases_filter(Shipment, base_fk_field_name="target_base"),
     )
 
 
@@ -711,7 +711,6 @@ def resolve_complete_distribution_events_tracking_group(
 @convert_kwargs_to_snake_case
 def resolve_create_qr_code(*_, box_label_identifier=None):
     authorize(permission="qr:create")
-    authorize(permission="stock:write")
     return create_qr_code(box_label_identifier=box_label_identifier)
 
 
@@ -754,7 +753,8 @@ def resolve_assign_box_to_distribution_event(
     mobile_distro_feature_flag_check(user_id=g.user.id)
     # Contemplate whether to enforce base-specific permission for box or event or both
     # Also: validate that base IDs of box location and event spot are identical
-    authorize(permission="stock:write")
+    event = DistributionEvent.get_by_id(distribution_event_id)
+    authorize(permission="stock:write", base_id=event.distribution_spot.base_id)
     return assign_box_to_distribution_event(box_label_identifier, distribution_event_id)
 
 
@@ -813,8 +813,8 @@ def resolve_remove_packing_list_entry_from_distribution_event(
 @mutation.field("createBox")
 @convert_kwargs_to_snake_case
 def resolve_create_box(*_, creation_input):
-    authorize(permission="stock:write")
     requested_location = Location.get_by_id(creation_input["location_id"])
+    authorize(permission="stock:write", base_id=requested_location.base_id)
     authorize(permission="location:read", base_id=requested_location.base_id)
     requested_product = Product.get_by_id(creation_input["product_id"])
     authorize(permission="product:read", base_id=requested_product.base_id)
@@ -906,30 +906,54 @@ def resolve_update_beneficiary(*_, update_input):
 @mutation.field("createTransferAgreement")
 @convert_kwargs_to_snake_case
 def resolve_create_transfer_agreement(*_, creation_input):
-    authorize(permission="transfer_agreement:create")
+    # Enforce that the user can access at least one of the specified source bases
+    # (default: all bases of the user's organisation)
+    base_ids = creation_input.get(
+        "source_base_ids",
+        [
+            b.id
+            for b in Base.select().where(Base.organisation == g.user.organisation_id)
+        ],
+    )
+    authorize(permission="transfer_agreement:create", base_ids=base_ids)
     return create_transfer_agreement(**creation_input, user=g.user)
 
 
 @mutation.field("acceptTransferAgreement")
 def resolve_accept_transfer_agreement(*_, id):
-    authorize(permission="transfer_agreement:edit")
+    # User must be member of at least one of the target bases to be authorized for
+    # accepting the agreement
     agreement = TransferAgreement.get_by_id(id)
+    bases = retrieve_transfer_agreement_bases(
+        transfer_agreement=agreement, kind="target"
+    )
+    authorize(permission="transfer_agreement:edit", base_ids=[b.id for b in bases])
     authorize(organisation_id=agreement.target_organisation_id)
     return accept_transfer_agreement(id=id, user=g.user)
 
 
 @mutation.field("rejectTransferAgreement")
 def resolve_reject_transfer_agreement(*_, id):
-    authorize(permission="transfer_agreement:edit")
+    # User must be member of at least one of the target bases to be authorized for
+    # rejecting the agreement
     agreement = TransferAgreement.get_by_id(id)
+    bases = retrieve_transfer_agreement_bases(
+        transfer_agreement=agreement, kind="target"
+    )
+    authorize(permission="transfer_agreement:edit", base_ids=[b.id for b in bases])
     authorize(organisation_id=agreement.target_organisation_id)
     return reject_transfer_agreement(id=id, user=g.user)
 
 
 @mutation.field("cancelTransferAgreement")
 def resolve_cancel_transfer_agreement(*_, id):
-    authorize(permission="transfer_agreement:edit")
+    # User must be member of at least one of the source or target bases to be authorized
+    # for cancelling the agreement
     agreement = TransferAgreement.get_by_id(id)
+    bases = retrieve_transfer_agreement_bases(
+        transfer_agreement=agreement, kind="target"
+    ) + retrieve_transfer_agreement_bases(transfer_agreement=agreement, kind="source")
+    authorize(permission="transfer_agreement:edit", base_ids=[b.id for b in bases])
     authorize(
         organisation_ids=[
             agreement.source_organisation_id,
@@ -942,7 +966,10 @@ def resolve_cancel_transfer_agreement(*_, id):
 @mutation.field("createShipment")
 @convert_kwargs_to_snake_case
 def resolve_create_shipment(*_, creation_input):
-    authorize(permission="shipment:create")
+    authorize(
+        permission="shipment:create",
+        base_ids=[creation_input["source_base_id"], creation_input["target_base_id"]],
+    )
     agreement = TransferAgreement.get_by_id(creation_input["transfer_agreement_id"])
     organisation_ids = [agreement.source_organisation_id]
     if agreement.type == TransferAgreementType.Bidirectional:
@@ -954,9 +981,12 @@ def resolve_create_shipment(*_, creation_input):
 @mutation.field("updateShipment")
 @convert_kwargs_to_snake_case
 def resolve_update_shipment(*_, update_input):
-    authorize(permission="shipment:edit")
-
     shipment = Shipment.get_by_id(update_input["id"])
+    authorize(
+        permission="shipment:edit",
+        base_ids=[shipment.source_base_id, shipment.target_base_id],
+    )
+
     source_update_fields = [
         "prepared_box_label_identifiers",
         "removed_box_label_identifiers",
@@ -983,8 +1013,11 @@ def resolve_update_shipment(*_, update_input):
 
 @mutation.field("cancelShipment")
 def resolve_cancel_shipment(*_, id):
-    authorize(permission="shipment:edit")
     shipment = Shipment.get_by_id(id)
+    authorize(
+        permission="shipment:edit",
+        base_ids=[shipment.source_base_id, shipment.target_base_id],
+    )
     authorize(
         organisation_ids=[
             shipment.transfer_agreement.source_organisation_id,
@@ -996,8 +1029,11 @@ def resolve_cancel_shipment(*_, id):
 
 @mutation.field("sendShipment")
 def resolve_send_shipment(*_, id):
-    authorize(permission="shipment:edit")
     shipment = Shipment.get_by_id(id)
+    authorize(
+        permission="shipment:edit",
+        base_ids=[shipment.source_base_id, shipment.target_base_id],
+    )
     authorize(organisation_id=shipment.source_base.organisation_id)
     return send_shipment(id=id, user=g.user)
 
@@ -1063,7 +1099,7 @@ def resolve_base_distribution_events_statistics(base_obj, _):
 
 @base.field("locations")
 def resolve_base_locations(base_obj, _):
-    authorize(permission="location:read")
+    authorize(permission="location:read", base_id=base_obj.id)
     return Location.select().where(
         (Location.base == base_obj.id) & (Location.type == LocationType.ClassicLocation)
     )
@@ -1134,7 +1170,10 @@ def resolve_base_beneficiaries(base_obj, _, pagination_input=None, filter_input=
 @distribution_event.field("boxes")
 @convert_kwargs_to_snake_case
 def resolve_distribution_event_boxes(distribution_event_obj, _):
-    authorize(permission="stock:read")
+    authorize(
+        permission="stock:read",
+        base_id=distribution_event_obj.distribution_spot.base_id,
+    )
     return Box.select().where(Box.distribution_event == distribution_event_obj.id)
 
 
@@ -1223,7 +1262,7 @@ def resolve_distribution_spot_distribution_events(obj, *_):
 @classic_location.field("boxes")
 @convert_kwargs_to_snake_case
 def resolve_location_boxes(location_obj, _, pagination_input=None, filter_input=None):
-    authorize(permission="stock:read")
+    authorize(permission="stock:read", base_id=location_obj.base_id)
     location_filter_condition = Box.location == location_obj.id
     filter_condition = location_filter_condition & derive_box_filter(filter_input)
     selection = Box.select()
@@ -1273,7 +1312,10 @@ def resolve_metrics_moved_stock_overview(metrics_obj, _, after=None, before=None
 
 @organisation.field("bases")
 def resolve_organisation_bases(organisation_obj, _):
-    authorize(permission="base:read")
+    # This is an exceptional use for ignoring missing base info. It must be possible to
+    # read organisations' bases information for anyone. The resolvers for base fields
+    # are guarded with base-specific permission enforcement
+    _authorize(permission="base:read", ignore_missing_base_info=True)
     return Base.select().where(Base.organisation_id == organisation_obj.id)
 
 
@@ -1282,7 +1324,7 @@ def resolve_organisation_bases(organisation_obj, _):
 @classic_location.field("base")
 @product.field("base")
 def resolve_resource_base(obj, _):
-    authorize(permission="base:read")
+    authorize(permission="base:read", base_id=obj.base_id)
     return obj.base
 
 
@@ -1311,10 +1353,12 @@ def resolve_product_category_has_gender(product_category_obj, _):
 @product_category.field("products")
 @convert_kwargs_to_snake_case
 def resolve_product_category_products(product_category_obj, _, pagination_input=None):
-    authorize(permission="product:read")
     category_filter_condition = Product.category == product_category_obj.id
     return load_into_page(
-        Product, category_filter_condition, pagination_input=pagination_input
+        Product,
+        authorized_bases_filter(Product),
+        category_filter_condition,
+        pagination_input=pagination_input,
     )
 
 
@@ -1335,37 +1379,67 @@ def resolve_shipment_details(shipment_obj, _):
 
 @shipment.field("sourceBase")
 def resolve_shipment_source_base(shipment_obj, _):
-    authorize(permission="base:read")
+    authorize(
+        permission="base:read",
+        base_ids=[shipment_obj.source_base_id, shipment_obj.target_base_id],
+    )
     return shipment_obj.source_base
 
 
 @shipment.field("targetBase")
 def resolve_shipment_target_base(shipment_obj, _):
-    authorize(permission="base:read")
+    authorize(
+        permission="base:read",
+        base_ids=[shipment_obj.source_base_id, shipment_obj.target_base_id],
+    )
     return shipment_obj.target_base
 
 
 @shipment_detail.field("sourceProduct")
 def resolve_shipment_detail_source_product(detail_obj, _):
-    authorize(permission="product:read")
+    authorize(
+        permission="product:read",
+        base_ids=[
+            detail_obj.shipment.source_base_id,
+            detail_obj.shipment.target_base_id,
+        ],
+    )
     return detail_obj.source_product
 
 
 @shipment_detail.field("targetProduct")
 def resolve_shipment_detail_target_product(detail_obj, _):
-    authorize(permission="product:read")
+    authorize(
+        permission="product:read",
+        base_ids=[
+            detail_obj.shipment.source_base_id,
+            detail_obj.shipment.target_base_id,
+        ],
+    )
     return detail_obj.target_product
 
 
 @shipment_detail.field("sourceLocation")
 def resolve_shipment_detail_source_location(detail_obj, _):
-    authorize(permission="location:read")
+    authorize(
+        permission="location:read",
+        base_ids=[
+            detail_obj.shipment.source_base_id,
+            detail_obj.shipment.target_base_id,
+        ],
+    )
     return detail_obj.source_location
 
 
 @shipment_detail.field("targetLocation")
 def resolve_shipment_detail_target_location(detail_obj, _):
-    authorize(permission="location:read")
+    authorize(
+        permission="location:read",
+        base_ids=[
+            detail_obj.shipment.source_base_id,
+            detail_obj.shipment.target_base_id,
+        ],
+    )
     return detail_obj.target_location
 
 
@@ -1376,7 +1450,7 @@ def resolve_size_range_sizes(size_range_obj, info):
 
 @transfer_agreement.field("sourceBases")
 def resolve_transfer_agreement_source_bases(transfer_agreement_obj, _):
-    authorize(permission="base:read")
+    _authorize(permission="base:read", ignore_missing_base_info=True)
     return retrieve_transfer_agreement_bases(
         transfer_agreement=transfer_agreement_obj, kind="source"
     )
@@ -1384,7 +1458,7 @@ def resolve_transfer_agreement_source_bases(transfer_agreement_obj, _):
 
 @transfer_agreement.field("targetBases")
 def resolve_transfer_agreement_target_bases(transfer_agreement_obj, _):
-    authorize(permission="base:read")
+    _authorize(permission="base:read", ignore_missing_base_info=True)
     return retrieve_transfer_agreement_bases(
         transfer_agreement=transfer_agreement_obj, kind="target"
     )
@@ -1392,10 +1466,17 @@ def resolve_transfer_agreement_target_bases(transfer_agreement_obj, _):
 
 @transfer_agreement.field("shipments")
 def resolve_transfer_agreement_shipments(transfer_agreement_obj, _):
-    authorize(permission="shipment:read")
     return Shipment.select().where(
-        Shipment.transfer_agreement == transfer_agreement_obj.id
+        Shipment.transfer_agreement == transfer_agreement_obj.id,
+        authorized_bases_filter(Shipment, base_fk_field_name="source_base")
+        | authorized_bases_filter(Shipment, base_fk_field_name="target_base"),
     )
+
+
+@user.field("email")
+def resolve_user_email(user_obj, _):
+    authorize(user_id=user_obj.id)
+    return user_obj.email
 
 
 @user.field("organisation")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -20,7 +20,7 @@ from peewee import fn
 from ..authz import (
     agreement_organisation_filter_condition,
     authorize,
-    base_filter_condition,
+    authorized_bases_filter,
 )
 from ..box_transfer.agreement import (
     accept_transfer_agreement,
@@ -168,7 +168,7 @@ def resolve_tag(*_, id):
 @query.field("tags")
 def resolve_tags(*_):
     authorize(permission="tag:read")
-    return Tag.select().where(Tag.deleted.is_null() & base_filter_condition(Tag))
+    return Tag.select().where(Tag.deleted.is_null() & authorized_bases_filter(Tag))
 
 
 @query.field("packingListEntry")
@@ -203,7 +203,7 @@ def resolve_packing_list_entry_matching_packed_items_collections(obj, *_):
 @query.field("bases")
 def resolve_bases(*_):
     authorize(permission="base:read")
-    return Base.select().where(base_filter_condition())
+    return Base.select().where(authorized_bases_filter())
 
 
 @query.field("base")
@@ -400,7 +400,7 @@ def resolve_organisations(*_):
 def resolve_locations(*_):
     authorize(permission="location:read")
     return Location.select().where(
-        Location.type == LocationType.ClassicLocation, base_filter_condition(Location)
+        Location.type == LocationType.ClassicLocation, authorized_bases_filter(Location)
     )
 
 
@@ -417,7 +417,7 @@ def resolve_products(*_, pagination_input=None):
     authorize(permission="product:read")
     return load_into_page(
         Product,
-        base_filter_condition(Product),
+        authorized_bases_filter(Product),
         pagination_input=pagination_input,
     )
 
@@ -429,7 +429,7 @@ def resolve_beneficiaries(*_, pagination_input=None, filter_input=None):
     filter_condition = derive_beneficiary_filter(filter_input)
     return load_into_page(
         Beneficiary,
-        base_filter_condition(Beneficiary) & filter_condition,
+        authorized_bases_filter(Beneficiary) & filter_condition,
         pagination_input=pagination_input,
     )
 
@@ -481,7 +481,7 @@ def resolve_tag_tagged_resources(tag_obj, _):
     return list(
         Beneficiary.select().where(
             Beneficiary.id << [r.object_id for r in beneficiary_relations],
-            base_filter_condition(Beneficiary),
+            authorized_bases_filter(Beneficiary),
         )
     ) + list(Box.select().where(Box.id << [r.object_id for r in box_relations]))
 
@@ -1088,7 +1088,7 @@ def resolve_distributions_spots(base_obj, _):
     authorize(permission="location:read")
     return Location.select().where(
         (Location.type == LocationType.DistributionSpot)
-        & (base_filter_condition(Location))
+        & (authorized_bases_filter(Location))
     )
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -167,7 +167,6 @@ def resolve_tag(*_, id):
 
 @query.field("tags")
 def resolve_tags(*_):
-    authorize(permission="tag:read")
     return Tag.select().where(Tag.deleted.is_null() & authorized_bases_filter(Tag))
 
 
@@ -202,7 +201,6 @@ def resolve_packing_list_entry_matching_packed_items_collections(obj, *_):
 @user.field("bases")
 @query.field("bases")
 def resolve_bases(*_):
-    authorize(permission="base:read")
     return Base.select().where(authorized_bases_filter())
 
 
@@ -398,7 +396,6 @@ def resolve_organisations(*_):
 
 @query.field("locations")
 def resolve_locations(*_):
-    authorize(permission="location:read")
     return Location.select().where(
         Location.type == LocationType.ClassicLocation, authorized_bases_filter(Location)
     )
@@ -414,7 +411,6 @@ def resolve_products_for_base(obj, *_):
 @query.field("products")
 @convert_kwargs_to_snake_case
 def resolve_products(*_, pagination_input=None):
-    authorize(permission="product:read")
     return load_into_page(
         Product,
         authorized_bases_filter(Product),
@@ -425,7 +421,6 @@ def resolve_products(*_, pagination_input=None):
 @query.field("beneficiaries")
 @convert_kwargs_to_snake_case
 def resolve_beneficiaries(*_, pagination_input=None, filter_input=None):
-    authorize(permission="beneficiary:read")
     filter_condition = derive_beneficiary_filter(filter_input)
     return load_into_page(
         Beneficiary,
@@ -1085,7 +1080,6 @@ def resolve_distribution_events_tracking_group(*_, id):
 @query.field("distributionSpots")
 def resolve_distributions_spots(base_obj, _):
     mobile_distro_feature_flag_check(user_id=g.user.id)
-    authorize(permission="location:read")
     return Location.select().where(
         (Location.type == LocationType.DistributionSpot)
         & (authorized_bases_filter(Location))

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -377,7 +377,7 @@ type User {
   id: ID!
   organisation: Organisation
   name: String
-  email: String!
+  email: String
   validFirstDay: Date
   validLastDay: Date
   " List of all [`Bases`]({{Types.Base}}) this user can access "

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -102,6 +102,8 @@ def create_jwt_payload(
             f"{base_prefix}/beneficiary:create",
             f"{base_prefix}/beneficiary:edit",
             f"{base_prefix}/qr:create",
+            f"{base_prefix}/size:read",
+            f"{base_prefix}/size_range:read",
             f"{base_prefix}/stock:write",
             f"{base_prefix}/tag:write",
             f"{base_prefix}/tag_relation:read",

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -61,7 +61,7 @@ from .transfer_agreement import (
     transfer_agreements,
     unidirectional_transfer_agreement,
 )
-from .user import default_user, default_users
+from .user import another_user, default_user, default_users
 
 __all__ = [
     "another_beneficiary",
@@ -74,6 +74,7 @@ __all__ = [
     "another_shipment",
     "another_shipment_detail",
     "another_size",
+    "another_user",
     "base1_classic_locations",
     "box_without_qr_code",
     "canceled_shipment",

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -33,6 +33,7 @@ from .location import (
 )
 from .log import default_log
 from .organisation import another_organisation, default_organisation, organisations
+from .packing_list_entry import packing_list_entry
 from .product import another_product, default_product, products
 from .product_category import default_product_category
 from .product_gender import default_product_gender
@@ -107,6 +108,7 @@ __all__ = [
     "non_default_box_state_location",
     "null_box_state_location",
     "organisations",
+    "packing_list_entry",
     "prepared_shipment_detail",
     "products",
     "qr_code_without_box",

--- a/back/test/data/packing_list_entry.py
+++ b/back/test/data/packing_list_entry.py
@@ -1,7 +1,11 @@
+import pytest
 from boxtribute_server.enums import PackingListEntryState
 from boxtribute_server.models.definitions.packing_list_entry import PackingListEntry
 
-from .distribution_event import another_distribution_event_data
+from .distribution_event import (
+    another_distribution_event_data,
+    default_distribution_event_data,
+)
 from .product import data as product_data
 from .size import default_data as default_size_data
 
@@ -16,7 +20,20 @@ def data():
             "distribution_event": another_distribution_event_data()["id"],
             "state": PackingListEntryState.NotStarted,
         },
+        {
+            "id": 2,
+            "product": product_data()[0]["id"],
+            "number_of_items": 1,
+            "size": default_size_data()["id"],
+            "distribution_event": default_distribution_event_data()["id"],
+            "state": PackingListEntryState.NotStarted,
+        },
     ]
+
+
+@pytest.fixture
+def packing_list_entry():
+    return data()[1]
 
 
 def create():

--- a/back/test/data/shipment.py
+++ b/back/test/data/shipment.py
@@ -48,6 +48,15 @@ def data():
             "started_by": default_user_data()["id"],
             "started_on": TIME,
         },
+        {
+            "id": 5,
+            "source_base": base_data()[1]["id"],
+            "target_base": base_data()[2]["id"],
+            "transfer_agreement": transfer_agreement_data()[0]["id"],
+            "state": ShipmentState.Preparing,
+            "started_by": default_user_data()["id"],
+            "started_on": TIME,
+        },
     ]
 
 

--- a/back/test/data/transfer_agreement_detail.py
+++ b/back/test/data/transfer_agreement_detail.py
@@ -14,7 +14,13 @@ def data():
             "transfer_agreement": transfer_agreement_data()[0]["id"],
             "source_base": None,
             "target_base": base_data()[2]["id"],
-        }
+        },
+        {
+            "id": 2,
+            "transfer_agreement": transfer_agreement_data()[1]["id"],
+            "source_base": None,
+            "target_base": base_data()[2]["id"],
+        },
     ]
 
 

--- a/back/test/data/user.py
+++ b/back/test/data/user.py
@@ -27,14 +27,8 @@ def default_user_data():
     }
 
 
-def default_users_data():
-    users = {}
-
-    mock_user = default_user_data()
-
-    users[mock_user["id"]] = mock_user
-
-    mock_user = {
+def second_user_data():
+    return {
         "id": 2,
         "name": "trainer",
         "email": "alarm@bedpost.com",
@@ -51,9 +45,9 @@ def default_users_data():
         "deleted": None,
     }
 
-    users[mock_user["id"]] = mock_user
 
-    mock_user = {
+def another_user_data():
+    return {
         "id": 8,
         "name": "coord",
         "email": "dev_coordinator@boxaid.org",
@@ -70,20 +64,25 @@ def default_users_data():
         "deleted": None,
     }
 
-    users[mock_user["id"]] = mock_user
 
-    return users
+def data():
+    return [default_user_data(), second_user_data(), another_user_data()]
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_user():
     return default_user_data()
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_users():
-    return default_users_data()
+    return data()
+
+
+@pytest.fixture
+def another_user():
+    return another_user_data()
 
 
 def create():
-    User.insert_many(default_users_data().values()).execute()
+    User.insert_many(data()).execute()

--- a/back/test/endpoint_tests/test_distribution_event.py
+++ b/back/test/endpoint_tests/test_distribution_event.py
@@ -44,7 +44,7 @@ def test_update_selected_products_for_distribution_event_packing_list(
             {
                 "product": {"id": str(default_product["id"])},
                 "size": {"id": str(default_size["id"])},
-                "numberOfItems": 0,
+                "numberOfItems": 1,
             },
             {
                 "product": {"id": str(default_product["id"])},

--- a/back/test/endpoint_tests/test_packing_list_entry.py
+++ b/back/test/endpoint_tests/test_packing_list_entry.py
@@ -1,0 +1,22 @@
+from utils import assert_successful_request
+
+
+def test_packing_list_entry(read_only_client, packing_list_entry):
+    entry_id = str(packing_list_entry["id"])
+    query = f"""query {{ packingListEntry(id: {entry_id}) {{
+                id
+                product {{ id }}
+                size {{ id }}
+                numberOfItems
+                matchingPackedItemsCollections {{ id }}
+                state
+            }} }}"""
+    entry = assert_successful_request(read_only_client, query)
+    assert entry == {
+        "id": entry_id,
+        "product": {"id": str(packing_list_entry["product"])},
+        "size": {"id": str(packing_list_entry["size"])},
+        "numberOfItems": packing_list_entry["number_of_items"],
+        "matchingPackedItemsCollections": [],
+        "state": packing_list_entry["state"].name,
+    }

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -86,6 +86,8 @@ def test_invalid_permission(unauthorized, read_only_client, query):
         # Test case 10.1.5
         """user( id: 1) { id }""",
         """packingListEntry( id: 1 ) { id }""",
+        # Test case 3.1.6
+        """shipment( id: 5 ) { id }""",
     ],
     ids=operation_name,
 )
@@ -459,3 +461,15 @@ def test_permission_for_god_user(
     query = "query { transferAgreements { id } }"
     agreements = assert_successful_request(read_only_client, query)
     assert len(agreements) == len(transfer_agreements)
+
+
+def test_invalid_permission_for_user_read(
+    read_only_client, default_product, default_user
+):
+    product_id = default_product["id"]
+    query = f"query {{ product(id: {product_id}) {{ createdBy {{ name email }} }} }}"
+    assert_forbidden_request(
+        read_only_client,
+        query,
+        value={"createdBy": {"email": None, "name": default_user["name"]}},
+    )

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -79,7 +79,7 @@ def test_shipment_mutations_on_source_side(
     prepared_shipment_detail,
 ):
     # Test case 3.2.1a
-    source_base_id = default_bases[2]["id"]
+    source_base_id = default_bases[1]["id"]
     target_base_id = default_bases[3]["id"]
     agreement_id = default_transfer_agreement["id"]
     creation_input = f"""sourceBaseId: {source_base_id},
@@ -553,7 +553,7 @@ def test_shipment_mutations_create_with_invalid_base(
     # Test case 3.2.3
     assert_bad_user_input_when_creating_shipment(
         read_only_client,
-        source_base=default_bases[2],
+        source_base=default_bases[1],
         target_base=default_bases[4],  # not part of agreement
         agreement=default_transfer_agreement,
     )

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -217,7 +217,9 @@ def test_transfer_agreement_mutations_invalid_state(
 ):
     # The client has to be permitted to perform the action in general
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
-        organisation_id=expired_transfer_agreement["target_organisation"], user_id=2
+        organisation_id=expired_transfer_agreement["target_organisation"],
+        user_id=2,
+        base_ids=[3],
     )
     # Test cases 2.2.11, 2.2.12, 2.2.13
     agreement_id = expired_transfer_agreement["id"]
@@ -260,8 +262,9 @@ def test_transfer_agreement_mutations_identical_source_org_for_creation(
 
 @pytest.mark.parametrize("kind,base_id", [["source", 3], ["target", 1]])
 def test_transfer_agreement_mutations_create_invalid_source_base(
-    read_only_client, kind, base_id
+    read_only_client, mocker, kind, base_id
 ):
+    mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(base_ids=[1, 3])
     # Test cases 2.2.18, 2.2.19
     mutation = f"""mutation {{ createTransferAgreement( creationInput: {{
                     targetOrganisationId: 2,

--- a/back/test/endpoint_tests/test_user.py
+++ b/back/test/endpoint_tests/test_user.py
@@ -1,11 +1,9 @@
 from utils import assert_successful_request
 
 
-def test_user_query(read_only_client, default_users, default_organisation):
+def test_user_query(read_only_client, another_user, default_organisation):
     # Test case 10.1.2
-    test_id = 8
-    expected_user = default_users[test_id]
-
+    test_id = another_user["id"]
     query = f"""query User {{
                 user(id: {test_id}) {{
                     id
@@ -22,15 +20,15 @@ def test_user_query(read_only_client, default_users, default_organisation):
 
     queried_user = assert_successful_request(read_only_client, query)
     assert int(queried_user["id"]) == test_id
-    assert queried_user["name"] == expected_user["name"]
-    assert queried_user["email"] == expected_user["email"]
-    assert queried_user["validFirstDay"] == expected_user["valid_first_day"].isoformat()
-    assert queried_user["lastLogin"][:-6] == expected_user["last_login"].isoformat()
+    assert queried_user["name"] == another_user["name"]
+    assert queried_user["email"] == another_user["email"]
+    assert queried_user["validFirstDay"] == another_user["valid_first_day"].isoformat()
+    assert queried_user["lastLogin"][:-6] == another_user["last_login"].isoformat()
     assert [int(b["id"]) for b in queried_user["bases"]] == [1]
     assert int(queried_user["organisation"]["id"]) == default_organisation["id"]
 
 
-def test_users_query(read_only_client, default_users):
+def test_users_query(read_only_client):
     # Test case 10.1.1
     query = """query { users { id name } }"""
     assert assert_successful_request(read_only_client, query) == []


### PR DESCRIPTION
This is the first of a series of at least two PRs related to enforcing base-specific permissions. I'm breaking it down because after the authz logic was changed, there are quite some effects on the resolvers (mostly because base-specific permissions were (lazily) not enforced, or because the permission level was clarified, e.g. for transfer agreement to also operate on base-level). This means a couple of tests are failing but I'll fix them in subsequent PRs which will be merged here one by one. Eventually this branch can go into master.

You can read the background in the attached Trello card.

The main functional change is in cdb1bac4.
