### PR TITLE
Remove all assigned tags when passing empty list for tag IDs

### DIFF
--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -132,7 +132,7 @@ def update_box(
         box.size = size_id
     if state is not None:
         box.state = state
-    if tag_ids:
+    if tag_ids is not None:
         # Find all tag IDs that are currently assigned to the box
         assigned_tag_ids = set(
             r.tag_id

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -273,6 +273,13 @@ def test_update_box_tag_ids(client, default_box, tags):
     updated_box = assert_successful_request(client, mutation)
     assert updated_box == {"tags": [{"id": tag_id}, {"id": another_tag_id}]}
 
+    # Remove all assigned tags when passing empty list
+    mutation = f"""mutation {{ updateBox(updateInput : {{
+                    labelIdentifier: "{label_identifier}"
+                    tagIds: [] }} ) {{ tags {{ id }} }} }}"""
+    updated_box = assert_successful_request(client, mutation)
+    assert updated_box == {"tags": []}
+
 
 def _format(parameter):
     try:


### PR DESCRIPTION
Follow-up for #462
