### PR TITLE
Enable accessing InTransit/Receiving boxes for members of target base

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -74,15 +74,7 @@ Install the dependencies of the app in the activated virtual environment
 
     pip install -U -e back -r back/requirements-dev.txt
 
-For the integration tests authentication information is fetched from the [Auth0](https://auth0.com) website. Log in and select `Applications` -> `Applications` from the side bar menu. Select `boxtribute-dev-api`. Copy the `Client Secret` into the `.env` file as the `TEST_AUTH0_CLIENT_SECRET` variables.
-
-We're subject to a rate limit for tokens from Auth0. In order to avoid fetching tokens over and over again for every test run, do the following once before you start your development session:
-
-1. Activate the virtual environment
-1. Run `./fetch_token --test`
-1. Paste the displayed token as `TEST_AUTH0_JWT=` into the `.env` file
-
-After 24h the token expires, so you have to repeat the procedure.
+For the integration tests authentication information is fetched from the [Auth0](https://auth0.com) website. Log in and select `Applications` -> `Applications` from the side bar menu. Select `boxtribute-dev-api`. Copy the `Client Secret` into the `.env` file as the `TEST_AUTH0_CLIENT_SECRET` variable.
 
 Furthermore Auth0 public key information can be stored locally to avoid the overhead when the server fetches it every time it receives a request and decodes the JWT. For the boxtribute-dev tenant run
 

--- a/back/boxtribute_server/business_logic/box_transfer/shipment/fields.py
+++ b/back/boxtribute_server/business_logic/box_transfer/shipment/fields.py
@@ -81,7 +81,7 @@ def resolve_shipment_detail_target_product(detail_obj, info):
 
 
 @shipment_detail.field("sourceLocation")
-def resolve_shipment_detail_source_location(detail_obj, _):
+def resolve_shipment_detail_source_location(detail_obj, info):
     authorize(
         permission="location:read",
         base_ids=[
@@ -89,11 +89,11 @@ def resolve_shipment_detail_source_location(detail_obj, _):
             detail_obj.shipment.target_base_id,
         ],
     )
-    return detail_obj.source_location
+    return info.context["location_loader"].load(detail_obj.source_location_id)
 
 
 @shipment_detail.field("targetLocation")
-def resolve_shipment_detail_target_location(detail_obj, _):
+def resolve_shipment_detail_target_location(detail_obj, info):
     authorize(
         permission="location:read",
         base_ids=[
@@ -101,7 +101,7 @@ def resolve_shipment_detail_target_location(detail_obj, _):
             detail_obj.shipment.target_base_id,
         ],
     )
-    return detail_obj.target_location
+    return info.context["location_loader"].load(detail_obj.target_location_id)
 
 
 @shipment_detail.field("box")

--- a/back/boxtribute_server/business_logic/warehouse/box/fields.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/fields.py
@@ -45,8 +45,14 @@ def resolve_box_size(box_obj, info):
 
 
 @box.field("location")
-def resolve_box_location(box_obj, info):
-    return info.context["location_loader"].load(box_obj.location_id)
+async def resolve_box_location(box_obj, info):
+    location = await info.context["location_loader"].load(box_obj.location_id)
+    # See comment in resolve_box_product()
+    try:
+        authorize(permission="location:read", base_id=location.base_id)
+        return location
+    except Forbidden:
+        return
 
 
 @box.field("state")

--- a/back/boxtribute_server/business_logic/warehouse/box/queries.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/queries.py
@@ -1,8 +1,11 @@
 from ariadne import QueryType
 
 from ....authz import authorize
+from ....enums import BoxState
 from ....models.definitions.box import Box
 from ....models.definitions.location import Location
+from ....models.definitions.shipment import Shipment
+from ....models.definitions.shipment_detail import ShipmentDetail
 
 query = QueryType()
 
@@ -15,5 +18,25 @@ def resolve_box(*_, label_identifier):
         .where(Box.label_identifier == label_identifier)
         .get()
     )
-    authorize(permission="stock:read", base_id=box.location.base_id)
+
+    if box.state_id in [BoxState.InTransit, BoxState.Receiving]:
+        # Users of both source and target base of the underlying shipment are allowed to
+        # view InTransit or Receiving boxes
+        detail = (
+            ShipmentDetail.select(Shipment)
+            .join(Shipment)
+            .where(
+                ShipmentDetail.box_id == box.id,
+                ShipmentDetail.removed_on.is_null(),
+                ShipmentDetail.received_on.is_null(),
+            )
+        ).get()
+        authz_kwargs = {
+            "base_ids": [detail.shipment.source_base_id, detail.shipment.target_base_id]
+        }
+
+    else:
+        authz_kwargs = {"base_id": box.location.base_id}
+
+    authorize(permission="stock:read", **authz_kwargs)
     return box

--- a/back/boxtribute_server/graph_ql/loaders.py
+++ b/back/boxtribute_server/graph_ql/loaders.py
@@ -42,10 +42,7 @@ class ProductLoader(DataLoader):
 class LocationLoader(DataLoader):
     async def batch_load_fn(self, keys):
         locations = {
-            loc.id: loc
-            for loc in Location.select().where(
-                Location.id << keys, authorized_bases_filter(Location)
-            )
+            loc.id: loc for loc in Location.select().where(Location.id << keys)
         }
         return [locations.get(i) for i in keys]
 

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -31,10 +31,6 @@ def memoize(function):
 @memoize
 def fetch_token(username):
     """Grabs a test user access token for Auth0."""
-    token = os.getenv("TEST_AUTH0_JWT")
-    if token is not None:
-        return token
-
     success, response = request_jwt(
         client_id=os.getenv("TEST_AUTH0_CLIENT_ID"),
         client_secret=os.getenv("TEST_AUTH0_CLIENT_SECRET"),

--- a/back/test/data/box.py
+++ b/back/test/data/box.py
@@ -44,6 +44,7 @@ def another_box_data():
     data["id"] = 4
     data["label_identifier"] = "34567890"
     data["location"] = another_location_data()["id"]
+    data["product"] = product_data()[1]["id"]
     return data
 
 
@@ -76,6 +77,7 @@ def box_in_another_location_with_qr_code_data():
     data["id"] = 8
     data["label_identifier"] = "78901234"
     data["location"] = another_location_data()["id"]
+    data["product"] = product_data()[1]["id"]
     data["qr_code"] = another_qr_code_with_box_data()["id"]
     return data
 

--- a/back/test/data/shipment_detail.py
+++ b/back/test/data/shipment_detail.py
@@ -3,6 +3,7 @@ from boxtribute_server.models.definitions.shipment_detail import ShipmentDetail
 from boxtribute_server.models.utils import utcnow
 
 from .box import (
+    another_box_data,
     another_in_transit_box_data,
     another_marked_for_shipment_box_data,
     default_box_data,
@@ -17,6 +18,7 @@ TIME = utcnow().replace(tzinfo=None)
 def data():
     shipments = shipment_data()
     default_box = default_box_data()
+    box_in_another_location = another_box_data()
     in_transit_box = in_transit_box_data()
     another_in_transit_box = another_in_transit_box_data()
     shippable_box = another_marked_for_shipment_box_data()
@@ -72,6 +74,19 @@ def data():
             "created_by": default_user_data()["id"],
             "removed_on": TIME,
             "removed_by": second_user_data()["id"],
+        },
+        {
+            "id": 5,
+            "shipment": shipments[2]["id"],  # another shipment
+            "box": box_in_another_location["id"],
+            "source_product": box_in_another_location["product"],
+            "source_location": box_in_another_location["location"],
+            "source_size": box_in_another_location["size"],
+            "source_quantity": box_in_another_location["number_of_items"],
+            "created_on": TIME,
+            "created_by": default_user_data()["id"],
+            "removed_on": None,
+            "removed_by": None,
         },
     ]
 

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -76,7 +76,7 @@ def test_invalid_pagination_input(read_only_client):
     [
         # Test case 9.1.5
         "beneficiary",
-        # Test case 8.1.11
+        # Test case 8.1.15
         "location",
         # Test case 8.1.22
         "product",

--- a/back/test/endpoint_tests/test_classic_location.py
+++ b/back/test/endpoint_tests/test_classic_location.py
@@ -9,7 +9,7 @@ def test_location_query(
     default_location_boxes,
     distribution_spot,
 ):
-    # Test case 8.1.6, 8.1.10
+    # Test case 8.1.6, 8.1.14
     query = f"""query {{
                 location(id: "{default_location['id']}") {{
                     id
@@ -46,7 +46,7 @@ def test_location_query(
 
 
 def test_locations_query(read_only_client, base1_classic_locations):
-    # Test case 8.1.9
+    # Test case 8.1.13
     query = """query { locations { name } }"""
     locations = assert_successful_request(read_only_client, query)
     assert locations == [{"name": loc["name"]} for loc in base1_classic_locations]

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -387,7 +387,7 @@ def test_invalid_permission_for_shipment_base(read_only_client, mocker, field):
     assert_forbidden_request(read_only_client, query)
 
 
-@pytest.mark.parametrize("field", ["location", "qrCode", "tags"])
+@pytest.mark.parametrize("field", ["qrCode", "tags"])
 def test_invalid_permission_for_box_field(read_only_client, mocker, default_box, field):
     # Test case 8.1.9
     # verify missing field:read permission

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -10,7 +10,7 @@ from utils import assert_forbidden_request, assert_successful_request
         "base",
         # Test cases 9.1.6, 9.1.7
         "beneficiary",
-        # Test cases 8.1.12, 8.1.13
+        # Test cases 8.1.16, 8.1.17
         "location",
         # Test cases 99.1.9b, 99.1.9c
         "organisation",
@@ -75,7 +75,7 @@ def test_invalid_permission(unauthorized, read_only_client, query):
     [
         # Test case 99.1.5
         """base( id: 2 ) { id }""",
-        # Test case 8.1.14
+        # Test case 8.1.18
         """location( id: 2 ) { id }""",  # ID of another_location fixture
         # Test case 4.1.5
         """tag( id: 4 ) { id }""",
@@ -262,7 +262,7 @@ def test_invalid_permission_when_mutating_box(read_only_client, mutation):
 
 
 def test_invalid_permission_when_creating_box_with_tags(read_only_client, mocker):
-    # Test case 8.1.11
+    # Test case 8.2.11
     # Verify missing tag_relation:assign permission
     mocker.patch("jose.jwt.decode").return_value = create_jwt_payload(
         permissions=["location:read", "stock:write", "product:read"]

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -70,6 +70,37 @@ def test_shipments_query(
     ]
 
 
+def test_source_base_box_product_as_null_for_target_side(
+    read_only_client, another_shipment, another_box
+):
+    shipment_id = str(another_shipment["id"])
+    query = f"""query {{
+                shipment(id: {shipment_id}) {{
+                    details {{
+                        box {{
+                            labelIdentifier
+                            product {{ id }}
+                            location {{ id }}
+                        }}
+                        sourceProduct {{ id }}
+                        sourceLocation {{ id }}
+                    }} }} }}"""
+    shipment = assert_successful_request(read_only_client, query)
+    assert shipment == {
+        "details": [
+            {
+                "box": {
+                    "labelIdentifier": another_box["label_identifier"],
+                    "product": None,
+                    "location": None,
+                },
+                "sourceProduct": {"id": str(another_box["product"])},
+                "sourceLocation": {"id": str(another_box["location"])},
+            },
+        ]
+    }
+
+
 def test_shipment_mutations_on_source_side(
     client,
     default_bases,

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -73,6 +73,7 @@ def test_shipments_query(
 def test_source_base_box_product_as_null_for_target_side(
     read_only_client, another_shipment, another_box
 ):
+    # Test case 8.1.12a, 8.1.12b
     shipment_id = str(another_shipment["id"])
     query = f"""query {{
                 shipment(id: {shipment_id}) {{


### PR DESCRIPTION
New behavior: If I access an InTransit or Receiving box, and I'm member of either source or target base of the corresponding shipment, 
- no authz error is thrown, and
- `Box.product` and `Box.location` return null if the box is still registered in the opposite base. I have to use `ShipmentDetail.source/targetProduct/Location` instead