### PR TITLE
ReconciliationView: Change the Label and Style of the AYS Buttons 

### DIFF
--- a/react/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.test.tsx
+++ b/react/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.test.tsx
@@ -254,7 +254,7 @@ noDeliveryTests.forEach(({ name, mocks, toast }) => {
 
       // AYS is open
       expect(await screen.findByText(/box not delivered\?/i)).toBeInTheDocument();
-      const noButton = screen.getByRole("button", { name: /no/i });
+      const noButton = screen.getByRole("button", { name: /nevermind/i });
       expect(noButton).toBeInTheDocument();
       user.click(noButton);
 
@@ -273,7 +273,7 @@ noDeliveryTests.forEach(({ name, mocks, toast }) => {
 
       // AYS is open
       expect(await screen.findByText(/box not delivered\?/i)).toBeInTheDocument();
-      const yesButton = screen.getByRole("button", { name: /yes/i });
+      const yesButton = screen.getByRole("button", { name: /confirm/i });
       expect(yesButton).toBeInTheDocument();
       user.click(yesButton);
 

--- a/react/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.tsx
+++ b/react/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.tsx
@@ -227,15 +227,19 @@ export function BoxReconciliationOverlay({
         title="Box Not Delivered?"
         body={
           "Confirming this means that this box never arrived as part of this shipment." +
+          " " +
           "We’ll record this as NotDelivered and remove it from the shipment receive list."
         }
+        rightButtonProps={{
+          colorScheme: "red",
+        }}
         isOpen={boxUndeliveredAYSState !== ""}
         isLoading={loading}
-        leftButtonText="Yes"
-        rightButtonText="No"
+        leftButtonText="Nevermind"
+        rightButtonText="Confirm"
         onClose={() => setBoxUndeliveredAYSState("")}
-        onLeftButtonClick={() => onBoxUndelivered(boxUndeliveredAYSState)}
-        onRightButtonClick={() => setBoxUndeliveredAYSState("")}
+        onLeftButtonClick={() => setBoxUndeliveredAYSState("")}
+        onRightButtonClick={() => onBoxUndelivered(boxUndeliveredAYSState)}
       />
     </>
   );


### PR DESCRIPTION
The PR corrects the labels and styles of the reconciliation buttons and updates the AYS buttons labels in the test case 4.7. Also add a space after the period of the first sentence.