### PR TITLE
BoxView: Prevent State Changes or Assignments to Shipments When a Box in the Legacy Lost Location

### DIFF
--- a/react/src/views/Box/BoxView.tsx
+++ b/react/src/views/Box/BoxView.tsx
@@ -165,7 +165,7 @@ function BTBox() {
   }, [allData]);
 
   const boxInTransit = currentBoxState
-    ? [BoxState.Receiving, BoxState.MarkedForShipment].includes(currentBoxState)
+    ? [BoxState.Receiving, BoxState.MarkedForShipment, BoxState.InTransit].includes(currentBoxState)
     : false;
 
   const [updateNumberOfItemsMutation, updateNumberOfItemsMutationStatus] = useMutation<

--- a/react/src/views/Box/components/AssignBoxToShipment.tsx
+++ b/react/src/views/Box/components/AssignBoxToShipment.tsx
@@ -46,7 +46,8 @@ function AssignBoxToShipment({
     if (
       selectedShipmentOption &&
       selectedShipmentOption.value !== "" &&
-      boxData?.state !== BoxState.Donated
+      boxData?.state !== BoxState.Donated &&
+      (boxData?.location as any)?.defaultBoxState !== BoxState.Lost
     ) {
       return false;
     }

--- a/react/src/views/Box/components/AssignBoxToShipment.tsx
+++ b/react/src/views/Box/components/AssignBoxToShipment.tsx
@@ -122,6 +122,7 @@ function AssignBoxToShipment({
               colorScheme="blue"
               size="md"
               mt={2}
+              disabled={boxData.state === BoxState.InTransit}
               aria-label="remove to shipment"
               onClick={() => {
                 onUnassignBoxesToShipment(currentShipmentId);

--- a/react/src/views/Box/components/AssignBoxToShipment.tsx
+++ b/react/src/views/Box/components/AssignBoxToShipment.tsx
@@ -46,8 +46,7 @@ function AssignBoxToShipment({
     if (
       selectedShipmentOption &&
       selectedShipmentOption.value !== "" &&
-      boxData?.state !== BoxState.Donated &&
-      (boxData?.location as any)?.defaultBoxState !== BoxState.Lost
+      boxData?.state === BoxState.InStock
     ) {
       return false;
     }

--- a/react/src/views/Box/components/BoxCard.tsx
+++ b/react/src/views/Box/components/BoxCard.tsx
@@ -27,6 +27,7 @@ import { NavLink } from "react-router-dom";
 import {
   BoxByLabelIdentifierQuery,
   BoxState,
+  ClassicLocation,
   HistoryEntry,
   UpdateLocationOfBoxMutation,
 } from "types/generated/graphql";
@@ -245,7 +246,8 @@ function BoxCard({
               <Switch
                 id="scrap"
                 isDisabled={
-                  boxInTransit || (boxData?.location as any)?.defaultBoxState === BoxState.Lost
+                  boxInTransit ||
+                  (boxData?.location as ClassicLocation)?.defaultBoxState === BoxState.Lost
                 }
                 isReadOnly={isLoading}
                 isChecked={boxData?.state === BoxState.Scrap}
@@ -273,7 +275,8 @@ function BoxCard({
                 isFocusable={false}
                 data-testid="box-lost-btn"
                 isDisabled={
-                  boxInTransit || (boxData?.location as any)?.defaultBoxState === BoxState.Lost
+                  boxInTransit ||
+                  (boxData?.location as ClassicLocation)?.defaultBoxState === BoxState.Lost
                 }
                 onChange={() =>
                   onStateChange(

--- a/react/src/views/Box/components/BoxCard.tsx
+++ b/react/src/views/Box/components/BoxCard.tsx
@@ -244,7 +244,9 @@ function BoxCard({
             {!isLoading && (
               <Switch
                 id="scrap"
-                isDisabled={boxInTransit}
+                isDisabled={
+                  boxInTransit || (boxData?.location as any)?.defaultBoxState === BoxState.Lost
+                }
                 isReadOnly={isLoading}
                 isChecked={boxData?.state === BoxState.Scrap}
                 data-testid="box-scrap-btn"
@@ -270,7 +272,9 @@ function BoxCard({
                 id="lost"
                 isFocusable={false}
                 data-testid="box-lost-btn"
-                isDisabled={boxInTransit}
+                isDisabled={
+                  boxInTransit || (boxData?.location as any)?.defaultBoxState === BoxState.Lost
+                }
                 onChange={() =>
                   onStateChange(
                     // If the current box state 'Lost' is toggled, set the defaultBoxState of the box location


### PR DESCRIPTION
- use the new InTransit to prevent change in the box
- prevent changing state to lost / scrap
- prevent adding the box on lost location to shipment
- prevent removing box from shipment while box state is InTransit
