### PR TITLE
Remove the Logo Link and Add State Label on the Location Buttons

### DIFF
--- a/react/src/components/HeaderMenu/HeaderMenuMobile.tsx
+++ b/react/src/components/HeaderMenu/HeaderMenuMobile.tsx
@@ -38,11 +38,7 @@ const MenuToggle = ({ toggle, isOpen, ...props }) => (
   />
 );
 
-const Logo = () => (
-  <NavLink to="/">
-    <Image src={BoxtributeLogo} maxH={"3.5em"} />
-  </NavLink>
-);
+const Logo = () => <Image src={BoxtributeLogo} maxH={"3.5em"} />;
 
 const LoginOrUserMenuButtonMobile = ({
   isAuthenticated,

--- a/react/src/views/Box/components/BoxDetails.tsx
+++ b/react/src/views/Box/components/BoxDetails.tsx
@@ -288,7 +288,7 @@ function BoxDetails({
                     {location.defaultBoxState !== boxData.state && (
                       <>
                         {" "}
-                        - Boxes are &nbsp;<i> {location.defaultBoxState}</i>
+                        - Boxes are&nbsp;<i> {location.defaultBoxState}</i>
                       </>
                     )}
                   </Button>

--- a/react/src/views/Box/components/BoxDetails.tsx
+++ b/react/src/views/Box/components/BoxDetails.tsx
@@ -285,6 +285,12 @@ function BoxDetails({
                     border="2px"
                   >
                     {location.name}
+                    {location.defaultBoxState !== boxData.state && (
+                      <>
+                        {" "}
+                        - Boxes are &nbsp;<i> {location.defaultBoxState}</i>
+                      </>
+                    )}
                   </Button>
                 </WrapItem>
               ))}

--- a/react/src/views/Box/components/BoxDetails.tsx
+++ b/react/src/views/Box/components/BoxDetails.tsx
@@ -285,7 +285,7 @@ function BoxDetails({
                     border="2px"
                   >
                     {location.name}
-                    {location.defaultBoxState !== boxData.state && (
+                    {location.defaultBoxState !== BoxState.InStock && (
                       <>
                         {" "}
                         - Boxes are&nbsp;<i> {location.defaultBoxState}</i>

--- a/react/src/views/BoxEdit/BoxEditView.tsx
+++ b/react/src/views/BoxEdit/BoxEditView.tsx
@@ -181,7 +181,10 @@ function BoxEditView() {
     )
     .map((location) => ({
       ...location,
-      name: location.name ?? "",
+      name:
+        (location.defaultBoxState !== BoxState.InStock
+          ? `${location.name} - Boxes are ${location.defaultBoxState}`
+          : location.name) ?? "",
     }));
 
   if (allLocations == null) {


### PR DESCRIPTION
The PR contains minor changes before the release, including removing the link from the logo and adding box state to the locations button and drop down menu in the edit box when the location associated box state is not equal to InStock. 