### PR TITLE
BoxView: Make the Text for the Most Recent History Smaller 

### DIFF
--- a/react/src/views/Box/components/BoxCard.tsx
+++ b/react/src/views/Box/components/BoxCard.tsx
@@ -329,7 +329,7 @@ function BoxCard({
                 <HistoryEntries data={boxData?.history as unknown as HistoryEntry[]} total={1} />
               )}
               {isLoading && (
-                <SkeletonText noOfLines={5} width="100%" py={2} px={2} alignContent="center" />
+                <SkeletonText noOfLines={2} width="100%" py={2} px={2} alignContent="center" />
               )}
             </Flex>
           </Stack>

--- a/react/src/views/Box/components/BoxCard.tsx
+++ b/react/src/views/Box/components/BoxCard.tsx
@@ -329,7 +329,7 @@ function BoxCard({
                 <HistoryEntries data={boxData?.history as unknown as HistoryEntry[]} total={1} />
               )}
               {isLoading && (
-                <SkeletonText noOfLines={2} width="100%" py={2} px={2} alignContent="center" />
+                <SkeletonText noOfLines={3} width="100%" py={2} px={2} alignContent="center" />
               )}
             </Flex>
           </Stack>

--- a/react/src/views/Box/components/HistoryEntries.tsx
+++ b/react/src/views/Box/components/HistoryEntries.tsx
@@ -1,4 +1,4 @@
-import { ListItem, ListIcon, List, Stack, Flex } from "@chakra-ui/react";
+import { ListItem, ListIcon, List, Stack, Flex, Text, chakra, Box } from "@chakra-ui/react";
 import { IconType } from "react-icons";
 import { MdCheckCircle, MdSettings, MdHistory } from "react-icons/md";
 import { HistoryEntry } from "types/generated/graphql";
@@ -7,42 +7,66 @@ interface IHistoryEntriesProps {
   data: HistoryEntry[];
   total: number | undefined;
 }
-function HistoryEntries({ data, total }: IHistoryEntriesProps) {
-  // show different icons for changed / created records also default history for the rest
-  const getHistoryIcon = (changes: string): IconType => {
-    if (changes.includes("created")) {
-      return MdSettings;
-    }
-    if (changes.includes("changed")) {
-      return MdCheckCircle;
-    }
-    return MdHistory;
-  };
 
+function getHistoryIcon(changes: string): IconType {
+  if (changes.includes("created")) {
+    return MdSettings;
+  }
+  if (changes.includes("changed")) {
+    return MdCheckCircle;
+  }
+  return MdHistory;
+}
+
+function fixTrailingSemicolon(text: string): string {
+  return text?.endsWith(";") ? text?.slice(0, -1) : text;
+}
+
+function formatDate(date: Date): string {
+  return new Date(date).toLocaleString("en-GB", {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function HistoryEntries({ data, total }: IHistoryEntriesProps) {
   return (
-    <Stack py={2} px={2} alignContent="center">
-      <Flex alignContent="center" direction="column">
+    <Stack py={2} px={2} align="center">
+      <Flex align="center" direction="column">
         <List spacing={1}>
           {data.slice(0, total).map((historyEntry) => (
-            <ListItem key={historyEntry.id} data-testid={`history-${historyEntry.id}`}>
-              <ListIcon as={getHistoryIcon(historyEntry?.changes)} h={5} w={5} color="green.500" />
-              <b>{historyEntry?.user?.name}</b> on{" "}
-              <b>
-                {new Date(historyEntry?.changeDate).toLocaleDateString("en-GB", {
-                  weekday: "long",
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
-                ,{" "}
-                {new Date(historyEntry?.changeDate).toLocaleTimeString("en-GB", {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}{" "}
-              </b>
-              {historyEntry?.changes.endsWith(";")
-                ? historyEntry?.changes.slice(0, -1)
-                : historyEntry?.changes}
+            <ListItem
+              key={historyEntry.id}
+              data-testid={`history-${historyEntry.id}`}
+              fontSize="sm"
+              as="span"
+              display="flex"
+              alignItems="flex-start"
+            >
+              <ListIcon
+                as={getHistoryIcon(historyEntry?.changes)}
+                h={4}
+                w={4}
+                color="green.500"
+                mt={1}
+                mr={1}
+                alignSelf="flex-start"
+              />
+              <Box
+                maxWidth="300px" // Adjust the width as needed
+              >
+                <Text
+                  noOfLines={2} // Limit text to 2 lines
+                >
+                  <b>{historyEntry?.user?.name}</b> on
+                  <b>{formatDate(historyEntry?.changeDate)}</b>{" "}
+                  {fixTrailingSemicolon(historyEntry?.changes)}
+                </Text>
+              </Box>
             </ListItem>
           ))}
         </List>

--- a/react/src/views/Box/components/HistoryEntries.tsx
+++ b/react/src/views/Box/components/HistoryEntries.tsx
@@ -59,9 +59,7 @@ function HistoryEntries({ data, total }: IHistoryEntriesProps) {
               <Box
                 maxWidth="300px" // Adjust the width as needed
               >
-                <Text
-                  noOfLines={2} // Limit text to 2 lines
-                >
+                <Text>
                   <b>{historyEntry?.user?.name}</b> on
                   <b>{formatDate(historyEntry?.changeDate)}</b>{" "}
                   {fixTrailingSemicolon(historyEntry?.changes)}

--- a/react/src/views/Box/components/HistoryEntries.tsx
+++ b/react/src/views/Box/components/HistoryEntries.tsx
@@ -56,11 +56,10 @@ function HistoryEntries({ data, total }: IHistoryEntriesProps) {
                 mr={1}
                 alignSelf="flex-start"
               />
-              <Box
-                maxWidth="300px" // Adjust the width as needed
-              >
+              <Box>
                 <Text>
-                  <b>{historyEntry?.user?.name}</b> on
+                  <b>{historyEntry?.user?.name}</b>
+                  {" on "}
                   <b>{formatDate(historyEntry?.changeDate)}</b>{" "}
                   {fixTrailingSemicolon(historyEntry?.changes)}
                 </Text>

--- a/react/src/views/Box/components/HistoryEntries.tsx
+++ b/react/src/views/Box/components/HistoryEntries.tsx
@@ -1,4 +1,4 @@
-import { ListItem, ListIcon, List, Stack, Flex, Text, chakra, Box } from "@chakra-ui/react";
+import { ListItem, ListIcon, List, Stack, Flex, Text, Box } from "@chakra-ui/react";
 import { IconType } from "react-icons";
 import { MdCheckCircle, MdSettings, MdHistory } from "react-icons/md";
 import { HistoryEntry } from "types/generated/graphql";


### PR DESCRIPTION
In this PR, history records are made smaller, dates are compacted, and the icon and text are aligned.

Note: Merge this [PR](https://github.com/boxwise/boxtribute/pull/982) first, then this one