### PR TITLE
Fix slow box-query loading time if tags present

### DIFF
--- a/back/boxtribute_server/graph_ql/loaders.py
+++ b/back/boxtribute_server/graph_ql/loaders.py
@@ -47,10 +47,11 @@ class TagsForBoxLoader(DataLoader):
         tags = defaultdict(list)
         # maybe need different join type
         for relation in (
-            TagsRelation.select()
+            TagsRelation.select(TagsRelation.object_type, TagsRelation.object_id, Tag)
             .join(Tag)
             .where(
                 TagsRelation.object_type == TaggableObjectType.Box,
+                TagsRelation.object_id << keys,
                 authorized_bases_filter(Tag),
             )
         ):


### PR DESCRIPTION
The newest DB seeds contains tag/tag relation data. We found that a
query like `boxes { elements { tags { id } } }` performs very slow.
Introspecting peewee logs shows that thousands of individual
Tag.select() queries are performed.
The culprit is missing to additional select Tags when selecting tag relations
(which then is joined with tags). After fixing, all Tag objects are fetched in
one go instead of having peewee issue a select every time a tag object
is actually accessed.
This brings down execution time from 3.5s to about 0.7s for a query like
`shipment(id: 1) { details { boxes { tags { id } } } }`, and only
queries the TagsRelation table once.

Also only select TagsRelation that are correspond to boxes requested by
the user when batch-loading tags.
