### PR TITLE
Correctly configure CORS in back-end

### DIFF
--- a/back/boxtribute_server/app.py
+++ b/back/boxtribute_server/app.py
@@ -3,7 +3,6 @@ import os
 
 import sentry_sdk
 from flask import Flask
-from flask_cors import CORS
 from graphql.error import GraphQLError
 from sentry_sdk.integrations.flask import FlaskIntegration
 
@@ -15,11 +14,9 @@ def create_app():
 
 
 def configure_app(app, *blueprints, database_interface=None, **mysql_kwargs):
-    """Initialize CORS handling in app, and register blueprints.
-    Configure the app's database interface. `mysql_kwargs` are forwarded.
+    """Register blueprints. Configure the app's database interface. `mysql_kwargs` are
+    forwarded.
     """
-    CORS(app)
-
     for blueprint in blueprints:
         app.register_blueprint(blueprint)
 

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -1,11 +1,10 @@
 """Utilities for handling authorization"""
-import os
-
 from flask import g
 
 from .exceptions import Forbidden
 from .models.definitions.base import Base
 from .models.definitions.transfer_agreement import TransferAgreement
+from .utils import in_ci_environment, in_development_environment
 
 BASE_AGNOSTIC_RESOURCES = (
     "box_state",
@@ -160,7 +159,7 @@ def check_beta_feature_access(payload, *, current_user=None):
     """Check whether the current user wants to execute a beta-feature mutation, and
     whether they have sufficient beta-feature scope to run it.
     """
-    if os.getenv("CI") == "true" or os.getenv("ENVIRONMENT") == "development":
+    if in_ci_environment() or in_development_environment():
         # Skip check when running tests in CircleCI, or during local development
         return True
 

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -1,13 +1,13 @@
 """Setup for logging in Google Cloud."""
-import os
-
 from flask import request
+
+from .utils import in_ci_environment, in_development_environment
 
 # Context names
 API_CONTEXT = "api"
 WEBAPP_CONTEXT = "webapp"
 
-if os.getenv("CI") == "true" or os.getenv("ENVIRONMENT") == "development":
+if in_ci_environment() or in_development_environment():
     # Skip logger initialization when running tests in CircleCI, or during local
     # development
     request_loggers = None

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -1,7 +1,6 @@
 """Construction of routes for web app and API"""
 import asyncio
 import os
-import re
 
 from ariadne import graphql
 from ariadne.constants import PLAYGROUND_HTML
@@ -79,8 +78,12 @@ def api_token():
     origins=[
         "http://localhost:5005",
         "http://localhost:3000",
-        re.compile(r"https://.+.boxtribute.org"),
-        re.compile(r"https://v2-.+-dot-dropapp-242214.ew.r.appspot.com"),
+        "https://v2-staging.boxtribute.org",
+        "https://v2-demo.boxtribute.org",
+        "https://v2.boxtribute.org",
+        "https://v2-staging-dot-dropapp-242214.ew.r.appspot.com",
+        "https://v2-demo-dot-dropapp-242214.ew.r.appspot.com",
+        "https://v2-production-dot-dropapp-242214.ew.r.appspot.com",
     ],
     methods=["POST"],
     allow_headers=["Content-Type", "Authorization"],

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -86,7 +86,9 @@ def api_token():
         "https://v2-production-dot-dropapp-242214.ew.r.appspot.com",
     ],
     methods=["POST"],
-    allow_headers=["Content-Type", "Authorization"],
+    allow_headers="*"
+    if os.getenv("ENVIRONMENT") == "development"
+    else ["Content-Type", "Authorization"],
 )
 @requires_auth
 def graphql_server():

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -20,6 +20,7 @@ from .loaders import (
     TagsForBoxLoader,
 )
 from .logging import API_CONTEXT, WEBAPP_CONTEXT, log_request_to_gcloud
+from .utils import in_development_environment
 
 # Blueprint for query-only API. Deployed on the 'api*' subdomains
 api_bp = Blueprint("api_bp", __name__)
@@ -87,7 +88,7 @@ def api_token():
     ],
     methods=["POST"],
     allow_headers="*"
-    if os.getenv("ENVIRONMENT") == "development"
+    if in_development_environment()
     else ["Content-Type", "Authorization"],
 )
 @requires_auth

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -1,6 +1,7 @@
 """Construction of routes for web app and API"""
 import asyncio
 import os
+import re
 
 from ariadne import graphql
 from ariadne.constants import PLAYGROUND_HTML
@@ -37,7 +38,6 @@ def handle_auth_error(ex):
 
 
 @app_bp.route("/public", methods=["GET"])
-@cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
 def public():
     response = (
         "Hello from a public endpoint! You don't need to be authenticated to see this."
@@ -51,7 +51,6 @@ def query_api_playground():
 
 
 @api_bp.route("/", methods=["POST"])
-@cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
 @requires_auth
 def query_api_server():
     log_request_to_gcloud(context=API_CONTEXT)
@@ -59,7 +58,6 @@ def query_api_server():
 
 
 @api_bp.route("/token", methods=["POST"])
-@cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
 def api_token():
     success, result = request_jwt(
         **request.get_json(),  # must contain username and password
@@ -72,17 +70,21 @@ def api_token():
     return jsonify(result), status_code
 
 
-@app_bp.route("/graphql", methods=["GET"])
-def graphql_playgroud():
-    # On GET request serve GraphQL Playground
-    # You don't need to provide Playground if you don't want to
-    # but keep on mind this will not prohibit clients from
-    # exploring your API using desktop GraphQL Playground app.
-    return PLAYGROUND_HTML, 200
-
-
+# Due to a bug in the flask-cors package, the function decorated with cross_origin must
+# be listed before any other function that has the same route
+# see https://github.com/corydolphin/flask-cors/issues/280
 @app_bp.route("/graphql", methods=["POST"])
-@cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
+@cross_origin(
+    # Allow dev localhost ports, and boxtribute subdomains as origins
+    origins=[
+        "http://localhost:5005",
+        "http://localhost:3000",
+        re.compile(r"https://.+.boxtribute.org"),
+        re.compile(r"https://v2-.+-dot-dropapp-242214.ew.r.appspot.com"),
+    ],
+    methods=["POST"],
+    allow_headers=["Content-Type", "Authorization"],
+)
 @requires_auth
 def graphql_server():
     log_request_to_gcloud(context=WEBAPP_CONTEXT)
@@ -91,6 +93,15 @@ def graphql_server():
         return {"error": "No permission to access beta feature"}, 401
 
     return execute_async(schema=full_api_schema)
+
+
+@app_bp.route("/graphql", methods=["GET"])
+def graphql_playgroud():
+    # On GET request serve GraphQL Playground
+    # You don't need to provide Playground if you don't want to
+    # but keep on mind this will not prohibit clients from
+    # exploring your API using desktop GraphQL Playground app.
+    return PLAYGROUND_HTML, 200
 
 
 def execute_async(*, schema, introspection=None):

--- a/back/boxtribute_server/utils.py
+++ b/back/boxtribute_server/utils.py
@@ -1,0 +1,9 @@
+import os
+
+
+def in_development_environment():
+    return os.getenv("ENVIRONMENT") == "development"
+
+
+def in_ci_environment():
+    return os.getenv("CI") == "true"

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -218,33 +218,36 @@ def test_mutation_arbitrary_database_error(read_only_client, mocker):
 
 
 @pytest.mark.parametrize(
-    "origin,illegal,headers,methods",
+    "origin",
     [
-        ["https://illegal-origin.org", True, None, None],
-        ["http://localhost:3000", False, "Authorization", "POST"],
-        ["https://v2-staging.boxtribute.org", False, "Authorization", "POST"],
-        [
-            "https://v2-production-dot-dropapp-242214.ew.r.appspot.com",
-            False,
-            "Authorization",
-            "POST",
-        ],
+        "https://illegal-origin.org",
+        "http://localhost:3000",
+        "https://v2-staging.boxtribute.org",
+        "https://v2-demo.boxtribute.org",
+        "https://v2.boxtribute.org",
+        "https://v2-staging-dot-dropapp-242214.ew.r.appspot.com",
+        "https://v2-demo-dot-dropapp-242214.ew.r.appspot.com",
+        "https://v2-production-dot-dropapp-242214.ew.r.appspot.com",
     ],
 )
-def test_cors_preflight_request(read_only_client, origin, illegal, headers, methods):
+def test_cors_preflight_request(read_only_client, origin):
     # Simulate CORS preflight request
+    request_methods = "POST"
+    request_headers = "Authorization"
     response = read_only_client.options(
         "/graphql",
         headers=[
             ("origin", origin),
-            ("Access-Control-Request-Method", "POST"),
-            ("Access-Control-Request-Headers", "Authorization"),
+            ("Access-Control-Request-Method", request_methods),
+            ("Access-Control-Request-Headers", request_headers),
         ],
     )
     assert response.status_code == 200
-    if illegal:
+    if "illegal" in origin:
         assert response.headers.get("Access-Control-Allow-Origin") is None
+        assert response.headers.get("Access-Control-Allow-Headers") is None
+        assert response.headers.get("Access-Control-Allow-Methods") is None
     else:
         assert response.headers.get("Access-Control-Allow-Origin") == origin
-    assert response.headers.get("Access-Control-Allow-Headers") == headers
-    assert response.headers.get("Access-Control-Allow-Methods") == methods
+        assert response.headers.get("Access-Control-Allow-Headers") == request_headers
+        assert response.headers.get("Access-Control-Allow-Methods") == request_methods

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
             MYSQL_DB: dropapp_dev
             MYSQL_PORT: 3306
             ENVIRONMENT: ${ENVIRONMENT:-development}
+            CI: "true"
     react:
         build:
             context: ./react


### PR DESCRIPTION
When running the back-end tests a warning "unknown option passed to
flask-cors: origin" could be seen. It turns out that the option
correctly has to be named 'origins'. But even then the server would
accept any origins for making requests.
More research revealed that the flask-cors offers several ways of
configuring the extension: using the `CORS` wrapper, and using the
`cross_origin` decorator. Since we used both, the former took
precedence, and it's default is to allow any origins, methods, and
headers (questionable defaults, however that's exactly what the docs
state).
As a solution, the `CORS` wrapper is removed, and the `cross_origin`
decorator is applied to the one route that matters, with the correct
options passed in.

FYI @aerinsol
