### PR TITLE
Remove Logo Link on Desktop View

### DIFF
--- a/react/src/components/HeaderMenu/HeaderMenuDeskop.tsx
+++ b/react/src/components/HeaderMenu/HeaderMenuDeskop.tsx
@@ -28,11 +28,7 @@ import {
 } from "./HeaderMenu";
 import { generateDropappUrl } from "utils/helpers";
 
-const Logo = () => (
-  <NavLink to="/">
-    <Image src={BoxtributeLogo} maxH={"3.5em"} />
-  </NavLink>
-);
+const Logo = () => <Image src={BoxtributeLogo} maxH={"3.5em"} />;
 
 const BaseSwitcher = ({ currentActiveBaseId, availableBases }: BaseSwitcherProps) => {
   return (


### PR DESCRIPTION
In this PR, the logo link in the desktop view has been removed, which fixes a minor issue for the release.

Related PR: https://github.com/boxwise/boxtribute/pull/548
