### PR TITLE
Add optional filtering for Base.tags by resource type

### DIFF
--- a/back/boxtribute_server/graph_ql/resolvers.py
+++ b/back/boxtribute_server/graph_ql/resolvers.py
@@ -41,6 +41,7 @@ from ..enums import (
     HumanGender,
     LocationType,
     TaggableObjectType,
+    TagType,
     TransferAgreementType,
 )
 from ..mobile_distribution.crud import (
@@ -1110,9 +1111,19 @@ def resolve_base_locations(base_obj, _):
 
 
 @base.field("tags")
-def resolve_base_tags(base_obj, _):
+@convert_kwargs_to_snake_case
+def resolve_base_tags(base_obj, _, resource_type=None):
     authorize(permission="tag:read", base_id=base_obj.id)
-    return Tag.select().where(Tag.base == base_obj.id, Tag.deleted.is_null())
+
+    filter_condition = True
+    if resource_type == TaggableObjectType.Box:
+        filter_condition = Tag.type << [TagType.Box, TagType.All]
+    elif resource_type == TaggableObjectType.Beneficiary:
+        filter_condition = Tag.type << [TagType.Beneficiary, TagType.All]
+
+    return Tag.select().where(
+        Tag.base == base_obj.id, Tag.deleted.is_null(), filter_condition
+    )
 
 
 @query.field("distributionEventsTrackingGroup")

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -224,7 +224,8 @@ type Base {
   " List of all [`ClassicLocations`]({{Types.ClassicLocation}}) present in this base "
   locations: [ClassicLocation!]!
   products: [Product!]!
-  tags: [Tag!]
+  " List of all [`Tags`]({{Types.Tag}}) registered in this base. Optionally filter for a [`resource type`]({{Types.TaggableResourceType}}) "
+  tags(resourceType: TaggableResourceType): [Tag!]
   distributionSpots: [DistributionSpot!]!
   distributionEvents(states: [DistributionEventState!]): [DistributionEvent!]!
 

--- a/back/test/endpoint_tests/test_tag.py
+++ b/back/test/endpoint_tests/test_tag.py
@@ -320,3 +320,17 @@ def test_assign_tag_with_invalid_resource_type(
                     ...on Box {{ tags {{ id }} }}
                 }} }}"""
     assert_bad_user_input(read_only_client, mutation)
+
+
+@pytest.mark.parametrize(
+    "filter_input,tag_ids",
+    [
+        ["", ["1", "2", "3"]],
+        ["(resourceType: Box)", ["2", "3"]],
+        ["(resourceType: Beneficiary)", ["1", "3"]],
+    ],
+)
+def test_base_tags_query(read_only_client, filter_input, tag_ids):
+    query = f"""query {{ base(id: 1) {{ tags{filter_input} {{ id }} }} }}"""
+    tags = assert_successful_request(read_only_client, query)["tags"]
+    assert tags == [{"id": i} for i in tag_ids]

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -35,6 +35,7 @@ export type Base = {
   name: Scalars['String'];
   organisation: Organisation;
   products: Array<Product>;
+  /**  List of all [`Tags`]({{Types.Tag}}) registered in this base. Optionally filter for a [`resource type`]({{Types.TaggableResourceType}})  */
   tags?: Maybe<Array<Tag>>;
 };
 
@@ -64,6 +65,15 @@ export type BaseDistributionEventsArgs = {
  */
 export type BaseDistributionEventsTrackingGroupsArgs = {
   states?: InputMaybe<Array<DistributionEventsTrackingGroupState>>;
+};
+
+
+/**
+ * Representation of a base.
+ * The base is managed by a specific [`Organisation`]({{Types.Organisation}}).
+ */
+export type BaseTagsArgs = {
+  resourceType?: InputMaybe<TaggableResourceType>;
 };
 
 /**

--- a/react/src/views/BoxEdit/BoxEditView.tsx
+++ b/react/src/views/BoxEdit/BoxEditView.tsx
@@ -44,7 +44,7 @@ export const BOX_BY_LABEL_IDENTIFIER_AND_ALL_PRODUCTS_WITH_BASEID_QUERY = gql`
     }
 
     base(id: $baseId) {
-      tags {
+      tags(resourceType: Box) {
         ...TagOptions
       }
 


### PR DESCRIPTION
The FE should have the ability to filter tags acc. to a resource type.

E.g. in the BoxEdit page the queries should be adjusted like:

```
base(id: $baseId) {
    ...
    tags(resourceType: Box) { ... }
    ...
}
```

Otherwise tags that are only applicable to beneficiaries could be selected.
