### PR TITLE
prevent creating identical agreements

### DIFF
--- a/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
@@ -227,6 +227,7 @@ def reject_transfer_agreement(*, id, user):
 def cancel_transfer_agreement(*, id, user_id):
     """Transition state of specified transfer agreement to 'Canceled'.
     Raise error if agreement state different from 'UnderReview'/'Accepted'.
+    Any shipments derived from the agreement are not affected.
     """
     agreement = TransferAgreement.get_by_id(id)
     if agreement.state not in [

--- a/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
@@ -197,6 +197,13 @@ def create_transfer_agreement(
         source_base_ids = initiating_organisation_base_ids
         target_base_ids = partner_organisation_base_ids
 
+    _validate_bases_as_part_of_organisation(
+        base_ids=source_base_ids, organisation_id=source_organisation_id
+    )
+    _validate_bases_as_part_of_organisation(
+        base_ids=target_base_ids, organisation_id=target_organisation_id
+    )
+
     with db.database.atomic():
         transfer_agreement = TransferAgreement.create(
             source_organisation=source_organisation_id,
@@ -206,13 +213,6 @@ def create_transfer_agreement(
             valid_until=valid_until,
             requested_by=user.id,
             comment=comment,
-        )
-
-        _validate_bases_as_part_of_organisation(
-            base_ids=source_base_ids, organisation_id=source_organisation_id
-        )
-        _validate_bases_as_part_of_organisation(
-            base_ids=target_base_ids, organisation_id=target_organisation_id
         )
 
         # Build all combinations of source and target organisation bases under current

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -118,6 +118,14 @@ class InvalidTransferAgreementDates(Exception):
     }
 
 
+class DuplicateTransferAgreement(Exception):
+    def __init__(self, *args, agreement_id, **kwargs):
+        self.extensions = {
+            "code": "BAD_USER_INPUT",
+            "description": f"An identical agreement already exists: ID {agreement_id}",
+        }
+
+
 class InvalidShipmentState(_InvalidResourceState):
     def __init__(self, *args, expected_states, actual_state, **kwargs):
         super().__init__(

--- a/back/test/data/transfer_agreement.py
+++ b/back/test/data/transfer_agreement.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from boxtribute_server.enums import TransferAgreementState, TransferAgreementType
 from boxtribute_server.models.definitions.transfer_agreement import TransferAgreement
@@ -20,6 +22,7 @@ def data():
             "requested_by": default_user_data()["id"],
             "requested_on": TIME,
             "valid_from": TIME,
+            "valid_until": None,
             "comment": "looks good to me",
         },
         {
@@ -53,6 +56,16 @@ def data():
             "state": TransferAgreementState.UnderReview,
             "type": TransferAgreementType.ReceivingFrom,
             "requested_by": default_user_data()["id"],
+        },
+        {
+            "id": 6,
+            "source_organisation": organisation_data()[0]["id"],
+            "target_organisation": organisation_data()[1]["id"],
+            "state": TransferAgreementState.Accepted,
+            "type": TransferAgreementType.Bidirectional,
+            "requested_by": default_user_data()["id"],
+            "valid_from": datetime(2021, 1, 1),
+            "valid_until": datetime(2024, 12, 31),
         },
     ]
 

--- a/back/test/data/transfer_agreement_detail.py
+++ b/back/test/data/transfer_agreement_detail.py
@@ -45,6 +45,12 @@ def data():
             "source_base": base_data()[2]["id"],
             "target_base": base_data()[1]["id"],
         },
+        {
+            "id": 7,
+            "transfer_agreement": transfer_agreement_data()[5]["id"],
+            "source_base": base_data()[1]["id"],
+            "target_base": base_data()[3]["id"],
+        },
     ]
 
 

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -188,6 +188,14 @@ def test_transfer_agreement_mutations(
         "shipments": [],
     }
 
+    # Test case 2.2.22
+    creation_input = f"""partnerOrganisationId: {another_organisation['id']},
+        initiatingOrganisationId: {default_organisation['id']}
+        initiatingOrganisationBaseIds: [1]
+        partnerOrganisationBaseIds: [3]
+        type: {TransferAgreementType.Bidirectional.name}"""
+    assert_bad_user_input(client, _create_mutation(creation_input))
+
     mock_user_for_request(mocker, base_ids=[3, 4], organisation_id=2, user_id=2)
     # Test case 2.2.3
     mutation = f"""mutation {{ acceptTransferAgreement(id: {first_agreement_id}) {{

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -205,6 +205,18 @@ def test_transfer_agreement_mutations(
         validUntil: "{valid_until}" """
     assert_bad_user_input(client, _create_mutation(creation_input))
 
+    mock_user_for_request(mocker, base_ids=[2], organisation_id=1, user_id=3)
+    valid_from = "2021-12-20"
+    valid_until = "2022-06-20"
+    creation_input = f"""partnerOrganisationId: {another_organisation['id']},
+        initiatingOrganisationId: {default_organisation['id']}
+        initiatingOrganisationBaseIds: [2]
+        partnerOrganisationBaseIds: [4]
+        type: {TransferAgreementType.Bidirectional.name}
+        validFrom: "{valid_from}"
+        validUntil: "{valid_until}" """
+    assert_bad_user_input(client, _create_mutation(creation_input))
+
     mock_user_for_request(mocker, base_ids=[3, 4], organisation_id=2, user_id=2)
     # Test case 2.2.3
     mutation = f"""mutation {{ acceptTransferAgreement(id: {first_agreement_id}) {{

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -196,6 +196,15 @@ def test_transfer_agreement_mutations(
         type: {TransferAgreementType.Bidirectional.name}"""
     assert_bad_user_input(client, _create_mutation(creation_input))
 
+    valid_until = "2022-06-25"
+    creation_input = f"""partnerOrganisationId: {another_organisation['id']},
+        initiatingOrganisationId: {default_organisation['id']}
+        initiatingOrganisationBaseIds: [1]
+        partnerOrganisationBaseIds: [3]
+        type: {TransferAgreementType.Bidirectional.name}
+        validUntil: "{valid_until}" """
+    assert_bad_user_input(client, _create_mutation(creation_input))
+
     mock_user_for_request(mocker, base_ids=[3, 4], organisation_id=2, user_id=2)
     # Test case 2.2.3
     mutation = f"""mutation {{ acceptTransferAgreement(id: {first_agreement_id}) {{

--- a/back/test/integration_tests/test_operations.py
+++ b/back/test/integration_tests/test_operations.py
@@ -83,7 +83,7 @@ def test_mutations(auth0_client):
 
     mutation = """mutation { createTransferAgreement(creationInput: {
                     initiatingOrganisationId: 1,
-                    partnerOrganisationId: 2,
+                    partnerOrganisationId: 100000000,
                     initiatingOrganisationBaseIds: [1]
                     type: Bidirectional
                 }) { id type } }"""


### PR DESCRIPTION
When creating an agreement, now it is first checked whether an identical accepted agreement exists, i.e. same set of organisations and same (sub)set of bases involved, and overlapping validity periods. If so, the GraphQL response contains an error with `BAD_USER_INPUT` code.
