### PR TITLE
GraphQL query for createdBoxes

### DIFF
--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -77,4 +77,16 @@ def compute_created_boxes():
         row["gender"] = ProductGender(row["gender"])
         row["created_on"] = row["created_on"].date()
 
-    return facts
+    products_ids = {f["product_id"] for f in facts}
+    dimensions = {
+        "product": list(
+            Product.select(Product.id, Product.name)
+            .where(Product.id << products_ids)
+            .dicts()
+        ),
+        "category": list(
+            ProductCategory.select(ProductCategory.id, ProductCategory.name).dicts()
+        ),
+    }
+
+    return {"facts": facts, "dimensions": dimensions}

--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -3,8 +3,12 @@ from datetime import date
 from peewee import SQL, fn
 
 from ...db import db
-from ...enums import HumanGender
+from ...enums import HumanGender, ProductGender
 from ...models.definitions.beneficiary import Beneficiary
+from ...models.definitions.box import Box
+from ...models.definitions.history import DbChangeHistory
+from ...models.definitions.product import Product
+from ...models.definitions.product_category import ProductCategory
 
 
 def compute_beneficiary_demographics(base_ids=None):
@@ -40,3 +44,37 @@ def compute_beneficiary_demographics(base_ids=None):
         row["created_on"] = row["created_on"].date()
 
     return demographics
+
+
+def compute_created_boxes():
+    """For each combination of product ID, category ID, gender, and day-truncated
+    creation date count the number of created boxes, and the contained items.
+    Return fact and dimension tables in the result.
+    """
+    facts = (
+        DbChangeHistory.select(
+            Product.id.alias("product_id"),
+            Product.gender.alias("gender"),
+            ProductCategory.id.alias("category_id"),
+            DbChangeHistory.change_date.alias("created_on"),
+            fn.COUNT(Box.id).alias("boxes_count"),
+        )
+        .join(Box, on=(DbChangeHistory.record_id == Box.id))
+        .join(Product)
+        .join(ProductCategory)
+        .where(
+            DbChangeHistory.table_name == "stock",
+            DbChangeHistory.changes == "Record created",
+        )
+        .group_by(
+            SQL("product_id"), SQL("category_id"), SQL("gender"), SQL("created_on")
+        )
+        .dicts()
+    )
+
+    # Conversions for GraphQL interface
+    for row in facts:
+        row["gender"] = ProductGender(row["gender"])
+        row["created_on"] = row["created_on"].date()
+
+    return facts

--- a/back/boxtribute_server/business_logic/statistics/queries.py
+++ b/back/boxtribute_server/business_logic/statistics/queries.py
@@ -11,5 +11,5 @@ def resolve_beneficiary_demographics(*_, base_ids=None):
 
 
 @query.field("createdBoxes")
-def resolve_created_boxes(*_):
-    return compute_created_boxes()
+def resolve_created_boxes(*_, base_id=None):
+    return compute_created_boxes(base_id)

--- a/back/boxtribute_server/business_logic/statistics/queries.py
+++ b/back/boxtribute_server/business_logic/statistics/queries.py
@@ -1,6 +1,6 @@
 from ariadne import QueryType
 
-from .crud import compute_beneficiary_demographics
+from .crud import compute_beneficiary_demographics, compute_created_boxes
 
 query = QueryType()
 
@@ -8,3 +8,8 @@ query = QueryType()
 @query.field("beneficiaryDemographics")
 def resolve_beneficiary_demographics(*_, base_ids=None):
     return compute_beneficiary_demographics(base_ids)
+
+
+@query.field("createdBoxes")
+def resolve_created_boxes(*_):
+    return compute_created_boxes()

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -28,7 +28,7 @@ def format_database_errors(error, debug=False):
             error.extensions = {}
         from flask import g
 
-        error.extensions["user"] = g.user.__dict__
+        error.extensions["user"] = g.user.__dict__ if hasattr(g, "user") else {}
 
     return error.formatted
 

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -1,6 +1,6 @@
 type Query {
   beneficiaryDemographics(baseIds: [Int!]): [BeneficiaryDemographicsResult]
-  createdBoxes: CreatedBoxesData
+  createdBoxes(baseId: Int): CreatedBoxesData
 }
 
 type BeneficiaryDemographicsResult {

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -1,5 +1,6 @@
 type Query {
   beneficiaryDemographics(baseIds: [Int!]): [BeneficiaryDemographicsResult]
+  createdBoxes: [CreatedBoxesResult]
 }
 
 type BeneficiaryDemographicsResult {
@@ -9,3 +10,11 @@ type BeneficiaryDemographicsResult {
   count: Int
 }
 
+type CreatedBoxesResult {
+  createdOn: Date
+  categoryId: Int
+  productId: Int
+  gender: ProductGender
+  boxesCount: Int
+  itemsCount: Int
+}

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -1,6 +1,6 @@
 type Query {
   beneficiaryDemographics(baseIds: [Int!]): [BeneficiaryDemographicsResult]
-  createdBoxes: [CreatedBoxesResult]
+  createdBoxes: CreatedBoxesData
 }
 
 type BeneficiaryDemographicsResult {
@@ -10,6 +10,11 @@ type BeneficiaryDemographicsResult {
   count: Int
 }
 
+type CreatedBoxesData {
+  facts: [CreatedBoxesResult]
+  dimensions: CreatedBoxDataDimensions
+}
+
 type CreatedBoxesResult {
   createdOn: Date
   categoryId: Int
@@ -17,4 +22,14 @@ type CreatedBoxesResult {
   gender: ProductGender
   boxesCount: Int
   itemsCount: Int
+}
+
+type CreatedBoxDataDimensions {
+  product: [ResultIdName]
+  category: [ResultIdName]
+}
+
+type ResultIdName {
+  id: ID
+  name: String
 }

--- a/back/boxtribute_server/graph_ql/schema.py
+++ b/back/boxtribute_server/graph_ql/schema.py
@@ -9,7 +9,7 @@ from .bindables import (
     union_types,
 )
 from .definitions import definitions, public_api_definitions, query_api_definitions
-from .enums import HumanGender, enum_types
+from .enums import enum_types
 from .scalars import date_scalar, datetime_scalar
 
 full_api_schema = make_executable_schema(
@@ -45,6 +45,6 @@ public_api_schema = make_executable_schema(
     public_api_definitions,
     date_scalar,
     statistics_query,
-    HumanGender,
+    *enum_types,
     convert_names_case=True,
 )

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -51,7 +51,7 @@ from .product import (
     default_product,
     products,
 )
-from .product_category import default_product_category
+from .product_category import default_product_category, product_categories
 from .product_gender import default_product_gender
 from .qr_code import another_qr_code_with_box, default_qr_code, qr_code_without_box
 from .shipment import (
@@ -141,6 +141,7 @@ __all__ = [
     "organisations",
     "packing_list_entry",
     "prepared_shipment_detail",
+    "product_categories",
     "products",
     "qr_code_without_box",
     "receiving_transfer_agreement",

--- a/back/test/data/history.py
+++ b/back/test/data/history.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 import pytest
 from boxtribute_server.models.definitions.history import DbChangeHistory
 
 from .box import another_marked_for_shipment_box_data
+from .box import data as box_data
 
 
 def data():
@@ -13,9 +16,19 @@ def data():
             "from_int": 1,
             "to_int": 3,
             "record_id": another_marked_for_shipment_box_data()["id"],
+            "change_date": datetime(2023, 6, 21),
             "table_name": "stock",
         },
         {"id": 112, "changes": "Changes"},
+    ] + [
+        {
+            "id": i,
+            "changes": "Record created",
+            "record_id": box["id"],
+            "change_date": box["created_on"],
+            "table_name": "stock",
+        }
+        for i, box in enumerate(box_data(), start=2)
     ]
 
 

--- a/back/test/data/product_category.py
+++ b/back/test/data/product_category.py
@@ -4,6 +4,8 @@ from boxtribute_server.models.definitions.product_category import ProductCategor
 
 def data():
     return [
+        # Categories that serve as parents must be listed first such that foreign key
+        # constraints function at the time of insertion
         {"id": 12, "name": "Clothing", "parent": None},
         {"id": 13, "name": "Equipment", "parent": None},
         {"id": 1, "name": "Underwear / Nightwear", "parent": 12},
@@ -16,9 +18,14 @@ def default_product_category_data():
     return data()[2]
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_product_category():
     return default_product_category_data()
+
+
+@pytest.fixture
+def product_categories():
+    return data()
 
 
 def create():

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -273,7 +273,7 @@ def test_box_mutations(
         .dicts()
     )
     box_id = int(updated_box["id"])
-    assert history[2:] == [
+    assert history[11:] == [
         {
             "changes": "Record created",
             "from_int": None,

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -227,7 +227,8 @@ def test_shipment_mutations_on_source_side(
                     "state": BoxState.MarkedForShipment.name,
                     "shipmentDetail": {"id": prepared_shipment_detail_id},
                     "history": [
-                        {"changes": f"{change_prefix} InStock to MarkedForShipment"}
+                        {"changes": "created record"},
+                        {"changes": f"{change_prefix} InStock to MarkedForShipment"},
                     ],
                 },
                 "sourceProduct": {
@@ -253,7 +254,8 @@ def test_shipment_mutations_on_source_side(
                     "state": BoxState.MarkedForShipment.name,
                     "shipmentDetail": {"id": shipment_detail_id},
                     "history": [
-                        {"changes": f"{change_prefix} InStock to MarkedForShipment"}
+                        {"changes": f"{change_prefix} InStock to MarkedForShipment"},
+                        {"changes": "created record"},
                     ],
                 },
                 "sourceProduct": {"id": str(default_box["product"])},
@@ -311,6 +313,8 @@ def test_shipment_mutations_on_source_side(
     shipment = assert_successful_request(client, mutation)
     assert shipment["details"][0].pop("removedOn").startswith(date.today().isoformat())
     assert shipment["details"][1].pop("removedOn").startswith(date.today().isoformat())
+    assert len(shipment["details"][0]["box"].pop("history")) == 3
+    assert len(shipment["details"][1]["box"].pop("history")) == 3
     assert shipment == {
         "id": shipment_id,
         "state": ShipmentState.Preparing.name,
@@ -318,13 +322,7 @@ def test_shipment_mutations_on_source_side(
             {
                 "id": i,
                 "removedBy": {"id": "8"},
-                "box": {
-                    "state": BoxState.InStock.name,
-                    "history": [
-                        {"changes": f"{change_prefix} MarkedForShipment to InStock"},
-                        {"changes": f"{change_prefix} InStock to MarkedForShipment"},
-                    ],
-                },
+                "box": {"state": BoxState.InStock.name},
             }
             for i in [prepared_shipment_detail_id, shipment_detail_id]
         ],
@@ -421,6 +419,7 @@ def test_shipment_mutations_on_source_side(
                     "state": BoxState.InStock.name,
                     "history": [
                         {"changes": f"{change_prefix} MarkedForShipment to InStock"},
+                        {"changes": "created record"},
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
                     ],
                 },
@@ -434,6 +433,7 @@ def test_shipment_mutations_on_source_side(
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
                         {"changes": f"{change_prefix} MarkedForShipment to InStock"},
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
+                        {"changes": "created record"},
                     ],
                 },
             },
@@ -446,6 +446,7 @@ def test_shipment_mutations_on_source_side(
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
                         {"changes": f"{change_prefix} MarkedForShipment to InStock"},
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
+                        {"changes": "created record"},
                     ],
                 },
             },
@@ -490,6 +491,7 @@ def test_shipment_mutations_cancel(
                     "state": BoxState.InStock.name,
                     "history": [
                         {"changes": f"{change_prefix} MarkedForShipment to InStock"},
+                        {"changes": "created record"},
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
                     ],
                 },
@@ -624,19 +626,28 @@ def test_shipment_mutations_on_target_side(
                 "id": detail_id,
                 "box": {
                     "state": BoxState.Receiving.name,
-                    "history": [{"changes": f"{change_prefix} InTransit to Receiving"}],
+                    "history": [
+                        {"changes": f"{change_prefix} InTransit to Receiving"},
+                        {"changes": "created record"},
+                    ],
                 },
             },
             {
                 "id": another_detail_id,
                 "box": {
                     "state": BoxState.Receiving.name,
-                    "history": [{"changes": f"{change_prefix} InTransit to Receiving"}],
+                    "history": [
+                        {"changes": f"{change_prefix} InTransit to Receiving"},
+                        {"changes": "created record"},
+                    ],
                 },
             },
             {
                 "id": removed_detail_id,
-                "box": {"state": BoxState.InStock.name, "history": []},
+                "box": {
+                    "state": BoxState.InStock.name,
+                    "history": [{"changes": "created record"}],
+                },
             },
         ],
     }
@@ -683,6 +694,7 @@ def test_shipment_mutations_on_target_side(
                             + f"to {another_product['name']}"
                         },
                         {"changes": f"{change_prefix} InTransit to Receiving"},
+                        {"changes": "created record"},
                     ],
                 },
                 "sourceProduct": {"id": str(default_shipment_detail["source_product"])},
@@ -698,7 +710,10 @@ def test_shipment_mutations_on_target_side(
                 "id": another_detail_id,
                 "box": {
                     "state": BoxState.Receiving.name,
-                    "history": [{"changes": f"{change_prefix} InTransit to Receiving"}],
+                    "history": [
+                        {"changes": f"{change_prefix} InTransit to Receiving"},
+                        {"changes": "created record"},
+                    ],
                 },
                 "sourceProduct": {"id": str(another_shipment_detail["source_product"])},
                 "targetProduct": None,
@@ -711,7 +726,10 @@ def test_shipment_mutations_on_target_side(
             },
             {
                 "id": removed_detail_id,
-                "box": {"state": BoxState.InStock.name, "history": []},
+                "box": {
+                    "state": BoxState.InStock.name,
+                    "history": [{"changes": "created record"}],
+                },
                 "sourceProduct": {"id": str(removed_shipment_detail["source_product"])},
                 "targetProduct": None,
                 "sourceLocation": {
@@ -799,6 +817,7 @@ def test_shipment_mutations_on_target_side(
                     "history": [
                         {"changes": f"{change_prefix} Receiving to Lost"},
                         {"changes": f"{change_prefix} InTransit to Receiving"},
+                        {"changes": "created record"},
                     ],
                 },
             },
@@ -807,7 +826,10 @@ def test_shipment_mutations_on_target_side(
                 "removedBy": {"id": "2"},
                 "lostBy": None,
                 "receivedBy": None,
-                "box": {"state": BoxState.InStock.name, "history": []},
+                "box": {
+                    "state": BoxState.InStock.name,
+                    "history": [{"changes": "created record"}],
+                },
             },
         ],
     }
@@ -875,7 +897,10 @@ def test_shipment_mutations_on_target_side_mark_shipment_as_lost(
                 "lostBy": {"id": "2"},
                 "box": {
                     "state": BoxState.Lost.name,
-                    "history": [{"changes": f"{change_prefix} InTransit to Lost"}],
+                    "history": [
+                        {"changes": f"{change_prefix} InTransit to Lost"},
+                        {"changes": "created record"},
+                    ],
                 },
             },
             {
@@ -884,14 +909,20 @@ def test_shipment_mutations_on_target_side_mark_shipment_as_lost(
                 "lostBy": {"id": "2"},
                 "box": {
                     "state": BoxState.Lost.name,
-                    "history": [{"changes": f"{change_prefix} InTransit to Lost"}],
+                    "history": [
+                        {"changes": f"{change_prefix} InTransit to Lost"},
+                        {"changes": "created record"},
+                    ],
                 },
             },
             {
                 "id": str(removed_shipment_detail["id"]),
                 "removedBy": {"id": "2"},
                 "lostBy": None,
-                "box": {"state": BoxState.InStock.name, "history": []},
+                "box": {
+                    "state": BoxState.InStock.name,
+                    "history": [{"changes": "created record"}],
+                },
             },
         ],
     }

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -25,7 +25,8 @@ def test_query_created_boxes(read_only_client, products, product_categories):
     data = assert_successful_request(read_only_client, query, endpoint="public")
     facts = data.pop("facts")
     assert len(facts) == 2
-    assert facts[0]["boxesCount"] == 2
+    assert facts[0]["boxesCount"] == 7
+    assert facts[1]["boxesCount"] == 2
     assert data == {
         "dimensions": {
             "product": [{"id": str(p["id"]), "name": p["name"]} for p in products[:2]],

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -11,3 +11,10 @@ def test_query_beneficiary_demographics(read_only_client):
         gender age createdOn count } }"""
     response = assert_successful_request(read_only_client, query, endpoint="public")
     assert len(response) == 3
+
+
+def test_query_created_boxes(read_only_client):
+    query = """query { createdBoxes {
+        createdOn categoryId productId gender boxesCount itemsCount } }"""
+    response = assert_successful_request(read_only_client, query, endpoint="public")
+    assert len(response) == 2

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -35,3 +35,7 @@ def test_query_created_boxes(read_only_client, products, product_categories):
             ],
         }
     }
+
+    query = """query { createdBoxes(baseId: 1) { facts { boxesCount } } }"""
+    data = assert_successful_request(read_only_client, query, endpoint="public")
+    assert data == {"facts": [{"boxesCount": 7}]}


### PR DESCRIPTION
This brings the new public GraphQL query `createdBoxes`.

The interface has been defined in #898.

Please verify that you can run a query like
```graphql
query { createdBoxes { facts { boxesCount } dimensions { product { id } category { id } } } }
```
without errors. In the response `facts` is expected to contain several elements; `dimensions` returns sensible data, too.

Note that the implementation is not precise with regards to possible changes in box product or item count that might have happened since creation.
