### PR TITLE
Make error detection for re-used QR code less strict

### DIFF
--- a/back/boxtribute_server/business_logic/warehouse/box/crud.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/crud.py
@@ -82,11 +82,12 @@ def create_box(
             # peewee throws the same exception for different constraint violations.
             # E.g. failing "NOT NULL" constraint shall be directly reported
             prefix = "Duplicate entry"
-            if f"{prefix} '{qr_id}' for key 'stock.qr_id_unique'" in str(e):
+            error = str(e)
+            if f"{prefix} '{qr_id}'" in error and "qr_id_unique" in error:
                 raise QrCodeAlreadyAssignedToBox()
             if (
-                f"{prefix} '{new_box.label_identifier}' for key 'stock.box_id_unique'"
-                not in str(e)
+                f"{prefix} '{new_box.label_identifier}'" not in error
+                and "box_id_unique" not in error
             ):
                 raise
     raise BoxCreationFailed()


### PR DESCRIPTION
Since the last prod deploy, the MySQL error message for when a used QR
code is added to a box is along 

    Duplicate entry '153659' for key 'qr_id_unique'

but the error detection was looking for an exact match

    Duplicate entry '153659' for key 'stock.qr_id_unique'

and, not finding a match, would leave this error unhandled.
A couple of occurrences have been reported by Sentry recently.

The error detection is now made less strict since we only have to
distinguish between an assignment of a duplicated QR code, a duplicated
box label identifier, or another unknown error.

This fix is important because the detection of a used QR code would
trigger an unknown error without telling the user what went wrong
(hence also the uncaught exceptions in Sentry). Now they're correctly
notified again about the QR code already being in use.
