### PR TITLE
BoxView: Disabling Buttons on State Lost and Scrap

### DIFF
--- a/react/src/views/Box/BoxView.test.tsx
+++ b/react/src/views/Box/BoxView.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { screen, waitFor, fireEvent, cleanup } from "@testing-library/react";
 import { render } from "utils/test-utils";
 import userEvent from "@testing-library/user-event";
 import BTBox, {
@@ -335,7 +335,7 @@ describe("Box view", () => {
       request: {
         query: BOX_BY_LABEL_IDENTIFIER_QUERY,
         variables: {
-          labelIdentifier: "189123",
+          labelIdentifier: "123",
         },
       },
       result: {
@@ -438,8 +438,15 @@ describe("Box view", () => {
   });
   // Test case 3.1.1.3
   it("3.1.1.3 - click on + and - to increase or decrease number of items", async () => {
+    cleanup();
+    render(<BTBox />, {
+      routePath: "/bases/:baseId/boxes/:labelIdentifier",
+      initialUrl: "/bases/2/boxes/123",
+      mocks,
+    });
     await waitFor(waitTillLoadingIsDone);
     const numberOfItemWhenIncreased = 31;
+
     fireEvent.click(screen.getByTestId("increase-items"));
     await waitFor(() => userEvent.type(screen.getByTestId("increase-number-items"), "1"));
     fireEvent.click(screen.getByText("Submit"));

--- a/react/src/views/Box/components/BoxDetails.tsx
+++ b/react/src/views/Box/components/BoxDetails.tsx
@@ -94,14 +94,25 @@ function BoxDetails({
           </Box>
           <Spacer />
           <Box>
-            <NavLink to="edit">
+            {(BoxState.Lost === boxData.state || BoxState.Scrap === boxData.state) && (
               <IconButton
                 aria-label="Edit box"
                 borderRadius="0"
                 icon={<EditIcon h={6} w={6} />}
                 border="2px"
+                disabled
               />
-            </NavLink>
+            )}
+            {BoxState.Lost !== boxData.state && BoxState.Scrap !== boxData.state && (
+              <NavLink to="edit">
+                <IconButton
+                  aria-label="Edit box"
+                  borderRadius="0"
+                  icon={<EditIcon h={6} w={6} />}
+                  border="2px"
+                />
+              </NavLink>
+            )}
           </Box>
         </Flex>
         {boxData.tags !== undefined && (
@@ -141,6 +152,7 @@ function BoxDetails({
                 >
                   <IconButton
                     onClick={onPlusOpen}
+                    disabled={BoxState.Lost === boxData.state || BoxState.Scrap === boxData.state}
                     size="sm"
                     border="2px"
                     isRound
@@ -163,6 +175,7 @@ function BoxDetails({
                     onClick={onMinusOpen}
                     border="2px"
                     size="sm"
+                    disabled={BoxState.Lost === boxData.state || BoxState.Scrap === boxData.state}
                     borderRadius="0"
                     isRound
                     aria-label="Search database"
@@ -281,7 +294,7 @@ function BoxDetails({
                       .toLowerCase()}-btn`}
                     borderRadius="0px"
                     onClick={() => onMoveToLocationClick(location.id)}
-                    disabled={boxData.location?.id === location.id}
+                    disabled={BoxState.Lost === boxData.state || BoxState.Scrap === boxData.state}
                     border="2px"
                   >
                     {location.name}


### PR DESCRIPTION
In this PR, the buttons are disabled if the box state is lost or scrapped.