### PR TITLE
use timezone from user jwt

### DIFF
--- a/back/boxtribute_server/auth.py
+++ b/back/boxtribute_server/auth.py
@@ -125,6 +125,7 @@ class CurrentUser:
         is_god=False,
         base_ids=None,
         beta_feature_scope=None,
+        timezone=None,
     ):
         """The `base_ids` field is a mapping of a permission name to a list of base IDs
         that the permission is granted for. However it is never exposed directly to
@@ -136,6 +137,7 @@ class CurrentUser:
         self._is_god = is_god
         self._base_ids = base_ids or {}
         self._beta_feature_scope = beta_feature_scope or 0
+        self._timezone = timezone
 
     @classmethod
     def from_jwt(cls, payload):
@@ -199,6 +201,7 @@ class CurrentUser:
             organisation_id=payload[f"{JWT_CLAIM_PREFIX}/organisation_id"],
             beta_feature_scope=payload.get(f"{JWT_CLAIM_PREFIX}/beta_user"),
             id=int(payload["sub"].replace("auth0|", "")),
+            timezone=payload.get(f"{JWT_CLAIM_PREFIX}/timezone"),
             is_god=is_god,
             base_ids=base_ids,
         )
@@ -221,6 +224,10 @@ class CurrentUser:
     @property
     def is_god(self):
         return self._is_god
+
+    @property
+    def timezone(self):
+        return self._timezone
 
 
 def requires_auth(f):

--- a/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
@@ -1,7 +1,7 @@
+import zoneinfo
 from datetime import datetime, time
 from datetime import timezone as dtimezone
 
-from dateutil import tz
 from peewee import fn
 
 from ....db import db
@@ -102,7 +102,7 @@ def _convert_dates_to_utc_datetimes(valid_from, valid_until, timezone):
     midnight. Let valid_from default to current UTC time.
     Return converted datetimes (UTC but without timezone information) as tuple.
     """
-    tzinfo = tz.gettz(timezone)
+    tzinfo = zoneinfo.ZoneInfo(timezone)
     if valid_from is not None:
         valid_from = (
             datetime.combine(valid_from, time(), tzinfo=tzinfo)

--- a/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
@@ -131,7 +131,6 @@ def create_transfer_agreement(
     partner_organisation_base_ids=None,
     valid_from=None,
     valid_until=None,
-    timezone=None,
     comment=None,
     user,
 ):
@@ -140,7 +139,7 @@ def create_transfer_agreement(
     the agreement is established between all bases of both organisations (indicated by
     NULL for the Detail.source/target_base field). As a result, any base that added to
     an organisation in the future would be part of such an agreement.
-    Convert optional local dates into UTC datetimes using timezone information.
+    Convert optional local dates into UTC datetimes using user timezone information.
     Raise an InvalidTransferAgreementOrganisation exception if the current user's
     organisation is identical to the target organisation.
     Raise a DuplicateTransferAgreement exception if the agreement requested to be
@@ -154,7 +153,7 @@ def create_transfer_agreement(
         raise InvalidTransferAgreementOrganisation()
 
     valid_from, valid_until = _convert_dates_to_utc_datetimes(
-        valid_from, valid_until, timezone
+        valid_from, valid_until, user.timezone
     )
 
     if valid_until and valid_from.date() >= valid_until.date():

--- a/back/boxtribute_server/graph_ql/definitions/protected/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/inputs.graphql
@@ -61,10 +61,9 @@ input TransferAgreementCreationInput {
   initiatingOrganisationId: Int!
   partnerOrganisationId: Int!
   type: TransferAgreementType!
-  # pass local date and timezone information (e.g. 'Europe/Berlin')
+  # pass local date
   validFrom: Date
   validUntil: Date
-  timezone: String
   initiatingOrganisationBaseIds: [Int!]!
   partnerOrganisationBaseIds: [Int!]
   comment: String

--- a/back/boxtribute_server/graph_ql/scalars.py
+++ b/back/boxtribute_server/graph_ql/scalars.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timezone
 
-import dateutil.parser
 from ariadne import ScalarType
 
 datetime_scalar = ScalarType("Datetime")
@@ -25,5 +24,6 @@ def parse_date(value):
 
 @datetime_scalar.value_parser
 def parse_datetime(value):
-    # return datetime.from strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
-    return dateutil.parser.isoparse(value)
+    # Datetime string must be of format '2022-08-30T14:00:00'.
+    # With Python 3.11 more formats will be supported
+    return datetime.fromisoformat(value)

--- a/back/requirements-dev.txt
+++ b/back/requirements-dev.txt
@@ -9,5 +9,4 @@ pytest-clarity==1.0.1
 mypy==1.5.0
 types-Flask-Cors==4.0.0.1
 types-peewee==3.16.0.2
-types-python-dateutil==2.8.19.14
 types-python-jose==3.3.4.8

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -5,7 +5,6 @@ sentry-sdk[flask]==1.29.2
 PyMySQL==1.1.0
 peewee==3.16.3
 peewee-moves==2.1.0
-python-dateutil==2.8.2
 python-dotenv==1.0.0
 python-jose==3.3.0
 aiodataloader==0.4.0

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -62,6 +62,7 @@ def _create_jwt_payload(
     roles=("Coordinator",),
     user_id=8,
     permissions=None,
+    timezone="Europe/London",
 ):
     """Create payload containing arbitrary authorization information of a user.
     The payload field names are identical to the actual ones in the JWT returned by
@@ -79,6 +80,7 @@ def _create_jwt_payload(
         f"{JWT_CLAIM_PREFIX}/organisation_id": organisation_id,
         f"{JWT_CLAIM_PREFIX}/base_ids": list(base_ids),
         f"{JWT_CLAIM_PREFIX}/roles": roles,
+        f"{JWT_CLAIM_PREFIX}/timezone": timezone,
         "sub": f"auth0|{user_id}",
     }
 

--- a/back/test/endpoint_tests/test_distribution_event_tracking_group.py
+++ b/back/test/endpoint_tests/test_distribution_event_tracking_group.py
@@ -88,8 +88,8 @@ def test_distribution_event_tracking_group_statistics(
         creationInput: {{
           distributionSpotId: {distribution_spot_1['id']}
           name: "Test Event"
-          plannedStartDateTime: "2022-08-30T14:00:00.023Z"
-          plannedEndDateTime: "2022-08-30T16:00:00.023Z"
+          plannedStartDateTime: "2022-08-30T14:00:00"
+          plannedEndDateTime: "2022-08-30T16:00:00"
         }}
       ) {{
         id
@@ -166,8 +166,8 @@ def test_distribution_event_tracking_group_statistics(
         creationInput: {{
           distributionSpotId: {distribution_spot_2['id']}
           name: "Test Event"
-          plannedStartDateTime: "2022-08-30T14:00:00.023Z"
-          plannedEndDateTime: "2022-08-30T16:00:00.023Z"
+          plannedStartDateTime: "2022-08-30T14:00:00"
+          plannedEndDateTime: "2022-08-30T16:00:00"
         }}
       ) {{
         id

--- a/back/test/endpoint_tests/test_transfer_agreement.py
+++ b/back/test/endpoint_tests/test_transfer_agreement.py
@@ -149,7 +149,6 @@ def test_transfer_agreement_mutations(
         validFrom: "{valid_from}",
         validUntil: "{valid_until}",
         comment: "{comment}",
-        timezone: "Europe/London",
         initiatingOrganisationBaseIds: [1],
         partnerOrganisationBaseIds: [3, 4]"""
     agreement = assert_successful_request(client, _create_mutation(creation_input))

--- a/back/test/unit_tests/test_authz.py
+++ b/back/test/unit_tests/test_authz.py
@@ -75,6 +75,7 @@ def test_authorized_user():
             "location:write": [4, 5],
             "product:read": [1],
         },
+        timezone="Europe/London",
     )
     assert authorize(user, permission="qr:create")
     assert authorize(user, permission="qr:create", base_id=3)
@@ -84,6 +85,7 @@ def test_authorized_user():
     assert authorize(user, permission="location:write", base_ids=[3, 4])
     assert authorize(user, permission="location:write", base_ids=[4, 5])
     assert authorize(user, permission="location:write", base_ids=[5, 6])
+    assert user.timezone == "Europe/London"
 
     # This is called in authorized_bases_filter for model=Product
     assert _authorize(user, permission="product:read", ignore_missing_base_info=True)
@@ -175,6 +177,7 @@ def test_user_with_multiple_roles():
         f"{JWT_CLAIM_PREFIX}/organisation_id": 1,
         f"{JWT_CLAIM_PREFIX}/base_ids": [2],
         f"{JWT_CLAIM_PREFIX}/permissions": [permission, f"base_1/{permission}"],
+        f"{JWT_CLAIM_PREFIX}/timezone": "Europe/Berlin",
         "sub": "auth0|42",
     }
     user = CurrentUser.from_jwt(payload)

--- a/docs/adr/adr_authorization-specification.md
+++ b/docs/adr/adr_authorization-specification.md
@@ -158,6 +158,7 @@ The current user is programmatically represented by the `auth.CurrentUser` class
 - `organisation_id`: ID of the organisation that the user belongs to. If the user is a god user, it is `None`
 - `is_god`: whether the user is god user or not (default: false)
 - `_base_ids`: a data structure indicating the bases in which the user is allowed to access specific resources. This structure has to be queried via the `CurrentUser.authorized_base_ids()` method, passing in an RBP name.
+- `timezone`: timezone identifier determined by Auth0, e.g. "Europe/Berlin"
 
 The decoded JWT payload is converted into a `CurrentUser` instance with the following procedure:
 

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -1461,7 +1461,6 @@ export type TransferAgreementCreationInput = {
   initiatingOrganisationId: Scalars['Int'];
   partnerOrganisationBaseIds?: InputMaybe<Array<Scalars['Int']>>;
   partnerOrganisationId: Scalars['Int'];
-  timezone?: InputMaybe<Scalars['String']>;
   type: TransferAgreementType;
   validFrom?: InputMaybe<Scalars['Date']>;
   validUntil?: InputMaybe<Scalars['Date']>;
@@ -1935,7 +1934,6 @@ export type CreateTransferAgreementMutationVariables = Exact<{
   type: TransferAgreementType;
   validFrom?: InputMaybe<Scalars['Date']>;
   validUntil?: InputMaybe<Scalars['Date']>;
-  timezone?: InputMaybe<Scalars['String']>;
   initiatingOrganisationBaseIds: Array<Scalars['Int']> | Scalars['Int'];
   partnerOrganisationBaseIds?: InputMaybe<Array<Scalars['Int']> | Scalars['Int']>;
   comment?: InputMaybe<Scalars['String']>;

--- a/react/src/views/Transfers/CreateTransferAgreement/CreateTransferAgreementView.tsx
+++ b/react/src/views/Transfers/CreateTransferAgreement/CreateTransferAgreementView.tsx
@@ -40,7 +40,6 @@ export const CREATE_AGREEMENT_MUTATION = gql`
     $type: TransferAgreementType!
     $validFrom: Date
     $validUntil: Date
-    $timezone: String
     $initiatingOrganisationBaseIds: [Int!]!
     $partnerOrganisationBaseIds: [Int!]
     $comment: String
@@ -52,7 +51,6 @@ export const CREATE_AGREEMENT_MUTATION = gql`
         type: $type
         validFrom: $validFrom
         validUntil: $validUntil
-        timezone: $timezone
         initiatingOrganisationBaseIds: $initiatingOrganisationBaseIds
         partnerOrganisationBaseIds: $partnerOrganisationBaseIds
         comment: $comment


### PR DESCRIPTION
Timezone info is needed for the validity times input when creating an agreement. This PR pulls the info from the user JWT (put there by Auth0), and also drops a Python package dependency.
