### PR TITLE
Extension of GraphQL API for shipment reception

### DIFF
--- a/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
@@ -303,42 +303,26 @@ def _complete_shipment_if_applicable(*, shipment, user_id):
         )
 
 
-def update_shipment(
+def update_shipment_when_preparing(
     *,
     id,
     user,
     prepared_box_label_identifiers=None,
     removed_box_label_identifiers=None,
-    received_shipment_detail_update_inputs=None,
-    lost_box_label_identifiers=None,
     target_base_id=None,
 ):
-    """Update shipment detail information.
-    On the shipment source side:
+    """Update shipment detail information during preparation (on shipment source side).
     - update prepared or removed boxes, or target base
     - raise InvalidShipmentState exception if shipment state is different from
       'Preparing'
     - raise an InvalidTransferAgreementBase exception if specified target base is not
       included in given agreement
-    On the shipment target side:
-    - update checked-in or lost boxes
-    - raise InvalidShipmentState exception if shipment state is different from
-      'Receiving'
     """
     shipment = Shipment.get_by_id(id)
-    if any(
-        [prepared_box_label_identifiers, removed_box_label_identifiers, target_base_id]
-    ):
-        if shipment.state != ShipmentState.Preparing:
-            raise InvalidShipmentState(
-                expected_states=[ShipmentState.Preparing], actual_state=shipment.state
-            )
-
-    if any([received_shipment_detail_update_inputs, lost_box_label_identifiers]):
-        if shipment.state != ShipmentState.Receiving:
-            raise InvalidShipmentState(
-                expected_states=[ShipmentState.Receiving], actual_state=shipment.state
-            )
+    if shipment.state != ShipmentState.Preparing:
+        raise InvalidShipmentState(
+            expected_states=[ShipmentState.Preparing], actual_state=shipment.state
+        )
 
     _validate_bases_as_part_of_transfer_agreement(
         transfer_agreement=TransferAgreement.get_by_id(shipment.transfer_agreement_id),
@@ -357,6 +341,33 @@ def update_shipment(
             box_label_identifiers=removed_box_label_identifiers,
             box_state=BoxState.InStock,
         )
+
+        if target_base_id is not None:
+            shipment.target_base = target_base_id
+            shipment.save()
+
+    return shipment
+
+
+def update_shipment_when_receiving(
+    *,
+    id,
+    user,
+    received_shipment_detail_update_inputs=None,
+    lost_box_label_identifiers=None,
+):
+    """Update shipment detail information during reception (on shipment target side).
+    - update checked-in or lost boxes
+    - raise InvalidShipmentState exception if shipment state is different from
+      'Receiving'
+    """
+    shipment = Shipment.get_by_id(id)
+    if shipment.state != ShipmentState.Receiving:
+        raise InvalidShipmentState(
+            expected_states=[ShipmentState.Receiving], actual_state=shipment.state
+        )
+
+    with db.database.atomic():
         _update_shipment_with_received_boxes(
             shipment=shipment,
             shipment_detail_update_inputs=received_shipment_detail_update_inputs,
@@ -369,10 +380,6 @@ def update_shipment(
             box_state=BoxState.Lost,
         )
         _complete_shipment_if_applicable(shipment=shipment, user_id=user.id)
-
-        if target_base_id is not None:
-            shipment.target_base = target_base_id
-            shipment.save()
 
     return shipment
 

--- a/back/boxtribute_server/business_logic/box_transfer/shipment/mutations.py
+++ b/back/boxtribute_server/business_logic/box_transfer/shipment/mutations.py
@@ -3,7 +3,13 @@ from flask import g
 
 from ....authz import authorize
 from ....models.definitions.shipment import Shipment
-from .crud import cancel_shipment, create_shipment, send_shipment, update_shipment
+from .crud import (
+    cancel_shipment,
+    create_shipment,
+    receive_shipment,
+    send_shipment,
+    update_shipment,
+)
 
 mutation = MutationType()
 
@@ -63,3 +69,10 @@ def resolve_send_shipment(*_, id):
     shipment = Shipment.get_by_id(id)
     authorize(permission="shipment:edit", base_id=shipment.source_base_id)
     return send_shipment(id=id, user=g.user)
+
+
+@mutation.field("receiveShipment")
+def resolve_receive_shipment(*_, id):
+    shipment = Shipment.get_by_id(id)
+    authorize(permission="shipment:edit", base_id=shipment.target_base_id)
+    return receive_shipment(id=id, user=g.user)

--- a/back/boxtribute_server/enums.py
+++ b/back/boxtribute_server/enums.py
@@ -54,6 +54,7 @@ class TransferAgreementType(enum.IntEnum):
 class ShipmentState(enum.IntEnum):
     Preparing = 1
     Sent = enum.auto()
+    Receiving = enum.auto()
     Completed = enum.auto()
     Canceled = enum.auto()
     Lost = enum.auto()

--- a/back/boxtribute_server/graph_ql/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/inputs.graphql
@@ -88,13 +88,17 @@ input DistributionEventCreationInput {
   plannedEndDateTime: Datetime
 }
 
-input ShipmentUpdateInput {
+input ShipmentWhenPreparingUpdateInput {
   id: ID!
   targetBaseId: Int
   # label identifiers of boxes prepared for shipment
   preparedBoxLabelIdentifiers: [String!]
   # label identifiers of prepared boxes to be moved back to stock
   removedBoxLabelIdentifiers: [String!]
+}
+
+input ShipmentWhenReceivingUpdateInput {
+  id: ID!
   # label identifiers of received boxes to be moved into target stock
   receivedShipmentDetailUpdateInputs: [ShipmentDetailUpdateInput!]
   # label identifiers of boxes that went lost during shipment

--- a/back/boxtribute_server/graph_ql/mutations.graphql
+++ b/back/boxtribute_server/graph_ql/mutations.graphql
@@ -22,7 +22,8 @@ type Mutation {
   cancelTransferAgreement(id: ID!): TransferAgreement
 
   createShipment(creationInput: ShipmentCreationInput): Shipment
-  updateShipment(updateInput: ShipmentUpdateInput): Shipment
+  updateShipmentWhenPreparing(updateInput: ShipmentWhenPreparingUpdateInput): Shipment
+  updateShipmentWhenReceiving(updateInput: ShipmentWhenReceivingUpdateInput): Shipment
   cancelShipment(id: ID!): Shipment
   sendShipment(id: ID!): Shipment
   receiveShipment(id: ID!): Shipment

--- a/back/boxtribute_server/graph_ql/mutations.graphql
+++ b/back/boxtribute_server/graph_ql/mutations.graphql
@@ -25,6 +25,7 @@ type Mutation {
   updateShipment(updateInput: ShipmentUpdateInput): Shipment
   cancelShipment(id: ID!): Shipment
   sendShipment(id: ID!): Shipment
+  receiveShipment(id: ID!): Shipment
 
   createDistributionSpot(creationInput: DistributionSpotCreationInput): DistributionSpot
   createDistributionEvent(creationInput: DistributionEventCreationInput): DistributionEvent

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -576,8 +576,8 @@ type TransferAgreement {
 
 type Shipment {
   id: ID!
-  sourceBase: Base
-  targetBase: Base
+  sourceBase: Base!
+  targetBase: Base!
   state: ShipmentState
   startedBy: User!
   startedOn: Datetime!

--- a/back/boxtribute_server/graph_ql/types.graphql
+++ b/back/boxtribute_server/graph_ql/types.graphql
@@ -622,6 +622,7 @@ enum TransferAgreementType {
 enum ShipmentState {
   Preparing
   Sent
+  Receiving
   Completed
   Canceled
   Lost

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -130,11 +130,12 @@ def test_query_non_existent_resource_for_god_user(read_only_client, mocker, reso
         "cancelTransferAgreement",
         "cancelShipment",
         "sendShipment",
+        "receiveShipment",
         "deleteTag",
     ],
 )
 def test_mutation_non_existent_resource(read_only_client, operation):
-    # Test cases 2.2.4, 2.2.6, 2.2.8, 3.2.8, 3.2.12, 4.2.10
+    # Test cases 2.2.4, 2.2.6, 2.2.8, 3.2.8, 3.2.12, 3.2.14b, 4.2.10
     mutation = f"mutation {{ {operation}(id: 0) {{ id }} }}"
     response = assert_bad_user_input(read_only_client, mutation, field=operation)
     assert "SQL" not in response.json["errors"][0]["message"]

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -149,7 +149,8 @@ def test_mutation_non_existent_resource(read_only_client, operation):
         # Test case 9.2.14
         ["updateBeneficiary", "updateInput: { id: 0 }", "id"],
         # Test case 3.2.21
-        ["updateShipment", "updateInput: { id: 0 }", "id"],
+        ["updateShipmentWhenPreparing", "updateInput: { id: 0 }", "id"],
+        ["updateShipmentWhenReceiving", "updateInput: { id: 0 }", "id"],
         # Test case 4.2.5
         ["updateTag", "updateInput: { id: 0 }", "id"],
         # Test case 4.2.15

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -383,7 +383,7 @@ def test_invalid_permission_for_shipment_base(read_only_client, mocker, field):
         permissions=["shipment:read"]
     )
     query = f"query {{ shipment(id: 1) {{ {field} {{ id }} }} }}"
-    assert_forbidden_request(read_only_client, query, value={field: None})
+    assert_forbidden_request(read_only_client, query)
 
 
 @pytest.mark.parametrize("field", ["location", "qrCode", "tags"])

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -162,6 +162,7 @@ def test_invalid_permission_for_given_resource_id(read_only_client, query):
         "updateShipment( updateInput : { id: 1 }) { id }",
         "cancelShipment( id : 1 ) { id }",
         "sendShipment( id : 1 ) { id }",
+        "receiveShipment( id : 1 ) { id }",
         # Test case 4.2.8
         """createTag(
             creationInput : {

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -159,7 +159,8 @@ def test_invalid_permission_for_given_resource_id(read_only_client, query):
                 targetBaseId: 3,
                 transferAgreementId: 1
             }) { id }""",
-        "updateShipment( updateInput : { id: 1 }) { id }",
+        "updateShipmentWhenPreparing( updateInput : { id: 1 }) { id }",
+        "updateShipmentWhenReceiving( updateInput : { id: 1 }) { id }",
         "cancelShipment( id : 1 ) { id }",
         "sendShipment( id : 1 ) { id }",
         "receiveShipment( id : 1 ) { id }",

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -123,7 +123,8 @@ def test_shipment_mutations_on_source_side(
     shipment_id = str(default_shipment["id"])
     update_input = f"""{{ id: {shipment_id},
                 targetBaseId: {target_base_id} }}"""
-    mutation = f"""mutation {{ updateShipment(updateInput: {update_input}) {{
+    mutation = f"""mutation {{ updateShipmentWhenPreparing(
+                updateInput: {update_input}) {{
                     id
                     state
                     targetBase {{ id }}
@@ -139,7 +140,8 @@ def test_shipment_mutations_on_source_side(
     box_label_identifier = default_box["label_identifier"]
     update_input = f"""{{ id: {shipment_id},
                 preparedBoxLabelIdentifiers: ["{box_label_identifier}"] }}"""
-    mutation = f"""mutation {{ updateShipment(updateInput: {update_input}) {{
+    mutation = f"""mutation {{ updateShipmentWhenPreparing(
+                updateInput: {update_input}) {{
                     id
                     state
                     details {{
@@ -214,7 +216,8 @@ def test_shipment_mutations_on_source_side(
         box_label_identifier = box["label_identifier"]
         update_input = f"""{{ id: {shipment_id},
                     preparedBoxLabelIdentifiers: ["{box_label_identifier}"] }}"""
-        mutation = f"""mutation {{ updateShipment(updateInput: {update_input}) {{
+        mutation = f"""mutation {{ updateShipmentWhenPreparing(
+                    updateInput: {update_input}) {{
                         details {{ id }}
                     }} }}"""
         shipment = assert_successful_request(client, mutation)
@@ -229,7 +232,8 @@ def test_shipment_mutations_on_source_side(
     box_label_identifiers = ",".join(f'"{b["label_identifier"]}"' for b in boxes)
     update_input = f"""{{ id: {shipment_id},
                 removedBoxLabelIdentifiers: [{box_label_identifiers}] }}"""
-    mutation = f"""mutation {{ updateShipment(updateInput: {update_input}) {{
+    mutation = f"""mutation {{ updateShipmentWhenPreparing(
+                updateInput: {update_input}) {{
                     id
                     state
                     details {{ id }}
@@ -256,7 +260,8 @@ def test_shipment_mutations_on_source_side(
         box_label_identifier = box["label_identifier"]
         update_input = f"""{{ id: {shipment_id},
                     removedBoxLabelIdentifiers: ["{box_label_identifier}"] }}"""
-        mutation = f"""mutation {{ updateShipment(updateInput: {update_input}) {{
+        mutation = f"""mutation {{ updateShipmentWhenPreparing(
+                    updateInput: {update_input}) {{
                         details {{ id }}
                     }} }}"""
         shipment = assert_successful_request(client, mutation)
@@ -374,7 +379,8 @@ def test_shipment_mutations_on_target_side(
                         targetProductId: {target_product_id},
                         targetLocationId: {target_location_id}
                     }}"""
-        return f"""mutation {{ updateShipment(updateInput: {{ {update_input} }}) {{
+        return f"""mutation {{ updateShipmentWhenReceiving(
+                    updateInput: {{ {update_input} }}) {{
                         id
                         state
                         completedBy {{ id }}
@@ -453,7 +459,7 @@ def test_shipment_mutations_on_target_side(
 
     # Test case 3.2.40, 3.2.34b
     box_label_identifier = marked_for_shipment_box["label_identifier"]
-    mutation = f"""mutation {{ updateShipment( updateInput: {{
+    mutation = f"""mutation {{ updateShipmentWhenReceiving( updateInput: {{
                 id: {shipment_id},
                 lostBoxLabelIdentifiers: ["{box_label_identifier}"]
             }} ) {{
@@ -517,11 +523,13 @@ def _generate_update_shipment_mutation(
     target_product=None,
 ):
     update_input = f"id: {shipment['id']}"
+    update_type = "WhenPreparing"
     if target_base is not None:
         update_input += f", targetBaseId: {target_base['id']}"
     if lost_boxes is not None:
         identifiers = ",".join(f'"{b["label_identifier"]}"' for b in lost_boxes)
         update_input += f", lostBoxLabelIdentifiers: [{identifiers}]"
+        update_type = "WhenReceiving"
     if received_details is not None:
         inputs = ", ".join(
             f"""{{ id: {detail["id"]},
@@ -530,8 +538,9 @@ def _generate_update_shipment_mutation(
             for detail in received_details
         )
         update_input += f", receivedShipmentDetailUpdateInputs: [{inputs}]"
-    return f"""mutation {{ updateShipment(updateInput: {{ {update_input} }} ) {{
-                    id }} }}"""
+        update_type = "WhenReceiving"
+    return f"""mutation {{ updateShipment{update_type}(
+                updateInput: {{ {update_input} }} ) {{ id }} }}"""
 
 
 def assert_bad_user_input_when_updating_shipment(client, **kwargs):
@@ -641,6 +650,7 @@ def test_shipment_mutations_update_with_invalid_target_base(
     read_only_client, default_bases, default_shipment
 ):
     # Test case 3.2.24
+    # This will use updateShipmentWhenPreparing
     assert_bad_user_input_when_updating_shipment(
         read_only_client,
         target_base=default_bases[4],  # not part of agreement
@@ -652,6 +662,7 @@ def test_shipment_mutations_update_in_non_preparing_state(
     read_only_client, canceled_shipment, default_bases
 ):
     # Test case 3.2.23
+    # This will use updateShipmentWhenPreparing
     assert_bad_user_input_when_updating_shipment(
         read_only_client,
         shipment=canceled_shipment,
@@ -665,6 +676,7 @@ def test_shipment_mutations_update_as_member_of_non_creating_org(
     # Test case 3.2.25
     # The default user (see auth_service fixture) is member of organisation 1 but
     # organisation 2 is the one that created another_shipment
+    # This will use updateShipmentWhenPreparing
     mutation = _generate_update_shipment_mutation(
         shipment=another_shipment,
         target_base=default_bases[2],
@@ -680,6 +692,7 @@ def test_shipment_mutations_update_checked_in_boxes_as_member_of_creating_org(
     another_product,
 ):
     # Test case 3.2.35
+    # This will use updateShipmentWhenReceiving
     mutation = _generate_update_shipment_mutation(
         shipment=sent_shipment,
         received_details=[default_shipment_detail],
@@ -695,6 +708,7 @@ def test_shipment_mutations_update_mark_lost_boxes_as_member_of_creating_org(
     marked_for_shipment_box,
 ):
     # Test case 3.2.41
+    # This will use updateShipmentWhenReceiving
     mutation = _generate_update_shipment_mutation(
         shipment=sent_shipment,
         lost_boxes=[marked_for_shipment_box],
@@ -723,6 +737,7 @@ def test_shipment_mutations_update_checked_in_boxes_when_shipment_in_non_sent_st
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         base_ids=[3], organisation_id=2, user_id=2
     )
+    # This will use updateShipmentWhenReceiving
     assert_bad_user_input_when_updating_shipment(
         read_only_client,
         shipment=default_shipment,

--- a/back/test/integration_tests/test_operations.py
+++ b/back/test/integration_tests/test_operations.py
@@ -106,7 +106,7 @@ def test_mutations(auth0_client):
         return shipment_id
 
     shipment_id = create_shipment()
-    mutation = f"""mutation {{ updateShipment(updateInput: {{
+    mutation = f"""mutation {{ updateShipmentWhenPreparing(updateInput: {{
                     id: {shipment_id} }}) {{ id }} }}"""
     response = assert_successful_request(auth0_client, mutation)
     assert response == {"id": str(shipment_id)}

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -1229,6 +1229,7 @@ export enum ShipmentState {
   Completed = 'Completed',
   Lost = 'Lost',
   Preparing = 'Preparing',
+  Receiving = 'Receiving',
   Sent = 'Sent'
 }
 

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -510,6 +510,7 @@ export type Mutation = {
   deleteTag?: Maybe<Tag>;
   moveItemsFromBoxToDistributionEvent?: Maybe<UnboxedItemsCollection>;
   moveItemsFromReturnTrackingGroupToBox?: Maybe<DistributionEventsTrackingEntry>;
+  receiveShipment?: Maybe<Shipment>;
   rejectTransferAgreement?: Maybe<TransferAgreement>;
   removeAllPackingListEntriesFromDistributionEventForProduct?: Maybe<Scalars['Boolean']>;
   removeItemsFromUnboxedItemsCollection?: Maybe<UnboxedItemsCollection>;
@@ -723,6 +724,16 @@ export type MutationMoveItemsFromReturnTrackingGroupToBoxArgs = {
   productId: Scalars['ID'];
   sizeId: Scalars['ID'];
   targetBoxLabelIdentifier: Scalars['ID'];
+};
+
+
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
+export type MutationReceiveShipmentArgs = {
+  id: Scalars['ID'];
 };
 
 

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -1211,11 +1211,11 @@ export type Shipment = {
   id: Scalars['ID'];
   sentBy?: Maybe<User>;
   sentOn?: Maybe<Scalars['Datetime']>;
-  sourceBase?: Maybe<Base>;
+  sourceBase: Base;
   startedBy: User;
   startedOn: Scalars['Datetime'];
   state?: Maybe<ShipmentState>;
-  targetBase?: Maybe<Base>;
+  targetBase: Base;
   transferAgreement: TransferAgreement;
 };
 

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -524,7 +524,8 @@ export type Mutation = {
   updateBox?: Maybe<Box>;
   updatePackingListEntry?: Maybe<PackingListEntry>;
   updateSelectedProductsForDistributionEventPackingList?: Maybe<DistributionEvent>;
-  updateShipment?: Maybe<Shipment>;
+  updateShipmentWhenPreparing?: Maybe<Shipment>;
+  updateShipmentWhenReceiving?: Maybe<Shipment>;
   updateTag?: Maybe<Tag>;
 };
 
@@ -882,8 +883,18 @@ export type MutationUpdateSelectedProductsForDistributionEventPackingListArgs = 
  * - input argument: creationInput/updateInput
  * - input type: <Resource>CreationInput/UpdateInput
  */
-export type MutationUpdateShipmentArgs = {
-  updateInput?: InputMaybe<ShipmentUpdateInput>;
+export type MutationUpdateShipmentWhenPreparingArgs = {
+  updateInput?: InputMaybe<ShipmentWhenPreparingUpdateInput>;
+};
+
+
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
+export type MutationUpdateShipmentWhenReceivingArgs = {
+  updateInput?: InputMaybe<ShipmentWhenReceivingUpdateInput>;
 };
 
 
@@ -1244,13 +1255,17 @@ export enum ShipmentState {
   Sent = 'Sent'
 }
 
-export type ShipmentUpdateInput = {
+export type ShipmentWhenPreparingUpdateInput = {
   id: Scalars['ID'];
-  lostBoxLabelIdentifiers?: InputMaybe<Array<Scalars['String']>>;
   preparedBoxLabelIdentifiers?: InputMaybe<Array<Scalars['String']>>;
-  receivedShipmentDetailUpdateInputs?: InputMaybe<Array<ShipmentDetailUpdateInput>>;
   removedBoxLabelIdentifiers?: InputMaybe<Array<Scalars['String']>>;
   targetBaseId?: InputMaybe<Scalars['Int']>;
+};
+
+export type ShipmentWhenReceivingUpdateInput = {
+  id: Scalars['ID'];
+  lostBoxLabelIdentifiers?: InputMaybe<Array<Scalars['String']>>;
+  receivedShipmentDetailUpdateInputs?: InputMaybe<Array<ShipmentDetailUpdateInput>>;
 };
 
 /** Representation of product size. */


### PR DESCRIPTION
Please see commits for details.

We probably need additional fields `updated_by`, `updated_on` in the `Shipment` model but I'm still clarifying with Roanna (code-wise it would be a minor change).