### PR TITLE
Add CLI to reconstruct box versions from history

### DIFF
--- a/back/boxtribute_server/models/utils.py
+++ b/back/boxtribute_server/models/utils.py
@@ -16,11 +16,11 @@ def utcnow():
     return datetime.now(tz=timezone.utc).replace(microsecond=0)
 
 
-def convert_ids(concat_ids):
+def convert_ids(concat_ids, new_type=int):
     """Convert a string of comma-separated IDs (returned from GROUP_CONCAT) into a
     list of integers.
     """
-    return [int(i) for i in (concat_ids or "").split(",") if i]
+    return [new_type(i) if i else None for i in (concat_ids or "").split(",")]
 
 
 today = date.today()

--- a/back/boxtribute_server/setup_wizard.py
+++ b/back/boxtribute_server/setup_wizard.py
@@ -333,6 +333,10 @@ def _grouped_convert(*, location_id, base_id, start):
         f"""Reconstruction completed after {round(time.perf_counter() -
     start_time, ndigits=1)}s."""
     )
+    LOGGER.debug(
+        f"""Total number of box versions: {sum(len(v) for v in
+        all_boxes_versions.values())}"""
+    )
     filename = "box_versions_grouped.json"
     with open(filename, "w") as f:
         json.dump(all_boxes_versions, f, default=str, indent=2)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       MYSQL_ROOT_HOST: "%"
       MYSQL_DATABASE: dropapp_dev
     volumes:
-      - ./back/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./back/dump-dropapp_production-202311012331.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       # <Port exposed> : < MySQL Port running inside container>
       - 32000:3306


### PR DESCRIPTION
## Goal
Reconstruct box versions from history for precise data in `createdBoxes` query.

It is necessary to find the number of items in the box *at the time of creation*. This can only be obtained by walking back all changes applied to a box.

At this point, the PR does not integrate the reconstruction in the actual `createdBoxes` BE but provides a CLI for experimenting and monitoring instead.

## Approach
As test data I got a production DB dump via

    mysqldump --gtid --tz-utc --dump-date --skip-lock-tables --disable-keys --quote-names --create-options --add-locks --extended-insert -u dropapp_selectonly --protocol=tcp -p --host 127.0.0.1 --port 3386 dropapp_production stock locations history > stock-history.sql

I used this dump as volume for the docker-compose db service.

Now the reconstruction script can be invoked via

    bwiz -P 32000 -u root -p dropapp_root -d dropapp_dev --verbose convert -l 54 -y 2017

to reconstruct all versions of boxes in location 54 created in 2017 or after.

## Result
The location above has about 3800 boxes with >20k history entries. Reconstruction takes about 13s. The results were visually inspected by comparing them to the history table, and are verified to be correct.

## Conclusion
The above reconstruction is too slow for acceptable UX. It surely can be optimized by using more sophisticated grouping, or using multiprocessing.

However bear in mind that the strategy to pre-select boxes of a certain base is not correct. This strategy erroneously finds only boxes that *currently* are in these places. What we want to know though are all boxes that were in these places *at their time of creation* which can only be obtained by processing all stock-related history entries (450k). So even if the runtime above can be optimized it will be 10-20x increased again.

Memory requirements: The resulting reconstructed data for 3800 boxes is about 5MB on disk, probably about the same in memory. In total 94k boxes are registered now, so we can estimate that >100MB of memory required for the reconstruction.
