### PR TITLE
ReconciliationView: Open Accordion Upon First Render

### DIFF
--- a/react/src/components/BoxReconciliationOverlay/components/BoxReconciliationAccordion.tsx
+++ b/react/src/components/BoxReconciliationOverlay/components/BoxReconciliationAccordion.tsx
@@ -40,7 +40,7 @@ export function BoxReconcilationAccordion({
   onBoxUndelivered,
   onBoxDelivered,
 }: IBoxReconcilationAccordionProps) {
-  const [accordionIndex, setAccordionIndex] = useState(-1);
+  const [accordionIndex, setAccordionIndex] = useState(0);
   const [productMatched, setProductMatched] = useState<boolean>(false);
   const [locationSpecified, setLocationSpecified] = useState<boolean>(false);
   const [productFormData, setProductFormData] = useState<IProductFormData>({


### PR DESCRIPTION
The PR fixes reconciliation view accordion to open/focus on when it is first rendered.