### PR TITLE
Use correct name for shipment ID variable

### DIFF
--- a/react/src/views/Transfers/ShipmentView/ShipmentView.tsx
+++ b/react/src/views/Transfers/ShipmentView/ShipmentView.tsx
@@ -184,7 +184,7 @@ function ShipmentView() {
       () => {
         mutation({
           variables: {
-            shipmentId,
+            id: shipmentId,
           },
         })
           .then((res) => {


### PR DESCRIPTION
Otherwise the following error happens:
"Variable '$id' of required type 'ID!' was not provided."
