### PR TITLE
Fix a Minor Bug that Displays the Last Notification Message on Home Page

### DIFF
--- a/react/src/components/NotificationMessage.tsx
+++ b/react/src/components/NotificationMessage.tsx
@@ -27,6 +27,10 @@ const NotificationMessage = ({
   const { createToast } = useNotification();
 
   createToast({ title: title, status: type, description: message, position: position });
+  // After the toast message is displayed, cleanup the reactive variable
+  notificationVar({
+    message: "",
+  });
 
   return <></>;
 };


### PR DESCRIPTION
This PR fixes a minor bug that displays the last notification message when clicking the home button. Reproduce by doing any action that displays a message, then clicking on the home page logo, the last message appears again.

Follow up: https://github.com/boxwise/boxtribute/pull/494