### PR TITLE
Add beta-access for mobile-distro mutations

### DIFF
--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -160,6 +160,29 @@ ALL_ALLOWED_MUTATIONS: Dict[int, Tuple[str, ...]] = {
     1: ("updateBox", "createBox", "createQrCode"),
     # + mutations for CreateAgreement page
     2: ("updateBox", "createBox", "createQrCode", "createTransferAgreement"),
+    # + mobile distribution pages
+    99: (
+        "updateBox",
+        "createBox",
+        "createQrCode",
+        "createTransferAgreement",
+        "createDistributionSpot",
+        "createDistributionEvent",
+        "addPackingListEntryToDistributionEvent",
+        "removePackingListEntryFromDistributionEvent",
+        "removeAllPackingListEntriesFromDistributionEventForProduct",
+        "updatePackingListEntry",
+        "updateSelectedProductsForDistributionEventPackingList",
+        "changeDistributionEventState",
+        "assignBoxToDistributionEvent",
+        "unassignBoxFromDistributionEvent",
+        "moveItemsFromBoxToDistributionEvent",
+        "removeItemsFromUnboxedItemsCollection",
+        "startDistributionEventsTrackingGroup",
+        "setReturnedNumberOfItemsForDistributionEventsTrackingGroup",
+        "moveItemsFromReturnTrackingGroupToBox",
+        "completeDistributionEventsTrackingGroup",
+    ),
 }
 
 


### PR DESCRIPTION
With this, mobile-distro mutations are enabled for users with beta-scope 99, and the mobile-distro pages become usable again.

I'll change selected users' metadata in the staging-tenant. For all other users, and any users in demo or prod, it will be impossible to execute mobile-distro mutations (should they find the hidden pages).
