### PR TITLE
[1st viz] Add beneficiary tag IDs to demographics query

### DIFF
--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -9,6 +9,7 @@ from ...models.definitions.box import Box
 from ...models.definitions.location import Location
 from ...models.definitions.product import Product
 from ...models.definitions.product_category import ProductCategory
+from ...models.definitions.tag import Tag
 from ...models.definitions.tags_relation import TagsRelation
 from ...models.utils import convert_ids
 
@@ -55,7 +56,12 @@ def compute_beneficiary_demographics(base_ids=None):
         row["gender"] = HumanGender(row["gender"])
         row["created_on"] = row["created_on"].date()
 
-    return {"facts": demographics}
+    selected_tag_ids = {t for t in row["tag_ids"] for row in demographics}
+    dimensions = {
+        "tag": Tag.select(Tag.id, Tag.name).where(Tag.id << selected_tag_ids).dicts()
+    }
+
+    return {"facts": demographics, "dimensions": dimensions}
 
 
 def compute_created_boxes(base_id=None):

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -17,7 +17,7 @@ type BeneficiaryDemographicsResult {
   age: Int
   gender: HumanGender
   createdOn: Date
-  tagIds: String
+  tagIds: [Int!]
   count: Int
 }
 

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -17,6 +17,7 @@ type BeneficiaryDemographicsResult {
   age: Int
   gender: HumanGender
   createdOn: Date
+  tagIds: String
   count: Int
 }
 

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -5,12 +5,19 @@ type Query {
 
 interface DataCube {
   facts: [Result]
+  dimensions: Dimensions
 }
 
 union Result = BeneficiaryDemographicsResult | CreatedBoxesResult
+union Dimensions = BeneficiaryDemographicsDimensions | CreatedBoxDataDimensions
 
 type BeneficiaryDemographicsData implements DataCube {
   facts: [BeneficiaryDemographicsResult]
+  dimensions: BeneficiaryDemographicsDimensions
+}
+
+type BeneficiaryDemographicsDimensions {
+  tag: [ResultIdName]
 }
 
 type BeneficiaryDemographicsResult {

--- a/back/boxtribute_server/models/utils.py
+++ b/back/boxtribute_server/models/utils.py
@@ -16,6 +16,13 @@ def utcnow():
     return datetime.now(tz=timezone.utc).replace(microsecond=0)
 
 
+def convert_ids(concat_ids):
+    """Convert a string of comma-separated IDs (returned from GROUP_CONCAT) into a
+    list of integers.
+    """
+    return [int(i) for i in (concat_ids or "").split(",") if i]
+
+
 def save_creation_to_history(f):
     """Utility for writing information about creating a resource to the history table,
     intended to decorate a function that modifies a database resource (e.g. a box).

--- a/back/setup.cfg
+++ b/back/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
-ignore=E402,W503
+ignore=E402,E731,W503
 
 [tool:isort]
 profile = black

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -3,12 +3,12 @@ from utils import assert_successful_request
 
 def test_query_beneficiary_demographics(read_only_client):
     query = """query { beneficiaryDemographics(baseIds: [1]) {
-        facts { gender age createdOn count } } }"""
+        facts { gender age createdOn count tagIds } } }"""
     response = assert_successful_request(read_only_client, query, endpoint="public")
     assert len(response["facts"]) == 2
 
     query = """query { beneficiaryDemographics {
-        facts { gender age createdOn count } } }"""
+        facts { gender age createdOn count tagIds } } }"""
     response = assert_successful_request(read_only_client, query, endpoint="public")
     assert len(response["facts"]) == 3
 

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -1,11 +1,17 @@
 from utils import assert_successful_request
 
 
-def test_query_beneficiary_demographics(read_only_client):
+def test_query_beneficiary_demographics(read_only_client, tags):
     query = """query { beneficiaryDemographics(baseIds: [1]) {
-        facts { gender age createdOn count tagIds } } }"""
+        facts { gender age createdOn count tagIds }
+        dimensions { tag { id name } } } }"""
     response = assert_successful_request(read_only_client, query, endpoint="public")
     assert len(response["facts"]) == 2
+    assert response["dimensions"] == {
+        "tag": [
+            {"id": str(tag["id"]), "name": tag["name"]} for tag in [tags[0], tags[2]]
+        ]
+    }
 
     query = """query { beneficiaryDemographics {
         facts { gender age createdOn count tagIds } } }"""


### PR DESCRIPTION
See comment in #888 for the updated data format.

The FE can now filter for a combination of tag IDs in the result. A dimensions table is provided such that human-readable tag names can be used.
