### PR TITLE
Add heap.io on Frontend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,8 +183,8 @@ jobs:
       - run:
           name: Inject Heap Analytics Script to index.html
           command: |
-            sed -i 's/HEAPIO_APP_ID/${HEAPIO_APP_ID}/' public/heapanalytics.js
-            sed -i 's|</head>| i <script src="/heapanalytics.js"></script>|' public/index.html
+            sed -i 's/HEAPIO_APP_ID/${HEAPIO_APP_ID}/' ../react/build/heapanalytics.js
+            sed -i 's|</head>| i <script src="/heapanalytics.js"></script>|' ../react/build/index.html
       - run:
           name: Copy react build into flask app for deployment
           command: mv ../react/build react-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,8 @@ jobs:
               REACT_APP_SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
               REACT_APP_SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE}
             " > .env
+            sed -i 's/HEAPIO_APP_ID/${HEAPIO_APP_ID}/' public/heapanalytics.js
+            sed -i 's|</head>| i <script src="/heapanalytics.js"></script>|' public/index.html
       # following https://circleci.com/docs/2.0/yarn/
       - restore_cache:
           name: Restore Yarn Package Cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,6 @@ jobs:
               REACT_APP_SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
               REACT_APP_SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE}
             " > .env
-            sed -i 's/HEAPIO_APP_ID/${HEAPIO_APP_ID}/' public/heapanalytics.js
-            sed -i 's|</head>| i <script src="/heapanalytics.js"></script>|' public/index.html
       # following https://circleci.com/docs/2.0/yarn/
       - restore_cache:
           name: Restore Yarn Package Cache
@@ -182,6 +180,11 @@ jobs:
           at: ~/
       # install gcloud orb
       - gcp-cli/install
+      - run:
+          name: Inject Heap Analytics Script to index.html
+          command: |
+            sed -i 's/HEAPIO_APP_ID/${HEAPIO_APP_ID}/' public/heapanalytics.js
+            sed -i 's|</head>| i <script src="/heapanalytics.js"></script>|' public/index.html
       - run:
           name: Copy react build into flask app for deployment
           command: mv ../react/build react-build

--- a/back/app.yaml
+++ b/back/app.yaml
@@ -12,6 +12,9 @@ handlers:
 - url: /manifest.json
   static_files: react-build/manifest.json
   upload: react-build/manifest.json
+- url: /heapanalytics.js
+  static_files: react-build/heapanalytics.js
+  upload: react-build/heapanalytics.js
 - url: /static/(.*)
   secure: always
   static_files: react-build/static/\1
@@ -24,7 +27,3 @@ handlers:
   secure: always
   static_files: react-build/index.html
   upload: react-build/index.html
-- url: /(.*\.js)$
-  secure: always
-  static_files: react-build/\1
-  upload: react-build/(.*\.js)$

--- a/back/app.yaml
+++ b/back/app.yaml
@@ -24,3 +24,7 @@ handlers:
   secure: always
   static_files: react-build/index.html
   upload: react-build/index.html
+- url: /(.*\.js)$
+  secure: always
+  static_files: react-build/\1
+  upload: react-build/(.*\.js)$

--- a/react/public/heapanalytics.js
+++ b/react/public/heapanalytics.js
@@ -1,3 +1,4 @@
+// This file is only integrated for deploys
 (window.heap = window.heap || []),
   (heap.load = function (e, t) {
     (window.heap.appid = e), (window.heap.config = t = t || {});
@@ -30,4 +31,5 @@
     )
       heap[p[o]] = n(p[o]);
   });
+// HEAPIO_APP_ID will be substituted during deploy by CircleCI
 heap.load(HEAPIO_APP_ID);

--- a/react/public/heapanalytics.js
+++ b/react/public/heapanalytics.js
@@ -1,0 +1,33 @@
+(window.heap = window.heap || []),
+  (heap.load = function (e, t) {
+    (window.heap.appid = e), (window.heap.config = t = t || {});
+    var r = document.createElement("script");
+    (r.type = "text/javascript"),
+      (r.async = !0),
+      (r.src = "https://cdn.heapanalytics.com/js/heap-" + e + ".js");
+    var a = document.getElementsByTagName("script")[0];
+    a.parentNode.insertBefore(r, a);
+    for (
+      var n = function (e) {
+          return function () {
+            heap.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+          };
+        },
+        p = [
+          "addEventProperties",
+          "addUserProperties",
+          "clearEventProperties",
+          "identify",
+          "resetIdentity",
+          "removeEventProperty",
+          "setEventProperties",
+          "track",
+          "unsetEventProperty",
+        ],
+        o = 0;
+      o < p.length;
+      o++
+    )
+      heap[p[o]] = n(p[o]);
+  });
+heap.load(HEAPIO_APP_ID);


### PR DESCRIPTION
This PR integrates Heap Analytics into the front-end by adding scripts to index HTML during deployment. In response to these changes, an environment variable HEAPIO_APP_ID is created in the CircleCI to store the heap app ID.