### PR TITLE
Update history table during shipment (box state)

### DIFF
--- a/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
@@ -201,7 +201,9 @@ def start_receiving_shipment(*, id, user):
     boxes = [
         detail.box
         for detail in _retrieve_shipment_details(
-            id, Box.state == BoxState.InTransit, ShipmentDetail.removed_on.is_null()
+            id,
+            Box.state == BoxState.InTransit,
+            ShipmentDetail.removed_on.is_null(),
         )
     ]
 

--- a/back/test/data/history.py
+++ b/back/test/data/history.py
@@ -1,16 +1,28 @@
 import pytest
 from boxtribute_server.models.definitions.history import DbChangeHistory
 
-
-def default_history_data():
-    mock_history = {"id": 112, "changes": "Changes"}
-    return mock_history
+from .box import another_marked_for_shipment_box_data
 
 
-@pytest.fixture()
+def data():
+    return [
+        {
+            # corresponding box was added to a shipment
+            "id": 1,
+            "changes": "box_state_id",
+            "from_int": 1,
+            "to_int": 3,
+            "record_id": another_marked_for_shipment_box_data()["id"],
+            "table_name": "stock",
+        },
+        {"id": 112, "changes": "Changes"},
+    ]
+
+
+@pytest.fixture
 def default_history():
-    return default_history_data()
+    return data()[1]
 
 
 def create():
-    DbChangeHistory.create(**default_history_data())
+    DbChangeHistory.insert_many(data()).execute()

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -273,7 +273,7 @@ def test_box_mutations(
         .dicts()
     )
     box_id = int(updated_box["id"])
-    assert history[1:] == [
+    assert history[2:] == [
         {
             "changes": "Record created",
             "from_int": None,


### PR DESCRIPTION
- Create list when querying shipment details instead of appending
- Update history test data
- New function for bulk updating box state during shipments and tracking the change
