### PR TITLE
Set ShipmentDetail.received_by/on immediately after box reconciliation

### DIFF
--- a/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
@@ -302,6 +302,7 @@ def _update_shipment_with_received_boxes(
         for i in shipment_detail_update_inputs or []
     }
 
+    now = utcnow()
     updated_box_fields = [
         Box.product,
         Box.location,
@@ -336,6 +337,8 @@ def _update_shipment_with_received_boxes(
         detail.target_location = target_location_id
         detail.target_size = target_size_id
         detail.target_quantity = target_quantity
+        detail.received_on = now
+        detail.received_by = user_id
         detail.box.product = target_product_id
         detail.box.location = target_location_id
         detail.box.size = target_size_id
@@ -370,6 +373,8 @@ def _update_shipment_with_received_boxes(
                 ShipmentDetail.target_location,
                 ShipmentDetail.target_size,
                 ShipmentDetail.target_quantity,
+                ShipmentDetail.received_on,
+                ShipmentDetail.received_by,
             ],
         )
         TagsRelation.delete().where(
@@ -402,17 +407,6 @@ def _complete_shipment_if_applicable(*, shipment, user_id):
         shipment.completed_by = user_id
         shipment.completed_on = now
         shipment.save()
-
-        for detail in details:
-            if detail.box.state_id == BoxState.Lost:
-                # Lost boxes must not be marked as received
-                continue
-            detail.received_by = user_id
-            detail.received_on = now
-
-        ShipmentDetail.bulk_update(
-            details, [ShipmentDetail.received_on, ShipmentDetail.received_by]
-        )
 
 
 def update_shipment_when_preparing(

--- a/react/src/views/Transfers/ShipmentView/components/ShipmentReceivingCard.tsx
+++ b/react/src/views/Transfers/ShipmentView/components/ShipmentReceivingCard.tsx
@@ -1,6 +1,6 @@
 import { Flex, Box, Spacer, Heading, Wrap, WrapItem, VStack, Center } from "@chakra-ui/react";
 import { BoxIcon } from "components/Icon/Transfer/BoxIcon";
-import { BoxState, Shipment } from "types/generated/graphql";
+import { Shipment } from "types/generated/graphql";
 
 export interface IShipmentReceivingCardProps {
   shipment: Shipment;

--- a/react/src/views/Transfers/ShipmentView/components/ShipmentReceivingCard.tsx
+++ b/react/src/views/Transfers/ShipmentView/components/ShipmentReceivingCard.tsx
@@ -53,9 +53,8 @@ function ShipmentReceivingCard({ shipment }: IShipmentReceivingCardProps) {
               <Wrap>
                 <WrapItem fontWeight="extrabold" fontSize="lg">
                   {
-                    shipment.details.filter(
-                      (b) => b.box.state === BoxState.InStock && b.removedOn === null,
-                    ).length
+                    shipment.details.filter((b) => b.receivedOn !== null && b.removedOn === null)
+                      .length
                   }{" "}
                   /{" "}
                   {shipment.details.filter((b) => b.removedOn === null).length -


### PR DESCRIPTION
Can be tested by reconciling a box via the GraphQL playground.