### PR TITLE
Sort history entries by ID instead of change date

### DIFF
--- a/back/boxtribute_server/warehouse/box/crud.py
+++ b/back/boxtribute_server/warehouse/box/crud.py
@@ -214,4 +214,4 @@ def get_box_history(box_id):
 
         raw_entry.changes = changes
         entries.append(raw_entry)
-    return sorted(entries, key=lambda e: e.change_date, reverse=True)
+    return sorted(entries, key=lambda e: e.id, reverse=True)

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -205,20 +205,13 @@ def test_box_mutations(
         # The entries for the update have the same change_date, hence the IDs do not
         # appear reversed
         {
-            "id": "115",
-            "changes": f"changed product type from {products[0]['name']} to "
-            + f"{products[2]['name']}",
+            "id": "120",
+            "changes": f"changed box state from InStock to {state}",
             "user": {"name": "coord"},
         },
         {
-            "id": "116",
-            "changes": f"changed size from {default_size['label']} to "
-            + f"{another_size['label']}",
-            "user": {"name": "coord"},
-        },
-        {
-            "id": "117",
-            "changes": f"changed the number of items from None to {nr_items}",
+            "id": "119",
+            "changes": 'changed comments from "" to "updatedComment";',
             "user": {"name": "coord"},
         },
         {
@@ -228,13 +221,20 @@ def test_box_mutations(
             "user": {"name": "coord"},
         },
         {
-            "id": "119",
-            "changes": 'changed comments from "" to "updatedComment";',
+            "id": "117",
+            "changes": f"changed the number of items from None to {nr_items}",
             "user": {"name": "coord"},
         },
         {
-            "id": "120",
-            "changes": f"changed box state from InStock to {state}",
+            "id": "116",
+            "changes": f"changed size from {default_size['label']} to "
+            + f"{another_size['label']}",
+            "user": {"name": "coord"},
+        },
+        {
+            "id": "115",
+            "changes": f"changed product type from {products[0]['name']} to "
+            + f"{products[2]['name']}",
             "user": {"name": "coord"},
         },
         {


### PR DESCRIPTION
The issue was that we use ordering by change datetime to sort log
entries, and then select the first one as the newest one. However the
datetime has second precision, hence when two changes occur within one
second, it's not necessarily the newest one that comes first in the
ordering. The newest entry always has the largest ID, so sorting by ID
is used now.

@aerinsol I'll merge this such that you can test on staging again.
