### PR TITLE
Box history GraphQL API

### DIFF
--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -68,6 +68,7 @@ from ..models.crud import (
     create_qr_code,
     create_tag,
     delete_tag,
+    get_box_history,
     unassign_tag,
     update_beneficiary,
     update_box,
@@ -309,6 +310,12 @@ def resolve_qr_code(obj, _, qr_code=None):
 @box.field("tags")
 def resolve_box_tags(box_obj, info):
     return info.context["tags_for_box_loader"].load(box_obj.id)
+
+
+@box.field("history")
+def resolve_box_history(box_obj, _):
+    authorize(permission="history:read")
+    return get_box_history(box_obj.id)
 
 
 @query.field("product")

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -42,6 +42,13 @@ type Box implements ItemsCollection {
   lastModifiedOn: Datetime
   comment: String
   tags: [Tag!]
+  history: [HistoryEntry!]
+}
+
+type HistoryEntry {
+  changes: String!
+  changeDate: Datetime
+  user: User
 }
 
 interface Location {

--- a/back/boxtribute_server/models/crud.py
+++ b/back/boxtribute_server/models/crud.py
@@ -13,6 +13,7 @@ from ..exceptions import (
 )
 from .definitions.beneficiary import Beneficiary
 from .definitions.box import Box
+from .definitions.history import DbChangeHistory
 from .definitions.location import Location
 from .definitions.qr_code import QrCode
 from .definitions.tag import Tag
@@ -435,3 +436,10 @@ def create_qr_code(box_label_identifier=None):
             box.save()
 
     return new_qr_code
+
+
+def get_box_history(box_id):
+    return DbChangeHistory.select().where(
+        DbChangeHistory.table_name == "stock",
+        DbChangeHistory.record_id == box_id,
+    )

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -109,6 +109,7 @@ def create_jwt_payload(
             f"{base_prefix}/tag_relation:read",
             f"{base_prefix}/tag_relation:assign",
             f"{base_prefix}/transaction:write",
+            f"{base_prefix}/history:read",
             "shipment:create",
             "shipment:edit",
             "transfer_agreement:create",

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -73,6 +73,7 @@ def test_box_mutations(
     another_size,
     products,
     default_location,
+    null_box_state_location,
     tags,
 ):
     # Test case 8.2.1
@@ -152,6 +153,7 @@ def test_box_mutations(
     # Test case 8.2.11
     new_size_id = str(another_size["id"])
     new_product_id = str(products[2]["id"])
+    new_location_id = str(null_box_state_location["id"])
     comment = "updatedComment"
     nr_items = 7777
     mutation = f"""mutation {{
@@ -160,6 +162,7 @@ def test_box_mutations(
                     numberOfItems: {nr_items},
                     labelIdentifier: "{created_box["labelIdentifier"]}"
                     comment: "{comment}"
+                    locationId: {new_location_id},
                     sizeId: {new_size_id},
                     productId: {new_product_id},
                 }} ) {{
@@ -169,6 +172,7 @@ def test_box_mutations(
                 createdOn
                 qrCode {{ id }}
                 comment
+                location {{ id }}
                 size {{ id }}
                 product {{ id }}
                 history {{
@@ -181,6 +185,7 @@ def test_box_mutations(
     assert updated_box["comment"] == comment
     assert updated_box["numberOfItems"] == nr_items
     assert updated_box["qrCode"] == created_box["qrCode"]
+    assert updated_box["location"]["id"] == new_location_id
     assert updated_box["size"]["id"] == new_size_id
     assert updated_box["product"]["id"] == new_product_id
     assert updated_box["history"] == [
@@ -200,6 +205,11 @@ def test_box_mutations(
         },
         {
             "changes": f"changed the number of items from None to {nr_items};",
+            "user": {"name": "coord"},
+        },
+        {
+            "changes": f"changed box location from {default_location['name']} to "
+            + f"{null_box_state_location['name']};",
             "user": {"name": "coord"},
         },
         {
@@ -264,6 +274,15 @@ def test_box_mutations(
             "changes": "items",
             "from_int": None,
             "to_int": nr_items,
+            "record_id": box_id,
+            "table_name": "stock",
+            "user": 8,
+            "ip": None,
+        },
+        {
+            "changes": "location_id",
+            "from_int": int(location_id),
+            "to_int": int(new_location_id),
             "record_id": box_id,
             "table_name": "stock",
             "user": 8,

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -171,6 +171,10 @@ def test_box_mutations(
                 comment
                 size {{ id }}
                 product {{ id }}
+                history {{
+                    changes
+                    user {{ name }}
+                }}
             }}
         }}"""
     updated_box = assert_successful_request(client, mutation)
@@ -179,6 +183,28 @@ def test_box_mutations(
     assert updated_box["qrCode"] == created_box["qrCode"]
     assert updated_box["size"]["id"] == new_size_id
     assert updated_box["product"]["id"] == new_product_id
+    assert updated_box["history"] == [
+        {
+            "changes": "Record created",
+            "user": {"name": "coord"},
+        },
+        {
+            "changes": "product_id",
+            "user": {"name": "coord"},
+        },
+        {
+            "changes": "size_id",
+            "user": {"name": "coord"},
+        },
+        {
+            "changes": "items",
+            "user": {"name": "coord"},
+        },
+        {
+            "changes": 'comments changed from "" to "updatedComment";',
+            "user": {"name": "coord"},
+        },
+    ]
 
     # Test cases 8.2.1, 8.2.2., 8.2.11
     history = list(

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -185,23 +185,25 @@ def test_box_mutations(
     assert updated_box["product"]["id"] == new_product_id
     assert updated_box["history"] == [
         {
-            "changes": "Record created",
+            "changes": "created record",
             "user": {"name": "coord"},
         },
         {
-            "changes": "product_id",
+            "changes": f"changed product type from {products[0]['name']} to "
+            + f"{products[2]['name']};",
             "user": {"name": "coord"},
         },
         {
-            "changes": "size_id",
+            "changes": f"changed size from {default_size['label']} to "
+            + f"{another_size['label']};",
             "user": {"name": "coord"},
         },
         {
-            "changes": "items",
+            "changes": f"changed the number of items from None to {nr_items};",
             "user": {"name": "coord"},
         },
         {
-            "changes": 'comments changed from "" to "updatedComment";',
+            "changes": 'changed comments from "" to "updatedComment";',
             "user": {"name": "coord"},
         },
     ]


### PR DESCRIPTION
This PR brings an extension of the GraphQL API such that the history of a Box can be displayed in the FE.

For orientation I took the content of the history entries in Dropapp:

    Dev Head of Operations on Monday 14 November 2022, 18:32
    Dev Head of Operations changed the number of items from 15 to 17;

So the FE needs to know about the name of the user who committed the change, the change date, and the change message.
