### PR TITLE
Integrate mypy type checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .venv
 .coverage
 htmlcov/
+.mypy_cache/
 env/
 back/test-results
 *.prof

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,14 @@ repos:
         types: [python]
         language: system
         require_serial: true
+      - id: mypy
+        name: Run Python type checks
+        entry: mypy
+        types_or: [python, pyi]
+        exclude: back/test
+        language: system
+        args: ["--scripts-are-modules"]
+        require_serial: true
       - id: isort
         name: Sort Python imports
         entry: isort

--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -4,6 +4,7 @@ import os
 import urllib
 from collections import defaultdict
 from functools import wraps
+from typing import Dict, Tuple
 
 from flask import g, request
 from jose import JOSEError, jwt
@@ -250,7 +251,9 @@ def requires_auth(f):
     return decorated
 
 
-def request_jwt(*, client_id, client_secret, audience, domain, username, password):
+def request_jwt(
+    *, client_id, client_secret, audience, domain, username, password
+) -> Tuple[bool, Dict[str, str]]:
     """Request JWT from Auth0 service on given domain, passing any additional
     parameters. Return whether request was successful, and the full response.
     """

--- a/back/boxtribute_server/db.py
+++ b/back/boxtribute_server/db.py
@@ -1,5 +1,5 @@
 from peewee import MySQLDatabase
-from playhouse.flask_utils import FlaskDB
+from playhouse.flask_utils import FlaskDB  # type: ignore
 
 db = FlaskDB()
 

--- a/back/boxtribute_server/graph_ql/definitions.py
+++ b/back/boxtribute_server/graph_ql/definitions.py
@@ -6,9 +6,9 @@ from ariadne import load_schema_from_path
 MODULE_DIRECTORY = Path(__file__).resolve().parent
 
 # Recursively load any .graphql files
-definitions = load_schema_from_path(MODULE_DIRECTORY)
+definitions = load_schema_from_path(str(MODULE_DIRECTORY))
 
 query_api_definitions = "\n".join(
-    load_schema_from_path(MODULE_DIRECTORY / f"{name}.graphql")
+    load_schema_from_path(str(MODULE_DIRECTORY / f"{name}.graphql"))
     for name in ["types", "queries"]
 )

--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -13,7 +13,7 @@ if in_ci_environment() or in_development_environment():
     request_loggers = None
 else:  # pragma: no cover
     # Google Cloud Logging is only available in deployed environments
-    from google.cloud import logging as gcloud_logging
+    from google.cloud import logging as gcloud_logging  # type: ignore
 
     # Initializing client requires Google credentials to be set (they automatically are
     # in the GOOGLE_APPLICATION_CREDENTIALS environment variable when the app is

--- a/back/boxtribute_server/utils.py
+++ b/back/boxtribute_server/utils.py
@@ -1,9 +1,9 @@
 import os
 
 
-def in_development_environment():
+def in_development_environment() -> bool:
     return os.getenv("ENVIRONMENT") == "development"
 
 
-def in_ci_environment():
+def in_ci_environment() -> bool:
     return os.getenv("CI") == "true"

--- a/back/requirements-dev.txt
+++ b/back/requirements-dev.txt
@@ -6,3 +6,8 @@ pytest>=5.4.3
 pytest-mock==3.10.0
 pytest-cov==4.0.0
 pytest-clarity==1.0.1
+mypy==0.991
+types-Flask-Cors==3.0.10
+types-peewee==3.15.0.5
+types-python-dateutil==2.8.19.5
+types-python-jose==3.3.4

--- a/back/scripts/list_models.py
+++ b/back/scripts/list_models.py
@@ -8,7 +8,7 @@ from pathlib import Path
 SCRIPT_DIRPATH = Path(__file__).resolve().parent
 TEST_DATA_DIRPATH = SCRIPT_DIRPATH.parent / "test"
 sys.path.insert(0, str(TEST_DATA_DIRPATH))
-from data import MODELS
+from data import MODELS  # type: ignore
 
 
 def main():

--- a/back/setup.py
+++ b/back/setup.py
@@ -13,5 +13,6 @@ setup(
     author_email="hello@boxtribute.org",
     license="Apache 2.0",
     packages=find_packages(exclude=["test"]),
+    package_data={"boxtribute_server": ["py.typed"]},
     install_requires=REQUIREMENTS,
 )

--- a/docs/peewee-moves/peewee-moves_test_migration.py
+++ b/docs/peewee-moves/peewee-moves_test_migration.py
@@ -6,9 +6,9 @@ This migration must be moved into back/boxtribute_server/migrations to work
 """
 import logging
 
-from boxtribute_server.models import base
+from boxtribute_server.models.definitions import base
 from peewee import SQL, ForeignKeyField
-from playhouse import migrate
+from playhouse import migrate  # type: ignore
 
 logger = logging.getLogger("peewee")
 logger.addHandler(logging.StreamHandler())

--- a/fetch_token
+++ b/fetch_token
@@ -14,7 +14,7 @@ from pathlib import Path
 SCRIPT_DIRPATH = Path(__file__).resolve().parent
 TEST_DATA_DIRPATH = SCRIPT_DIRPATH / "back" / "test"
 sys.path.insert(0, str(TEST_DATA_DIRPATH))
-from auth import TEST_AUTH0_PASSWORD, TEST_AUTH0_USERNAME
+from auth import TEST_AUTH0_PASSWORD, TEST_AUTH0_USERNAME  # type: ignore
 from boxtribute_server.auth import request_jwt
 from dotenv import load_dotenv
 


### PR DESCRIPTION
This PR adds a scaffold for using mypy type checking in the back-end code base.

Type annotations will be added incrementally in other PRs.

For an introduction, check out
- https://mypy.readthedocs.io/en/stable/index.html
- https://mypy.readthedocs.io/en/stable/getting_started.html