### PR TITLE
[B] add tag name & product gender to dimensions

### DIFF
--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -39,7 +39,7 @@ def _generate_dimensions(*names, facts):
     if "tag" in names:
         tag_ids = {t for f in facts for t in f["tag_ids"]}
         dimensions["tag"] = (
-            Tag.select(Tag.id, Tag.name).where(Tag.id << tag_ids).dicts()
+            Tag.select(Tag.id, Tag.name, Tag.color).where(Tag.id << tag_ids).dicts()
         )
 
     if "size" in names:

--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -26,7 +26,7 @@ def _generate_dimensions(*names, facts):
     if "product" in names:
         product_ids = {f["product_id"] for f in facts}
         dimensions["product"] = (
-            Product.select(Product.id, Product.name)
+            Product.select(Product.id, Product.name, Product.gender)
             .where(Product.id << product_ids)
             .dicts()
         )

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -45,7 +45,7 @@ type CreatedBoxesResult {
 }
 
 type CreatedBoxDataDimensions {
-  product: [DimensionInfo]
+  product: [ProductDimensionInfo]
   category: [DimensionInfo]
 }
 
@@ -80,7 +80,7 @@ type TopProductsDonatedResult {
 type TopProductsDimensions {
   " Always null for topProductsCheckedOut query "
   size: [DimensionInfo]
-  product: [DimensionInfo]
+  product: [ProductDimensionInfo]
   category: [DimensionInfo]
 }
 
@@ -99,4 +99,10 @@ type TagDimensionInfo implements BasicDimensionInfo {
   name: String
   " Hex color code "
   color: String
+}
+
+type ProductDimensionInfo implements BasicDimensionInfo {
+  id: ID
+  name: String
+  gender: ProductGender
 }

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -19,7 +19,7 @@ type BeneficiaryDemographicsData implements DataCube {
 }
 
 type BeneficiaryDemographicsDimensions {
-  tag: [ResultIdName]
+  tag: [TagDimensionInfo]
 }
 
 type BeneficiaryDemographicsResult {
@@ -45,8 +45,8 @@ type CreatedBoxesResult {
 }
 
 type CreatedBoxDataDimensions {
-  product: [ResultIdName]
-  category: [ResultIdName]
+  product: [DimensionInfo]
+  category: [DimensionInfo]
 }
 
 type TopProductsCheckedOutData implements DataCube {
@@ -79,12 +79,24 @@ type TopProductsDonatedResult {
 
 type TopProductsDimensions {
   " Always null for topProductsCheckedOut query "
-  size: [ResultIdName]
-  product: [ResultIdName]
-  category: [ResultIdName]
+  size: [DimensionInfo]
+  product: [DimensionInfo]
+  category: [DimensionInfo]
 }
 
-type ResultIdName {
+interface BasicDimensionInfo {
   id: ID
   name: String
+}
+
+type DimensionInfo implements BasicDimensionInfo {
+  id: ID
+  name: String
+}
+
+type TagDimensionInfo implements BasicDimensionInfo {
+  id: ID
+  name: String
+  " Hex color code "
+  color: String
 }

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -1,3 +1,4 @@
+from boxtribute_server.enums import ProductGender
 from utils import assert_successful_request
 
 
@@ -26,7 +27,7 @@ def test_query_created_boxes(read_only_client, products, product_categories):
             createdOn categoryId productId gender boxesCount itemsCount
         }
         dimensions {
-            product { id name }
+            product { id name gender }
             category { id name }
     } } }"""
     data = assert_successful_request(read_only_client, query, endpoint="public")
@@ -36,7 +37,14 @@ def test_query_created_boxes(read_only_client, products, product_categories):
     assert facts[1]["boxesCount"] == 2
     assert data == {
         "dimensions": {
-            "product": [{"id": str(p["id"]), "name": p["name"]} for p in products[:3]],
+            "product": [
+                {
+                    "id": str(p["id"]),
+                    "name": p["name"],
+                    "gender": ProductGender(p["gender"]).name,
+                }
+                for p in products[:3]
+            ],
             "category": [
                 {"id": str(c["id"]), "name": c["name"]}
                 for c in sorted(product_categories, key=lambda c: c["id"])

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -4,12 +4,13 @@ from utils import assert_successful_request
 def test_query_beneficiary_demographics(read_only_client, tags):
     query = """query { beneficiaryDemographics(baseIds: [1]) {
         facts { gender age createdOn count tagIds }
-        dimensions { tag { id name } } } }"""
+        dimensions { tag { id name color } } } }"""
     response = assert_successful_request(read_only_client, query, endpoint="public")
     assert len(response["facts"]) == 2
     assert response["dimensions"] == {
         "tag": [
-            {"id": str(tag["id"]), "name": tag["name"]} for tag in [tags[0], tags[2]]
+            {"id": str(tag["id"]), "name": tag["name"], "color": tag["color"]}
+            for tag in [tags[0], tags[2]]
         ]
     }
 

--- a/react/codegen.yml
+++ b/react/codegen.yml
@@ -1,5 +1,7 @@
 overwrite: true
-schema: "../back/boxtribute_server/graph_ql/definitions/**/*.graphql"
+schema:
+  - "../back/boxtribute_server/graph_ql/definitions/basic/*.graphql"
+  - "../back/boxtribute_server/graph_ql/definitions/protected/*.graphql"
 documents:
   - "./src/**/*.{ts,tsx}"
   - "!./src/queries/local-only.ts"

--- a/react/src/types/generated/graphql.ts
+++ b/react/src/types/generated/graphql.ts
@@ -130,26 +130,6 @@ export type BeneficiaryCreationInput = {
   signature?: InputMaybe<Scalars['String']>;
 };
 
-export type BeneficiaryDemographicsData = DataCube & {
-  __typename?: 'BeneficiaryDemographicsData';
-  dimensions?: Maybe<BeneficiaryDemographicsDimensions>;
-  facts?: Maybe<Array<Maybe<BeneficiaryDemographicsResult>>>;
-};
-
-export type BeneficiaryDemographicsDimensions = {
-  __typename?: 'BeneficiaryDemographicsDimensions';
-  tag?: Maybe<Array<Maybe<ResultIdName>>>;
-};
-
-export type BeneficiaryDemographicsResult = {
-  __typename?: 'BeneficiaryDemographicsResult';
-  age?: Maybe<Scalars['Int']>;
-  count?: Maybe<Scalars['Int']>;
-  createdOn?: Maybe<Scalars['Date']>;
-  gender?: Maybe<HumanGender>;
-  tagIds?: Maybe<Array<Scalars['Int']>>;
-};
-
 /** Utility type holding a page of [`Beneficiaries`]({{Types.Beneficiary}}). */
 export type BeneficiaryPage = {
   __typename?: 'BeneficiaryPage';
@@ -273,35 +253,6 @@ export type ClassicLocationBoxesArgs = {
   filterInput?: InputMaybe<FilterBoxInput>;
   paginationInput?: InputMaybe<PaginationInput>;
 };
-
-export type CreatedBoxDataDimensions = {
-  __typename?: 'CreatedBoxDataDimensions';
-  category?: Maybe<Array<Maybe<ResultIdName>>>;
-  product?: Maybe<Array<Maybe<ResultIdName>>>;
-};
-
-export type CreatedBoxesData = DataCube & {
-  __typename?: 'CreatedBoxesData';
-  dimensions?: Maybe<CreatedBoxDataDimensions>;
-  facts?: Maybe<Array<Maybe<CreatedBoxesResult>>>;
-};
-
-export type CreatedBoxesResult = {
-  __typename?: 'CreatedBoxesResult';
-  boxesCount?: Maybe<Scalars['Int']>;
-  categoryId?: Maybe<Scalars['Int']>;
-  createdOn?: Maybe<Scalars['Date']>;
-  gender?: Maybe<ProductGender>;
-  itemsCount?: Maybe<Scalars['Int']>;
-  productId?: Maybe<Scalars['Int']>;
-};
-
-export type DataCube = {
-  dimensions?: Maybe<Dimensions>;
-  facts?: Maybe<Array<Maybe<Result>>>;
-};
-
-export type Dimensions = BeneficiaryDemographicsDimensions | CreatedBoxDataDimensions;
 
 /** TODO: Add description here once specs are final/confirmed */
 export type DistributionEvent = {
@@ -1114,9 +1065,7 @@ export type Query = {
   /**  Return all [`Beneficiaries`]({{Types.Beneficiary}}) that the client is authorized to view.  */
   beneficiaries: BeneficiaryPage;
   beneficiary?: Maybe<Beneficiary>;
-  beneficiaryDemographics?: Maybe<BeneficiaryDemographicsData>;
   box?: Maybe<Box>;
-  createdBoxes?: Maybe<CreatedBoxesData>;
   distributionEvent?: Maybe<DistributionEvent>;
   distributionEventsTrackingGroup?: Maybe<DistributionEventsTrackingGroup>;
   distributionSpot?: Maybe<DistributionSpot>;
@@ -1174,18 +1123,8 @@ export type QueryBeneficiaryArgs = {
 };
 
 
-export type QueryBeneficiaryDemographicsArgs = {
-  baseIds?: InputMaybe<Array<Scalars['Int']>>;
-};
-
-
 export type QueryBoxArgs = {
   labelIdentifier: Scalars['String'];
-};
-
-
-export type QueryCreatedBoxesArgs = {
-  baseId?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -1276,14 +1215,6 @@ export type QueryTransferAgreementsArgs = {
 
 export type QueryUserArgs = {
   id?: InputMaybe<Scalars['ID']>;
-};
-
-export type Result = BeneficiaryDemographicsResult | CreatedBoxesResult;
-
-export type ResultIdName = {
-  __typename?: 'ResultIdName';
-  id?: Maybe<Scalars['ID']>;
-  name?: Maybe<Scalars['String']>;
 };
 
 export type Shipment = {

--- a/statviz/src/types/generated/graphql.ts
+++ b/statviz/src/types/generated/graphql.ts
@@ -57,7 +57,7 @@ export enum BoxState {
 export type CreatedBoxDataDimensions = {
   __typename?: 'CreatedBoxDataDimensions';
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
-  product?: Maybe<Array<Maybe<DimensionInfo>>>;
+  product?: Maybe<Array<Maybe<ProductDimensionInfo>>>;
 };
 
 export type CreatedBoxesData = DataCube & {
@@ -131,6 +131,13 @@ export enum PackingListEntryState {
   Packed = 'Packed',
   PackingInProgress = 'PackingInProgress'
 }
+
+export type ProductDimensionInfo = BasicDimensionInfo & {
+  __typename?: 'ProductDimensionInfo';
+  gender?: Maybe<ProductGender>;
+  id?: Maybe<Scalars['ID']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+};
 
 /** Classificators for [`Product`]({{Types.Product}}) gender. */
 export enum ProductGender {
@@ -224,7 +231,7 @@ export type TopProductsCheckedOutResult = {
 export type TopProductsDimensions = {
   __typename?: 'TopProductsDimensions';
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
-  product?: Maybe<Array<Maybe<DimensionInfo>>>;
+  product?: Maybe<Array<Maybe<ProductDimensionInfo>>>;
   /**  Always null for topProductsCheckedOut query  */
   size?: Maybe<Array<Maybe<DimensionInfo>>>;
 };

--- a/statviz/src/types/generated/graphql.ts
+++ b/statviz/src/types/generated/graphql.ts
@@ -18,6 +18,11 @@ export type Scalars = {
   Datetime: { input: any; output: any; }
 };
 
+export type BasicDimensionInfo = {
+  id?: Maybe<Scalars['ID']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+};
+
 export type BeneficiaryDemographicsData = DataCube & {
   __typename?: 'BeneficiaryDemographicsData';
   dimensions?: Maybe<BeneficiaryDemographicsDimensions>;
@@ -26,7 +31,7 @@ export type BeneficiaryDemographicsData = DataCube & {
 
 export type BeneficiaryDemographicsDimensions = {
   __typename?: 'BeneficiaryDemographicsDimensions';
-  tag?: Maybe<Array<Maybe<ResultIdName>>>;
+  tag?: Maybe<Array<Maybe<TagDimensionInfo>>>;
 };
 
 export type BeneficiaryDemographicsResult = {
@@ -51,8 +56,8 @@ export enum BoxState {
 
 export type CreatedBoxDataDimensions = {
   __typename?: 'CreatedBoxDataDimensions';
-  category?: Maybe<Array<Maybe<ResultIdName>>>;
-  product?: Maybe<Array<Maybe<ResultIdName>>>;
+  category?: Maybe<Array<Maybe<DimensionInfo>>>;
+  product?: Maybe<Array<Maybe<DimensionInfo>>>;
 };
 
 export type CreatedBoxesData = DataCube & {
@@ -74,6 +79,12 @@ export type CreatedBoxesResult = {
 export type DataCube = {
   dimensions?: Maybe<Dimensions>;
   facts?: Maybe<Array<Maybe<Result>>>;
+};
+
+export type DimensionInfo = BasicDimensionInfo & {
+  __typename?: 'DimensionInfo';
+  id?: Maybe<Scalars['ID']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 export type Dimensions = BeneficiaryDemographicsDimensions | CreatedBoxDataDimensions | TopProductsDimensions;
@@ -165,12 +176,6 @@ export type QueryTopProductsDonatedArgs = {
 
 export type Result = BeneficiaryDemographicsResult | CreatedBoxesResult | TopProductsCheckedOutResult | TopProductsDonatedResult;
 
-export type ResultIdName = {
-  __typename?: 'ResultIdName';
-  id?: Maybe<Scalars['ID']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-};
-
 export enum ShipmentState {
   Canceled = 'Canceled',
   Completed = 'Completed',
@@ -179,6 +184,14 @@ export enum ShipmentState {
   Receiving = 'Receiving',
   Sent = 'Sent'
 }
+
+export type TagDimensionInfo = BasicDimensionInfo & {
+  __typename?: 'TagDimensionInfo';
+  /**  Hex color code  */
+  color?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['ID']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+};
 
 /** Classificators for [`Tag`]({{Types.Tag}}) type. */
 export enum TagType {
@@ -210,10 +223,10 @@ export type TopProductsCheckedOutResult = {
 
 export type TopProductsDimensions = {
   __typename?: 'TopProductsDimensions';
-  category?: Maybe<Array<Maybe<ResultIdName>>>;
-  product?: Maybe<Array<Maybe<ResultIdName>>>;
+  category?: Maybe<Array<Maybe<DimensionInfo>>>;
+  product?: Maybe<Array<Maybe<DimensionInfo>>>;
   /**  Always null for topProductsCheckedOut query  */
-  size?: Maybe<Array<Maybe<ResultIdName>>>;
+  size?: Maybe<Array<Maybe<DimensionInfo>>>;
 };
 
 export type TopProductsDonatedData = DataCube & {
@@ -250,7 +263,7 @@ export enum TransferAgreementType {
 export type BeneficiaryDemographicsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type BeneficiaryDemographicsQuery = { __typename?: 'Query', beneficiaryDemographics?: { __typename?: 'BeneficiaryDemographicsData', facts?: Array<{ __typename?: 'BeneficiaryDemographicsResult', count?: number | null, createdOn?: any | null, age?: number | null, gender?: HumanGender | null } | null> | null, dimensions?: { __typename?: 'BeneficiaryDemographicsDimensions', tag?: Array<{ __typename?: 'ResultIdName', name?: string | null, id?: string | null } | null> | null } | null } | null };
+export type BeneficiaryDemographicsQuery = { __typename?: 'Query', beneficiaryDemographics?: { __typename?: 'BeneficiaryDemographicsData', facts?: Array<{ __typename?: 'BeneficiaryDemographicsResult', count?: number | null, createdOn?: any | null, age?: number | null, gender?: HumanGender | null } | null> | null, dimensions?: { __typename?: 'BeneficiaryDemographicsDimensions', tag?: Array<{ __typename?: 'TagDimensionInfo', name?: string | null, id?: string | null } | null> | null } | null } | null };
 
 
 export const BeneficiaryDemographicsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"BeneficiaryDemographics"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"beneficiaryDemographics"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"facts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"count"}},{"kind":"Field","name":{"kind":"Name","value":"createdOn"}},{"kind":"Field","name":{"kind":"Name","value":"age"}},{"kind":"Field","name":{"kind":"Name","value":"gender"}}]}},{"kind":"Field","name":{"kind":"Name","value":"dimensions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tag"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]}}]} as unknown as DocumentNode<BeneficiaryDemographicsQuery, BeneficiaryDemographicsQueryVariables>;


### PR DESCRIPTION
As per suggestion in #969.

@maikneubert: tag color information is useful to colorize the tag label in a UI filter component. Product gender can be useful to concatenate more meaningful, distinct product names, see [this comment](https://github.com/boxwise/boxtribute/pull/969#discussion_r1301710013).
