### PR TITLE
Add Sentry profiling for Python BE

### DIFF
--- a/back/boxtribute_server/app.py
+++ b/back/boxtribute_server/app.py
@@ -57,6 +57,7 @@ def main(*blueprints):
         integrations=[FlaskIntegration()],
         traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", 0.0)),
         before_send=before_sentry_send,
+        profiles_sample_rate=float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", 0)),
     )
 
     app = create_app()


### PR DESCRIPTION
Cf. https://docs.sentry.io/platforms/python/profiling/

The env variable `SENTRY_TRACES_SAMPLE_RATE` is set for 1 in the
CircleCI staging context. Profiling will not be effective in demo nor
production environments.
