### PR TITLE
Enable passing tag IDs when updating box

### DIFF
--- a/back/boxtribute_server/graph_ql/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/inputs.graphql
@@ -19,6 +19,7 @@ input BoxUpdateInput {
   locationId: Int
   comment: String
   state: BoxState
+  tagIds: [Int!]
 }
 
 input BeneficiaryCreationInput {

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -852,6 +852,10 @@ def resolve_update_box(*_, update_input):
         requested_product = Product.get_by_id(product_id)
         authorize(permission="product:read", base_id=requested_product.base_id)
 
+    tag_ids = update_input.get("tag_ids", [])
+    for tag in Tag.select().where(Tag.id << tag_ids):
+        authorize(permission="tag_relation:assign", base_id=tag.base_id)
+
     return update_box(user_id=g.user.id, **update_input)
 
 

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -107,6 +107,7 @@ def update_box(
     product_id=None,
     size_id=None,
     state=None,
+    tag_ids=None,
 ):
     """Look up an existing Box given a UUID, and update all requested fields.
     Insert timestamp for modification and return the box.
@@ -131,6 +132,35 @@ def update_box(
         box.size = size_id
     if state is not None:
         box.state = state
+    if tag_ids:
+        # Find all tag IDs that are currently assigned to the box
+        assigned_tag_ids = set(
+            r.tag_id
+            for r in TagsRelation.select(TagsRelation.tag_id).where(
+                TagsRelation.object_type == TaggableObjectType.Box,
+                TagsRelation.object_id == box.id,
+            )
+        )
+        updated_tag_ids = set(tag_ids)
+
+        # Unassign all tags that were previously assigned to the box but are not part
+        # of the updated set of tags
+        for tag_id in assigned_tag_ids.difference(updated_tag_ids):
+            unassign_tag(
+                user_id=user_id,
+                id=tag_id,
+                resource_id=box.id,
+                resource_type=TaggableObjectType.Box,
+            )
+        # Assign all tags that are part of the updated set of tags but were previously
+        # not assigned to the box
+        for tag_id in updated_tag_ids.difference(assigned_tag_ids):
+            assign_tag(
+                user_id=user_id,
+                id=tag_id,
+                resource_id=box.id,
+                resource_type=TaggableObjectType.Box,
+            )
 
     box.last_modified_by = user_id
     box.last_modified_on = utcnow()

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -253,6 +253,27 @@ def test_box_mutations(
     ]
 
 
+def test_update_box_tag_ids(client, default_box, tags):
+    # Test case 8.2.11c
+    label_identifier = default_box["label_identifier"]
+    tag_id = str(tags[1]["id"])
+    another_tag_id = str(tags[2]["id"])
+
+    # Default box has tag ID 2 assigned already. Remove it and add tag ID 3
+    mutation = f"""mutation {{ updateBox(updateInput : {{
+                    labelIdentifier: "{label_identifier}"
+                    tagIds: [{another_tag_id}] }} ) {{ tags {{ id }} }} }}"""
+    updated_box = assert_successful_request(client, mutation)
+    assert updated_box == {"tags": [{"id": another_tag_id}]}
+
+    # Now add tag ID 2 back while keeping tag ID 3
+    mutation = f"""mutation {{ updateBox(updateInput : {{
+                    labelIdentifier: "{label_identifier}"
+                    tagIds: [{tag_id},{another_tag_id}] }} ) {{ tags {{ id }} }} }}"""
+    updated_box = assert_successful_request(client, mutation)
+    assert updated_box == {"tags": [{"id": tag_id}, {"id": another_tag_id}]}
+
+
 def _format(parameter):
     try:
         return ",".join(f"{k}={v}" for f in parameter for k, v in f.items())

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -239,6 +239,12 @@ def test_invalid_write_permission(unauthorized, read_only_client, mutation):
                 labelIdentifier: "12345678",
                 productId: 2
             }) { id }""",
+        # Test case 8.2.21
+        """updateBox(
+            updateInput : {
+                labelIdentifier: "12345678",
+                tagIds: [4]
+            }) { id }""",
     ],
     ids=operation_name,
 )

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -200,6 +200,7 @@ export type BoxUpdateInput = {
   productId?: InputMaybe<Scalars['Int']>;
   sizeId?: InputMaybe<Scalars['Int']>;
   state?: InputMaybe<BoxState>;
+  tagIds?: InputMaybe<Array<Scalars['Int']>>;
 };
 
 /**


### PR DESCRIPTION
Simple extension of `BoxUpdateInput`.
