### PR TITLE
edit links to dropapp mobile views

### DIFF
--- a/react/src/components/HeaderMenu/HeaderMenuDeskop.tsx
+++ b/react/src/components/HeaderMenu/HeaderMenuDeskop.tsx
@@ -26,6 +26,7 @@ import {
   MenuItemsGroupsProps,
   UserMenuProps,
 } from "./HeaderMenu";
+import { generateDropappUrl } from "utils/helpers";
 
 const Logo = () => (
   <NavLink to="/">
@@ -98,15 +99,17 @@ const LoginOrUserMenuButton = ({
 
 const MenuItemsGroupDesktop = ({ ...props }: MenuItemsGroupProps) => {
   function renderMenuItem(link: MenuItemData, i: number) {
-    let { baseId } = useParams();
-
-    function redirectToOldApp(link: string) {
-      window.open(link + "?camp=" + baseId, "_blank");
-    }
+    let { baseId, qrCode, labelIdentifier } = useParams();
 
     if (link.link.includes(`${process.env.REACT_APP_OLD_APP_BASE_URL}`)) {
       return (
-        <MenuItem py={2} px={3} key={i} onClick={() => redirectToOldApp(link.link)}>
+        <MenuItem
+          py={2}
+          px={3}
+          key={i}
+          as="a"
+          href={generateDropappUrl(link.link, baseId, qrCode, labelIdentifier)}
+        >
           {link.name}
         </MenuItem>
       );

--- a/react/src/components/HeaderMenu/HeaderMenuMobile.tsx
+++ b/react/src/components/HeaderMenu/HeaderMenuMobile.tsx
@@ -24,6 +24,7 @@ import {
   MenuItemsGroupsProps,
 } from "./HeaderMenu";
 import BoxtributeLogo from "../../assets/images/boxtribute-logo.png";
+import { generateDropappUrl } from "utils/helpers";
 
 type MenuItemsGroupsMobileProps = MenuItemsGroupsProps & {
   isMenuOpen: boolean;
@@ -173,18 +174,14 @@ const MenuItemsGroupMobile = ({
   const { isOpen, onToggle } = useDisclosure();
 
   function renderLinkBoxes(link: MenuItemData, i: number) {
-    let { baseId } = useParams();
-
-    function redirectToOldApp(link: string) {
-      window.open(link + "?camp=" + baseId);
-    }
+    let { baseId, qrCode, labelIdentifier } = useParams();
 
     if (link.link.includes(`${process.env.REACT_APP_OLD_APP_BASE_URL}`)) {
       return (
         <Box key={i} py={1} px={4} onClick={() => setIsMenuOpen(false)}>
-          <Text key={link.name} cursor="pointer" onClick={() => redirectToOldApp(link.link)}>
+          <a key={link.name} href={generateDropappUrl(link.link, baseId, qrCode, labelIdentifier)}>
             {link.name}
-          </Text>
+          </a>
         </Box>
       );
     } else {

--- a/react/src/utils/helpers.ts
+++ b/react/src/utils/helpers.ts
@@ -1,25 +1,50 @@
 export const getISODateTimeFromDateAndTimeString = (date: Date, timeString: string) => {
-  const [hours, minutes] = timeString.split(':').map(Number);
+  const [hours, minutes] = timeString.split(":").map(Number);
   const dateTime = new Date(date);
   dateTime.setHours(hours);
   dateTime.setMinutes(minutes);
   return dateTime;
-}
+};
 
 export const getISODateTimeFromDateAndTime = (date: Date, time: Date) => {
   const dateTime = new Date(date);
   dateTime.setHours(time.getHours());
   dateTime.setMinutes(time.getMinutes());
   return dateTime;
-}
+};
 
 export const weekDayNumberToWeekDayName = (weekDayNumber: number) => {
-  const weekDayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  const weekDayNames = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
   return weekDayNames[weekDayNumber];
-}
+};
 
 export const getDateNormalizedDateTime = (dateTime: Date) => {
   const newDate = new Date(dateTime);
-  newDate.setHours(0,0,0,0);
+  newDate.setHours(0, 0, 0, 0);
   return newDate;
-}
+};
+
+export const generateDropappUrl = (
+  oldLink: String,
+  baseId: String | undefined,
+  qrCode: String | undefined,
+  labelIdentifier: String | undefined,
+) => {
+  const newLink = "https://" + oldLink + "?camp=" + baseId + "&preference=classic";
+  if (oldLink.includes("mobile.php")) {
+    if (labelIdentifier !== undefined) {
+      return newLink + "&boxid=" + labelIdentifier;
+    } else if (qrCode !== undefined) {
+      return newLink + "&barcode=" + qrCode;
+    }
+  }
+  return newLink;
+};

--- a/react/src/utils/helpers.ts
+++ b/react/src/utils/helpers.ts
@@ -38,7 +38,7 @@ export const generateDropappUrl = (
   qrCode: String | undefined,
   labelIdentifier: String | undefined,
 ) => {
-  const newLink = "https://" + oldLink + "?camp=" + baseId + "&preference=classic";
+  const newLink = oldLink + "?camp=" + baseId + "&preference=classic";
   if (oldLink.includes("mobile.php")) {
     if (labelIdentifier !== undefined) {
       return newLink + "&boxid=" + labelIdentifier;


### PR DESCRIPTION
Reason:
- set preference Session variable in dropapp to classic
- go to the same menu in dropapp on mobile.