### PR TITLE
Show menues and create protected routes based on beta flag

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import "regenerator-runtime/runtime";
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Outlet, Route, Routes } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Alert, AlertIcon, Button } from "@chakra-ui/react";
 import { useLoadAndSetGlobalPreferences } from "hooks/useLoadAndSetGlobalPreferences";
@@ -26,6 +26,22 @@ import ShipmentsOverviewView from "views/Transfers/ShipmentsOverview/ShipmentsOv
 import ShipmentView from "views/Transfers/ShipmentView/ShipmentView";
 import QrReaderView from "views/QrReader/QrReaderView";
 import NotFoundView from "views/NotFoundView/NotFoundView";
+import { useAuthorization } from "hooks/useAuthorization";
+
+interface IProtectedRouteProps {
+  minBeta: number;
+  redirectPath: string;
+}
+
+function ProtectedRoute({ minBeta, redirectPath }: IProtectedRouteProps) {
+  const isAuthorized = useAuthorization({ minBeta });
+
+  if (!isAuthorized) {
+    return <Navigate to={redirectPath} replace />;
+  }
+
+  return <Outlet />;
+}
 
 function App() {
   const { logout } = useAuth0();
@@ -53,7 +69,7 @@ function App() {
         <Route index />
         <Route path=":baseId">
           <Route index element={<BaseDashboardView />} />
-          <Route path="transfers">
+          <Route path="transfers" element={<ProtectedRoute minBeta={2} redirectPath="/qrreader" />}>
             <Route path="agreements">
               <Route index element={<TransferAgreementOverviewView />} />
               <Route path="create" element={<CreateTransferAgreementView />} />

--- a/react/src/components/HeaderMenu/HeaderMenu.tsx
+++ b/react/src/components/HeaderMenu/HeaderMenu.tsx
@@ -10,6 +10,7 @@ export interface MenuItemData {
 export interface MenuItemsGroupData {
   text: string;
   links: MenuItemData[];
+  minBeta?: number;
 }
 
 export interface BaseData {

--- a/react/src/components/HeaderMenu/HeaderMenuContainer.tsx
+++ b/react/src/components/HeaderMenu/HeaderMenuContainer.tsx
@@ -29,6 +29,7 @@ const HeaderMenuContainer = () => {
       },
       {
         text: "Transfers",
+        minBeta: 2,
         links: [
           {
             link: "/transfers/shipments",
@@ -102,11 +103,32 @@ const HeaderMenuContainer = () => {
     [baseId],
   );
 
+  const authorizedMenuItems: MenuItemsGroupData[] = useMemo(() => {
+    return menuItems.filter((menuItem) => {
+      // If no minimum beta requirement exists for the menu item, it should be included.
+      if (!menuItem.minBeta) {
+        return true;
+      }
+
+      // Ensure that auth0.user is defined and parse the beta_user value.
+      if (auth0.user) {
+        const userBetaValue = parseInt(
+          auth0.user["https://www.boxtribute.com/beta_user"] ?? "0",
+          10,
+        );
+        return userBetaValue >= menuItem.minBeta;
+      }
+
+      // If auth0.user is not defined, then don't show items that have a beta requirement.
+      return false;
+    });
+  }, [menuItems, auth0.user]);
+
   return (
     <>
       <HeaderMenu
         {...auth0}
-        menuItemsGroups={menuItems}
+        menuItemsGroups={authorizedMenuItems}
         currentActiveBaseId={baseId}
         availableBases={globalPreferences.availableBases}
         onClickScanQrCode={() => qrReaderOverlayVar({ isOpen: true })}

--- a/react/src/components/HeaderMenu/HeaderMenuDesktop.tsx
+++ b/react/src/components/HeaderMenu/HeaderMenuDesktop.tsx
@@ -28,7 +28,8 @@ import {
   MenuItemsGroupsProps,
   UserMenuProps,
 } from "./HeaderMenu";
-import { generateDropappUrl, handleLogout } from "utils/helpers";
+import { generateDropappUrl } from "utils/helpers";
+import { useHandleLogout } from "hooks/hooks";
 
 const Logo = () => <Image src={BoxtributeLogo} maxH={"3.5em"} />;
 
@@ -50,6 +51,7 @@ const BaseSwitcher = ({ currentActiveBaseId, availableBases }: BaseSwitcherProps
 };
 
 const UserMenu = ({ logout, user, currentActiveBaseId, availableBases }: UserMenuProps) => {
+  const handleLogout = useHandleLogout();
   return (
     <Menu>
       <MenuButton as={IconButton} icon={<Img src={user?.picture} width={10} height={10} />} />

--- a/react/src/components/HeaderMenu/HeaderMenuMobile.tsx
+++ b/react/src/components/HeaderMenu/HeaderMenuMobile.tsx
@@ -29,7 +29,8 @@ import {
   MenuItemsGroupsProps,
 } from "./HeaderMenu";
 import BoxtributeLogo from "../../assets/images/boxtribute-logo.png";
-import { generateDropappUrl, handleLogout } from "utils/helpers";
+import { generateDropappUrl } from "utils/helpers";
+import { useHandleLogout } from "hooks/hooks";
 
 type MenuItemsGroupsMobileProps = MenuItemsGroupsProps & {
   isMenuOpen: boolean;
@@ -57,6 +58,7 @@ const LoginOrUserMenuButtonMobile = ({
   setIsMenuOpen,
 }: LoginOrUserMenuButtonProps & { setIsMenuOpen: (isOpen: boolean) => void }) => {
   const { isOpen, onToggle } = useDisclosure();
+  const handleLogout = useHandleLogout();
 
   return isAuthenticated ? (
     <MenuItem onClick={handleLogout} key="logout-menu">

--- a/react/src/hooks/hooks.ts
+++ b/react/src/hooks/hooks.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useContext } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
 import { useNavigate } from "react-router-dom";
 import { GlobalPreferencesContext } from "providers/GlobalPreferencesProvider";
 import { UseToastOptions, ToastPositionWithLogical } from "@chakra-ui/react";
@@ -9,6 +10,22 @@ export interface INotificationProps extends UseToastOptions {
   type?: "info" | "warning" | "success" | "error" | undefined;
   position?: ToastPositionWithLogical;
 }
+
+// logout handler that redirect the v2 to dropapp related trello: https://trello.com/c/sbIJYHFF
+export const useHandleLogout = () => {
+  const { logout } = useAuth0();
+
+  const handleLogout = () => {
+    // only redirect in staging and production environments
+    if (process.env.REACT_APP_ENVIRONMENT !== "development") {
+      window.location.href = `${process.env.REACT_APP_OLD_APP_BASE_URL}/index.php?action=logoutfromv2`;
+    } else {
+      logout();
+    }
+    return null;
+  };
+  return handleLogout;
+};
 
 export const useGetUrlForResourceHelpers = () => {
   const { globalPreferences } = useContext(GlobalPreferencesContext);

--- a/react/src/hooks/hooks.ts
+++ b/react/src/hooks/hooks.ts
@@ -18,6 +18,7 @@ export const useHandleLogout = () => {
   const handleLogout = () => {
     // only redirect in staging and production environments
     if (process.env.REACT_APP_ENVIRONMENT !== "development") {
+      // eslint-disable-next-line max-len
       window.location.href = `${process.env.REACT_APP_OLD_APP_BASE_URL}/index.php?action=logoutfromv2`;
     } else {
       logout();

--- a/react/src/hooks/useAuthorization.ts
+++ b/react/src/hooks/useAuthorization.ts
@@ -1,0 +1,20 @@
+import { useAuth0 } from "@auth0/auth0-react";
+
+interface IUseAuthorizationProps {
+  minBeta?: number;
+}
+
+export function useAuthorization({ minBeta }: IUseAuthorizationProps) {
+  const { user } = useAuth0();
+
+  // Check if user has a beta flag higher than the minimum
+  const isAuthorized =
+    user && parseInt(user["https://www.boxtribute.com/beta_user"] ?? "0", 10) >= (minBeta ?? 0);
+
+  // Check if user has all the required permissions
+  //   const isAuthorized = requiredPermissions.every(permission =>
+  //     userPermissions.includes(permission)
+  //   );
+
+  return isAuthorized;
+}

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -130,12 +130,24 @@ export type BeneficiaryCreationInput = {
   signature?: InputMaybe<Scalars['String']>;
 };
 
+export type BeneficiaryDemographicsData = DataCube & {
+  __typename?: 'BeneficiaryDemographicsData';
+  dimensions?: Maybe<BeneficiaryDemographicsDimensions>;
+  facts?: Maybe<Array<Maybe<BeneficiaryDemographicsResult>>>;
+};
+
+export type BeneficiaryDemographicsDimensions = {
+  __typename?: 'BeneficiaryDemographicsDimensions';
+  tag?: Maybe<Array<Maybe<ResultIdName>>>;
+};
+
 export type BeneficiaryDemographicsResult = {
   __typename?: 'BeneficiaryDemographicsResult';
   age?: Maybe<Scalars['Int']>;
   count?: Maybe<Scalars['Int']>;
   createdOn?: Maybe<Scalars['Date']>;
   gender?: Maybe<HumanGender>;
+  tagIds?: Maybe<Array<Scalars['Int']>>;
 };
 
 /** Utility type holding a page of [`Beneficiaries`]({{Types.Beneficiary}}). */
@@ -268,7 +280,7 @@ export type CreatedBoxDataDimensions = {
   product?: Maybe<Array<Maybe<ResultIdName>>>;
 };
 
-export type CreatedBoxesData = {
+export type CreatedBoxesData = DataCube & {
   __typename?: 'CreatedBoxesData';
   dimensions?: Maybe<CreatedBoxDataDimensions>;
   facts?: Maybe<Array<Maybe<CreatedBoxesResult>>>;
@@ -283,6 +295,13 @@ export type CreatedBoxesResult = {
   itemsCount?: Maybe<Scalars['Int']>;
   productId?: Maybe<Scalars['Int']>;
 };
+
+export type DataCube = {
+  dimensions?: Maybe<Dimensions>;
+  facts?: Maybe<Array<Maybe<Result>>>;
+};
+
+export type Dimensions = BeneficiaryDemographicsDimensions | CreatedBoxDataDimensions;
 
 /** TODO: Add description here once specs are final/confirmed */
 export type DistributionEvent = {
@@ -1095,7 +1114,7 @@ export type Query = {
   /**  Return all [`Beneficiaries`]({{Types.Beneficiary}}) that the client is authorized to view.  */
   beneficiaries: BeneficiaryPage;
   beneficiary?: Maybe<Beneficiary>;
-  beneficiaryDemographics?: Maybe<Array<Maybe<BeneficiaryDemographicsResult>>>;
+  beneficiaryDemographics?: Maybe<BeneficiaryDemographicsData>;
   box?: Maybe<Box>;
   createdBoxes?: Maybe<CreatedBoxesData>;
   distributionEvent?: Maybe<DistributionEvent>;
@@ -1258,6 +1277,8 @@ export type QueryTransferAgreementsArgs = {
 export type QueryUserArgs = {
   id?: InputMaybe<Scalars['ID']>;
 };
+
+export type Result = BeneficiaryDemographicsResult | CreatedBoxesResult;
 
 export type ResultIdName = {
   __typename?: 'ResultIdName';

--- a/react/src/utils/helpers.ts
+++ b/react/src/utils/helpers.ts
@@ -71,8 +71,3 @@ export const formatDateKey = (date: Date): string => {
   return `${date.toLocaleString("default", { month: "short" })}
     ${date.getDate()}, ${date.getFullYear()}`;
 };
-// logout handler that redirect the v2 to dropapp related trello: https://trello.com/c/sbIJYHFF
-export const handleLogout = () => {
-  window.location.href = `${process.env.REACT_APP_OLD_APP_BASE_URL}/index.php?action=logoutfromv2`;
-  return null;
-};

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -13689,11 +13689,6 @@ markdown-to-jsx@^7.1.8:
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.3.2.tgz#f286b4d112dad3028acc1e77dfe1f653b347e131"
   integrity sha512-B+28F5ucp83aQm+OxNrPkS8z0tMKaeHiy0lHJs3LqCyDQFtWuenaIrkaVTgAm1pf1AU85LXltva86hlaT17i8Q==
 
-math-expression-evaluator@^1.2.14:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.4.0.tgz#3d66031117fbb7b9715ea6c9c68c2cd2eebd37e2"
-  integrity sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw==
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
I wrote a simple Authorization hook for routes and some initial new rendering for menues. I also fixed the redirect to dropapp in dev environments to make testing easier.

I updated dev_coordinator, dev_headofops of both organisations in staging and dev tennent in auth0 to have the "beta_user" flag with value 2.

## Therefore to test you should:
- see the menues and be able to access /transfer/agreements route if you are a dev_coordinator
- not see the menues and not be able to access /transfer/agreements route if you are a dev_volunteer