### PR TITLE
Update permissions enforcement part II

### DIFF
--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -82,7 +82,7 @@ def _authorize(
                 authorized = int(base_id) in authzed_base_ids
             elif base_ids is not None:
                 authorized = any([int(b) in authzed_base_ids for b in base_ids])
-            elif resource in BASE_AGNOSTIC_RESOURCES:
+            elif resource in BASE_AGNOSTIC_RESOURCES or ignore_missing_base_info:
                 authorized = True
 
     elif organisation_id is not None:

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -12,13 +12,14 @@ BASE_AGNOSTIC_RESOURCES = (
     "history",
     "language",
     "organisation",
+    "packing_list_entry",  # temporary
     "qr",
-    "shipment",  # temporary
     "size",
     "size_range",
-    "tag_relation",  # temporary
+    "tag_relation",
     "transaction",
     "transfer_agreement",  # temporary
+    "unboxed_items_collection",  # temporary
     "user",
 )
 

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -105,10 +105,11 @@ def _authorize(
         raise Forbidden(resource, value, current_user.__dict__)
 
 
-def authorized_bases_filter(model=Base):
+def authorized_bases_filter(model=Base, *, base_fk_field_name="base"):
     """Derive base filter condition for given resource model depending the current
-    user's base-specific permissions. The resource model must have a 'base' field, and
-    the lower-case model name must match the permission resource name.
+    user's base-specific permissions. The resource model must have a FK field referring
+    to the Base model named 'base_fk_field_name'.
+    The lower-case model name must match the permission resource name.
     See also `auth.requires_auth()`.
     """
     if g.user.is_god:
@@ -117,7 +118,7 @@ def authorized_bases_filter(model=Base):
     permission = f"{model.__name__.lower()}:read"
     _authorize(permission=permission, ignore_missing_base_info=True)
     base_ids = g.user.authorized_base_ids(permission)
-    pattern = Base.id if model is Base else model.base
+    pattern = Base.id if model is Base else getattr(model, base_fk_field_name)
     return pattern << base_ids
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -307,7 +307,6 @@ def resolve_qr_code(obj, _, qr_code=None):
 
 @box.field("tags")
 def resolve_box_tags(box_obj, info):
-    authorize(permission="tag:read")
     return info.context["tags_for_box_loader"].load(box_obj.id)
 
 
@@ -321,12 +320,7 @@ def resolve_product(*_, id):
 @box.field("product")
 @unboxed_items_collection.field("product")
 def resolve_box_product(obj, info):
-    product = info.context["product_loader"].load(obj.product_id)
-    # Base-specific authz can be omitted here since it was enforced in the box
-    # parent-resolver. It's not possible that the box's product is assigned to a
-    # different base than the box is in
-    authorize(permission="product:read")
-    return product
+    return info.context["product_loader"].load(obj.product_id)
 
 
 @box.field("size")

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -1339,37 +1339,61 @@ def resolve_shipment_details(shipment_obj, _):
 
 @shipment.field("sourceBase")
 def resolve_shipment_source_base(shipment_obj, _):
-    authorize(permission="base:read")
+    authorize(permission="base:read", base_id=shipment_obj.source_base_id)
     return shipment_obj.source_base
 
 
 @shipment.field("targetBase")
 def resolve_shipment_target_base(shipment_obj, _):
-    authorize(permission="base:read")
+    authorize(permission="base:read", base_id=shipment_obj.target_base_id)
     return shipment_obj.target_base
 
 
 @shipment_detail.field("sourceProduct")
 def resolve_shipment_detail_source_product(detail_obj, _):
-    authorize(permission="product:read")
+    authorize(
+        permission="product:read",
+        base_ids=[
+            detail_obj.shipment.source_base_id,
+            detail_obj.shipment.target_base_id,
+        ],
+    )
     return detail_obj.source_product
 
 
 @shipment_detail.field("targetProduct")
 def resolve_shipment_detail_target_product(detail_obj, _):
-    authorize(permission="product:read")
+    authorize(
+        permission="product:read",
+        base_ids=[
+            detail_obj.shipment.source_base_id,
+            detail_obj.shipment.target_base_id,
+        ],
+    )
     return detail_obj.target_product
 
 
 @shipment_detail.field("sourceLocation")
 def resolve_shipment_detail_source_location(detail_obj, _):
-    authorize(permission="location:read")
+    authorize(
+        permission="location:read",
+        base_ids=[
+            detail_obj.shipment.source_base_id,
+            detail_obj.shipment.target_base_id,
+        ],
+    )
     return detail_obj.source_location
 
 
 @shipment_detail.field("targetLocation")
 def resolve_shipment_detail_target_location(detail_obj, _):
-    authorize(permission="location:read")
+    authorize(
+        permission="location:read",
+        base_ids=[
+            detail_obj.shipment.source_base_id,
+            detail_obj.shipment.target_base_id,
+        ],
+    )
     return detail_obj.target_location
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -445,11 +445,9 @@ def resolve_transfer_agreements(*_, states=None):
 
 @query.field("shipments")
 def resolve_shipments(*_):
-    authorize(permission="shipment:read")
-    return (
-        Shipment.select()
-        .join(TransferAgreement)
-        .where(agreement_organisation_filter_condition())
+    return Shipment.select().orwhere(
+        authorized_bases_filter(Shipment, base_fk_field_name="source_base"),
+        authorized_bases_filter(Shipment, base_fk_field_name="target_base"),
     )
 
 
@@ -1339,13 +1337,19 @@ def resolve_shipment_details(shipment_obj, _):
 
 @shipment.field("sourceBase")
 def resolve_shipment_source_base(shipment_obj, _):
-    authorize(permission="base:read", base_id=shipment_obj.source_base_id)
+    authorize(
+        permission="base:read",
+        base_ids=[shipment_obj.source_base_id, shipment_obj.target_base_id],
+    )
     return shipment_obj.source_base
 
 
 @shipment.field("targetBase")
 def resolve_shipment_target_base(shipment_obj, _):
-    authorize(permission="base:read", base_id=shipment_obj.target_base_id)
+    authorize(
+        permission="base:read",
+        base_ids=[shipment_obj.source_base_id, shipment_obj.target_base_id],
+    )
     return shipment_obj.target_base
 
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -944,7 +944,10 @@ def resolve_cancel_transfer_agreement(*_, id):
 @mutation.field("createShipment")
 @convert_kwargs_to_snake_case
 def resolve_create_shipment(*_, creation_input):
-    authorize(permission="shipment:create")
+    authorize(
+        permission="shipment:create",
+        base_ids=[creation_input["source_base_id"], creation_input["target_base_id"]],
+    )
     agreement = TransferAgreement.get_by_id(creation_input["transfer_agreement_id"])
     organisation_ids = [agreement.source_organisation_id]
     if agreement.type == TransferAgreementType.Bidirectional:
@@ -956,9 +959,12 @@ def resolve_create_shipment(*_, creation_input):
 @mutation.field("updateShipment")
 @convert_kwargs_to_snake_case
 def resolve_update_shipment(*_, update_input):
-    authorize(permission="shipment:edit")
-
     shipment = Shipment.get_by_id(update_input["id"])
+    authorize(
+        permission="shipment:edit",
+        base_ids=[shipment.source_base_id, shipment.target_base_id],
+    )
+
     source_update_fields = [
         "prepared_box_label_identifiers",
         "removed_box_label_identifiers",
@@ -985,8 +991,11 @@ def resolve_update_shipment(*_, update_input):
 
 @mutation.field("cancelShipment")
 def resolve_cancel_shipment(*_, id):
-    authorize(permission="shipment:edit")
     shipment = Shipment.get_by_id(id)
+    authorize(
+        permission="shipment:edit",
+        base_ids=[shipment.source_base_id, shipment.target_base_id],
+    )
     authorize(
         organisation_ids=[
             shipment.transfer_agreement.source_organisation_id,
@@ -998,8 +1007,11 @@ def resolve_cancel_shipment(*_, id):
 
 @mutation.field("sendShipment")
 def resolve_send_shipment(*_, id):
-    authorize(permission="shipment:edit")
     shipment = Shipment.get_by_id(id)
+    authorize(
+        permission="shipment:edit",
+        base_ids=[shipment.source_base_id, shipment.target_base_id],
+    )
     authorize(organisation_id=shipment.source_base.organisation_id)
     return send_shipment(id=id, user=g.user)
 

--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -379,8 +379,12 @@ def resolve_transfer_agreement(*_, id):
 
 @query.field("shipment")
 def resolve_shipment(*_, id):
-    authorize(permission="shipment:read")
-    return Shipment.get_by_id(id)
+    shipment = Shipment.get_by_id(id)
+    authorize(
+        permission="shipment:read",
+        base_ids=[shipment.source_base_id, shipment.target_base_id],
+    )
+    return shipment
 
 
 @query.field("productCategories")

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -102,6 +102,8 @@ def create_jwt_payload(
             f"{base_prefix}/beneficiary:create",
             f"{base_prefix}/beneficiary:edit",
             f"{base_prefix}/qr:create",
+            f"{base_prefix}/size:read",
+            f"{base_prefix}/size_range:read",
             f"{base_prefix}/stock:write",
             f"{base_prefix}/tag:write",
             f"{base_prefix}/tag_relation:read",

--- a/back/test/auth_tests/test_authz.py
+++ b/back/test/auth_tests/test_authz.py
@@ -72,6 +72,9 @@ def test_authorized_user():
     assert authorize(user, permission="stock:write", base_id=2)
     assert authorize(user, permission="location:write", base_id=4)
     assert authorize(user, permission="location:write", base_id=5)
+    assert authorize(user, permission="location:write", base_ids=[3, 4])
+    assert authorize(user, permission="location:write", base_ids=[4, 5])
+    assert authorize(user, permission="location:write", base_ids=[5, 6])
 
 
 def test_user_with_insufficient_permissions():
@@ -89,6 +92,12 @@ def test_user_with_insufficient_permissions():
     with pytest.raises(Forbidden):
         # The permission field exists but access granted for different base
         authorize(user, permission="beneficiary:create", base_id=1)
+    with pytest.raises(Forbidden):
+        # The permission field exists but access granted for different base
+        authorize(user, permission="beneficiary:create", base_ids=[1])
+    with pytest.raises(Forbidden):
+        # The permission field exists but access granted for different base
+        authorize(user, permission="beneficiary:create", base_ids=[3, 4])
     with pytest.raises(Forbidden):
         # The permission field exists but holds no bases
         authorize(user, permission="stock:write", base_id=1)

--- a/back/test/auth_tests/test_authz.py
+++ b/back/test/auth_tests/test_authz.py
@@ -1,6 +1,6 @@
 import pytest
 from boxtribute_server.auth import JWT_CLAIM_PREFIX, CurrentUser
-from boxtribute_server.authz import authorize
+from boxtribute_server.authz import _authorize, authorize
 from boxtribute_server.exceptions import Forbidden, UnknownResource
 
 BASE_ID = 1
@@ -65,6 +65,7 @@ def test_authorized_user():
             "qr:create": [1, 3],
             "stock:write": [2],
             "location:write": [4, 5],
+            "product:read": [1],
         },
     )
     assert authorize(user, permission="qr:create")
@@ -75,6 +76,9 @@ def test_authorized_user():
     assert authorize(user, permission="location:write", base_ids=[3, 4])
     assert authorize(user, permission="location:write", base_ids=[4, 5])
     assert authorize(user, permission="location:write", base_ids=[5, 6])
+
+    # This is called in authorized_bases_filter for model=Product
+    assert _authorize(user, permission="product:read", ignore_missing_base_info=True)
 
 
 def test_user_with_insufficient_permissions():

--- a/back/test/data/shipment.py
+++ b/back/test/data/shipment.py
@@ -48,6 +48,15 @@ def data():
             "started_by": default_user_data()["id"],
             "started_on": TIME,
         },
+        {
+            "id": 5,
+            "source_base": base_data()[1]["id"],
+            "target_base": base_data()[2]["id"],
+            "transfer_agreement": transfer_agreement_data()[0]["id"],
+            "state": ShipmentState.Preparing,
+            "started_by": default_user_data()["id"],
+            "started_on": TIME,
+        },
     ]
 
 

--- a/back/test/endpoint_tests/test_distribution_event.py
+++ b/back/test/endpoint_tests/test_distribution_event.py
@@ -44,7 +44,7 @@ def test_update_selected_products_for_distribution_event_packing_list(
             {
                 "product": {"id": str(default_product["id"])},
                 "size": {"id": str(default_size["id"])},
-                "numberOfItems": 0,
+                "numberOfItems": 1,
             },
             {
                 "product": {"id": str(default_product["id"])},

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -86,6 +86,8 @@ def test_invalid_permission(unauthorized, read_only_client, query):
         # Test case 10.1.5
         """user( id: 1) { id }""",
         """packingListEntry( id: 1 ) { id }""",
+        # Test case 3.1.6
+        """shipment( id: 5 ) { id }""",
     ],
     ids=operation_name,
 )

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -79,7 +79,7 @@ def test_shipment_mutations_on_source_side(
     prepared_shipment_detail,
 ):
     # Test case 3.2.1a
-    source_base_id = default_bases[2]["id"]
+    source_base_id = default_bases[1]["id"]
     target_base_id = default_bases[3]["id"]
     agreement_id = default_transfer_agreement["id"]
     creation_input = f"""sourceBaseId: {source_base_id},
@@ -553,7 +553,7 @@ def test_shipment_mutations_create_with_invalid_base(
     # Test case 3.2.3
     assert_bad_user_input_when_creating_shipment(
         read_only_client,
-        source_base=default_bases[2],
+        source_base=default_bases[1],
         target_base=default_bases[4],  # not part of agreement
         agreement=default_transfer_agreement,
     )


### PR DESCRIPTION
This PR builds on #455, fixing a couple of tests that were broken in that PR.

I especially updated resolvers for shipment. To this end it was required to extend the `authorize()` function to authorize the user against several bases (when accessing a shipment, the user must be a member of either source or target base).

In a third PR I will fix the remaining tests corresponding to transfer agreement resolvers.
