### PR TITLE
BoxView: Disable Edits and Moves While in Shipment Transit

### DIFF
--- a/react/src/views/Box/BoxView.test.tsx
+++ b/react/src/views/Box/BoxView.test.tsx
@@ -530,8 +530,6 @@ it("3.1.4 - Move location", async () => {
   const whWomenLocation = screen.getByRole("button", { name: /wh women/i });
   await user.click(whWomenLocation);
 
-  screen.debug();
-
   await waitFor(() =>
     expect(mockedCreateToast).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -739,6 +737,7 @@ it("3.1.10 - No Data or Null Data Fetched for a given Box Label Identifier", asy
   render(
     <BoxDetails
       boxData={undefined}
+      boxInTransit={false}
       onMoveToLocationClick={mockFunction}
       onPlusOpen={mockFunction}
       onMinusOpen={mockFunction}

--- a/react/src/views/Box/BoxView.tsx
+++ b/react/src/views/Box/BoxView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { gql, useMutation, useQuery, NetworkStatus } from "@apollo/client";
 import {
   Alert,
@@ -140,6 +140,7 @@ function BTBox() {
   const labelIdentifier = useParams<{ labelIdentifier: string }>().labelIdentifier!;
   const { globalPreferences } = useContext(GlobalPreferencesContext);
   const currentBaseId = globalPreferences.selectedBaseId;
+  const [currentBoxState, setCurrentState] = useState<BoxState | undefined>();
 
   const {
     assignBoxesToShipment,
@@ -158,6 +159,14 @@ function BTBox() {
   );
 
   const shipmentsQueryResult = allData.data?.shipments;
+
+  useEffect(() => {
+    setCurrentState(allData.data?.box?.state);
+  }, [allData]);
+
+  const boxInTransit = currentBoxState
+    ? [BoxState.Receiving, BoxState.MarkedForShipment].includes(currentBoxState)
+    : false;
 
   const [updateNumberOfItemsMutation, updateNumberOfItemsMutationStatus] = useMutation<
     UpdateNumberOfItemsMutation,
@@ -561,6 +570,7 @@ function BTBox() {
           alertForLagacyBox}
         <BoxDetails
           boxData={boxData}
+          boxInTransit={boxInTransit}
           onPlusOpen={onPlusOpen}
           onMinusOpen={onMinusOpen}
           onMoveToLocationClick={onMoveBoxToLocationClick}

--- a/react/src/views/Box/components/BoxCard.tsx
+++ b/react/src/views/Box/components/BoxCard.tsx
@@ -36,13 +36,21 @@ import HistoryEntries from "./HistoryEntries";
 
 export interface IBoxCardProps {
   boxData: BoxByLabelIdentifierQuery["box"] | UpdateLocationOfBoxMutation["updateBox"];
+  boxInTransit: boolean;
   onPlusOpen: () => void;
   onMinusOpen: () => void;
   onStateChange: (boxState: BoxState) => void;
   isLoading: boolean;
 }
 
-function BoxCard({ boxData, onPlusOpen, onMinusOpen, onStateChange, isLoading }: IBoxCardProps) {
+function BoxCard({
+  boxData,
+  boxInTransit,
+  onPlusOpen,
+  onMinusOpen,
+  onStateChange,
+  isLoading,
+}: IBoxCardProps) {
   const statusColor = (value) => {
     let color;
     if (value === "Lost" || value === "Scrap") {
@@ -70,7 +78,9 @@ function BoxCard({ boxData, onPlusOpen, onMinusOpen, onStateChange, isLoading }:
         </WrapItem>
         <Spacer />
         <WrapItem>
-          {(BoxState.Lost === boxData?.state || BoxState.Scrap === boxData?.state) && (
+          {(BoxState.Lost === boxData?.state ||
+            BoxState.Scrap === boxData?.state ||
+            boxInTransit) && (
             <IconButton
               aria-label="Edit box"
               borderRadius="0"
@@ -79,7 +89,11 @@ function BoxCard({ boxData, onPlusOpen, onMinusOpen, onStateChange, isLoading }:
               disabled
             />
           )}
-          {BoxState.Lost !== boxData?.state && BoxState.Scrap !== boxData?.state && (
+          {!(
+            BoxState.Lost === boxData?.state ||
+            BoxState.Scrap === boxData?.state ||
+            boxInTransit
+          ) && (
             <NavLink to="edit">
               <IconButton
                 aria-label="Edit box"
@@ -137,7 +151,11 @@ function BoxCard({ boxData, onPlusOpen, onMinusOpen, onStateChange, isLoading }:
               <Tooltip hasArrow shouldWrapChildren mt="3" label="add items" aria-label="A tooltip">
                 <IconButton
                   onClick={onPlusOpen}
-                  disabled={BoxState.Lost === boxData?.state || BoxState.Scrap === boxData?.state}
+                  disabled={
+                    BoxState.Lost === boxData?.state ||
+                    BoxState.Scrap === boxData?.state ||
+                    boxInTransit
+                  }
                   size="sm"
                   border="2px"
                   isRound
@@ -161,7 +179,11 @@ function BoxCard({ boxData, onPlusOpen, onMinusOpen, onStateChange, isLoading }:
                   onClick={onMinusOpen}
                   border="2px"
                   size="sm"
-                  disabled={BoxState.Lost === boxData?.state || BoxState.Scrap === boxData?.state}
+                  disabled={
+                    BoxState.Lost === boxData?.state ||
+                    BoxState.Scrap === boxData?.state ||
+                    boxInTransit
+                  }
                   borderRadius="0"
                   isRound
                   aria-label="Search database"
@@ -219,6 +241,7 @@ function BoxCard({ boxData, onPlusOpen, onMinusOpen, onStateChange, isLoading }:
             {!isLoading && (
               <Switch
                 id="scrap"
+                isDisabled={boxInTransit}
                 isReadOnly={isLoading}
                 isChecked={boxData?.state === BoxState.Scrap}
                 data-testid="box-scrap-btn"
@@ -244,6 +267,7 @@ function BoxCard({ boxData, onPlusOpen, onMinusOpen, onStateChange, isLoading }:
                 id="lost"
                 isFocusable={false}
                 data-testid="box-lost-btn"
+                isDisabled={boxInTransit}
                 onChange={() =>
                   onStateChange(
                     // If the current box state 'Lost' is toggled, set the defaultBoxState of the box location

--- a/react/src/views/Box/components/BoxDetails.tsx
+++ b/react/src/views/Box/components/BoxDetails.tsx
@@ -11,6 +11,7 @@ import BoxTabs from "./BoxTabs";
 
 interface IBoxDetailsProps {
   boxData: BoxByLabelIdentifierQuery["box"] | UpdateLocationOfBoxMutation["updateBox"];
+  boxInTransit: boolean;
   onMoveToLocationClick: (locationId: string) => void;
   onPlusOpen: () => void;
   onMinusOpen: () => void;
@@ -25,6 +26,7 @@ interface IBoxDetailsProps {
 
 function BoxDetails({
   boxData,
+  boxInTransit,
   onMoveToLocationClick,
   onAssignBoxToDistributionEventClick,
   onUnassignBoxFromDistributionEventClick,
@@ -50,6 +52,7 @@ function BoxDetails({
     >
       <BoxCard
         boxData={boxData}
+        boxInTransit={boxInTransit}
         onMinusOpen={onMinusOpen}
         onPlusOpen={onPlusOpen}
         onStateChange={onStateChange}
@@ -57,6 +60,7 @@ function BoxDetails({
       />
       <BoxTabs
         boxData={boxData}
+        boxInTransit={boxInTransit}
         onMoveToLocationClick={onMoveToLocationClick}
         onAssignBoxesToShipment={onAssignBoxesToShipment}
         onUnassignBoxesToShipment={onUnassignBoxesToShipment}

--- a/react/src/views/Box/components/BoxMoveLocation.tsx
+++ b/react/src/views/Box/components/BoxMoveLocation.tsx
@@ -3,11 +3,17 @@ import { BoxState, ClassicLocation } from "types/generated/graphql";
 
 export interface IBoxMoveLocationProps {
   boxData: any;
+  boxInTransit: boolean;
   isLoading: boolean;
   onMoveToLocationClick: (locationId: string) => void;
 }
 
-function BoxMoveLocation({ boxData, onMoveToLocationClick, isLoading }: IBoxMoveLocationProps) {
+function BoxMoveLocation({
+  boxData,
+  boxInTransit,
+  onMoveToLocationClick,
+  isLoading,
+}: IBoxMoveLocationProps) {
   return (
     <>
       {isLoading && (
@@ -45,7 +51,9 @@ function BoxMoveLocation({ boxData, onMoveToLocationClick, isLoading }: IBoxMove
                   disabled={
                     (boxData.location as ClassicLocation).defaultBoxState !== BoxState.Lost &&
                     (boxData.location as ClassicLocation).defaultBoxState !== BoxState.Scrap
-                      ? BoxState.Lost === boxData.state || BoxState.Scrap === boxData.state
+                      ? BoxState.Lost === boxData.state ||
+                        BoxState.Scrap === boxData.state ||
+                        boxInTransit
                       : false
                   }
                   border="2px"

--- a/react/src/views/Box/components/BoxTabs.tsx
+++ b/react/src/views/Box/components/BoxTabs.tsx
@@ -23,6 +23,7 @@ import BoxMoveLocation from "./BoxMoveLocation";
 
 export interface IBoxTabsProps {
   boxData: BoxByLabelIdentifierQuery["box"];
+  boxInTransit: boolean;
   onMoveToLocationClick: (locationId: string) => void;
   onAssignBoxesToShipment: (shipmentId: string) => void;
   onUnassignBoxesToShipment: (shipmentId: string) => void;
@@ -32,6 +33,7 @@ export interface IBoxTabsProps {
 
 function BoxTabs({
   boxData,
+  boxInTransit,
   onMoveToLocationClick,
   onAssignBoxesToShipment,
   onUnassignBoxesToShipment,
@@ -102,6 +104,7 @@ function BoxTabs({
             <TabPanel p={4}>
               <BoxMoveLocation
                 boxData={boxData}
+                boxInTransit={boxInTransit}
                 onMoveToLocationClick={onMoveToLocationClick}
                 isLoading={isLoading}
               />


### PR DESCRIPTION
The PR disables editing and moving actions when a box is added to a shipment.