### PR TITLE
[4th viz] Implement GraphQL interface for movedBoxes

### DIFF
--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -4,6 +4,7 @@ from peewee import JOIN, SQL, fn
 
 from ...db import db
 from ...enums import BoxState, HumanGender, TaggableObjectType
+from ...models.definitions.base import Base
 from ...models.definitions.beneficiary import Beneficiary
 from ...models.definitions.box import Box
 from ...models.definitions.history import DbChangeHistory
@@ -47,6 +48,20 @@ def _generate_dimensions(*names, facts):
         dimensions["size"] = (
             Size.select(Size.id, Size.label.alias("name"))
             .where(Size.id << size_ids)
+            .dicts()
+        )
+
+    if "base" in names:
+        base_ids = {f["base_id"] for f in facts}
+        dimensions["base"] = (
+            Base.select(Base.id, Base.name).where(Base.id << base_ids).dicts()
+        )
+
+    if "location" in names:
+        location_ids = {f["location_id"] for f in facts}
+        dimensions["location"] = (
+            Location.select(Location.id, Location.name)
+            .where(Location.id << location_ids)
             .dicts()
         )
 
@@ -205,4 +220,54 @@ def compute_top_products_donated(base_id):
         row["created_on"] = row["created_on"].date()
 
     dimensions = _generate_dimensions("category", "product", "size", facts=facts)
+    return {"facts": facts, "dimensions": dimensions}
+
+
+def compute_moved_boxes(base_id):
+    """Count all boxes moved to locations in the given base, grouped by date of
+    movement, location, base, product category, and box state.
+    """
+    # TODO: use more precise query with box versions
+    selection = (
+        DbChangeHistory.select(
+            fn.MAX(DbChangeHistory.change_date).alias("moved_on"),
+            Box.location.alias("location_id"),
+            Box.state.alias("box_state"),
+            Location.base.alias("base_id"),
+            Product.category.alias("category_id"),
+            fn.COUNT(Box.id).alias("boxes_count"),
+        )
+        .join(
+            Box,
+            on=(
+                (DbChangeHistory.record_id == Box.id)
+                & (DbChangeHistory.table_name == Box._meta.table_name)
+                & (
+                    DbChangeHistory.changes
+                    << [Box.location.column_name, Box.state.column_name]
+                )
+            ),
+        )
+        .join(
+            Product,
+            on=((Box.product == Product.id) & (Product.base == base_id)),
+        )
+        .join(
+            Location,
+            src=Box,
+            on=((Box.location == Location.id) & (Location.base == base_id)),
+        )
+    )
+    facts = selection.group_by(
+        SQL("box_state"),
+        SQL("location_id"),
+        SQL("base_id"),
+        SQL("category_id"),
+    ).dicts()
+
+    # Conversions for GraphQL interface
+    for row in facts:
+        row["moved_on"] = row["moved_on"].date()
+
+    dimensions = _generate_dimensions("category", "base", "location", facts=facts)
     return {"facts": facts, "dimensions": dimensions}

--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -4,7 +4,6 @@ from peewee import JOIN, SQL, fn
 
 from ...db import db
 from ...enums import BoxState, HumanGender, TaggableObjectType, TargetType
-from ...models.definitions.base import Base
 from ...models.definitions.beneficiary import Beneficiary
 from ...models.definitions.box import Box
 from ...models.definitions.history import DbChangeHistory
@@ -217,9 +216,6 @@ def compute_top_products_donated(base_id):
     return {"facts": facts, "dimensions": dimensions}
 
 
-TARGET_ID_SEPARATOR = "---"
-
-
 def compute_moved_boxes(base_id):
     """Count all boxes moved to locations in the given base, grouped by date of
     movement, product category, and box state.
@@ -231,7 +227,7 @@ def compute_moved_boxes(base_id):
     selection = (
         DbChangeHistory.select(
             fn.MAX(DbChangeHistory.change_date).alias("moved_on"),
-            fn.CONCAT(Base.name, TARGET_ID_SEPARATOR, Location.name).alias("target_id"),
+            Location.name.alias("target_id"),
             Product.category.alias("category_id"),
             fn.COUNT(Box.id).alias("boxes_count"),
         )
@@ -254,7 +250,6 @@ def compute_moved_boxes(base_id):
             src=Box,
             on=((Box.location == Location.id) & (Location.base == base_id)),
         )
-        .join(Base)
     )
     facts = selection.group_by(
         SQL("target_id"),

--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -222,10 +222,12 @@ TARGET_ID_SEPARATOR = "---"
 
 def compute_moved_boxes(base_id):
     """Count all boxes moved to locations in the given base, grouped by date of
-    movement, location, base, product category, and box state.
+    movement, product category, and box state.
     """
-    # TODO: use more precise query with box versions
-    # This selects only information of boxes moved from InStock to Donated state
+    # This selects only information of boxes that were moved from InStock to Donated
+    # state, and are now in the base of given base ID. It is NOT taken into account that
+    # boxes can be moved back from Donated to InStock, nor that the product or other
+    # attributes of the box change after having been donated
     selection = (
         DbChangeHistory.select(
             fn.MAX(DbChangeHistory.change_date).alias("moved_on"),

--- a/back/boxtribute_server/business_logic/statistics/queries.py
+++ b/back/boxtribute_server/business_logic/statistics/queries.py
@@ -3,6 +3,7 @@ from ariadne import QueryType
 from .crud import (
     compute_beneficiary_demographics,
     compute_created_boxes,
+    compute_moved_boxes,
     compute_top_products_checked_out,
     compute_top_products_donated,
 )
@@ -28,3 +29,8 @@ def resolve_top_products_checked_out(*_, base_id):
 @query.field("topProductsDonated")
 def resolve_top_products_donated(*_, base_id):
     return compute_top_products_donated(base_id)
+
+
+@query.field("movedBoxes")
+def resolve_moved_boxes(*_, base_id=None):
+    return compute_moved_boxes(base_id)

--- a/back/boxtribute_server/enums.py
+++ b/back/boxtribute_server/enums.py
@@ -113,3 +113,8 @@ class TagType(enum.Enum):
 class TaggableObjectType(enum.Enum):
     Box = "Stock"
     Beneficiary = "People"
+
+
+class TargetType(enum.IntEnum):
+    Shipment = 1
+    OutgoingLocation = enum.auto()

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -3,6 +3,7 @@ type Query {
   createdBoxes(baseId: Int): CreatedBoxesData
   topProductsCheckedOut(baseId: Int!): TopProductsCheckedOutData
   topProductsDonated(baseId: Int!): TopProductsDonatedData
+  movedBoxes(baseId: Int!): MovedBoxesData
 }
 
 interface DataCube {
@@ -10,8 +11,8 @@ interface DataCube {
   dimensions: Dimensions
 }
 
-union Result = BeneficiaryDemographicsResult | CreatedBoxesResult | TopProductsCheckedOutResult | TopProductsDonatedResult
-union Dimensions = BeneficiaryDemographicsDimensions | CreatedBoxDataDimensions | TopProductsDimensions
+union Result = BeneficiaryDemographicsResult | CreatedBoxesResult | TopProductsCheckedOutResult | TopProductsDonatedResult | MovedBoxesResult
+union Dimensions = BeneficiaryDemographicsDimensions | CreatedBoxDataDimensions | TopProductsDimensions | MovedBoxDataDimensions
 
 type BeneficiaryDemographicsData implements DataCube {
   facts: [BeneficiaryDemographicsResult]
@@ -82,6 +83,35 @@ type TopProductsDimensions {
   size: [DimensionInfo]
   product: [ProductDimensionInfo]
   category: [DimensionInfo]
+}
+
+type MovedBoxesData implements DataCube {
+  facts: [MovedBoxesResult]
+  dimensions: MovedBoxDataDimensions
+}
+
+"""
+A box can be moved in various ways:
+- within a base (location ID with InStock/Donated)
+- because it's lost (Lost)
+- because it becomes scrap (Scrap)
+- because it's about to be shipped (target base ID with MarkedForShipment)
+- because it's being shipped (target base ID with InTransit/Receiving)
+"""
+type MovedBoxesResult {
+  movedOn: Date!
+  boxState: BoxState!
+  locationId: Int
+  baseId: Int
+  categoryId: Int!
+  boxesCount: Int!
+}
+
+type MovedBoxDataDimensions {
+  category: [DimensionInfo]
+  tag: [TagDimensionInfo]
+  location: [DimensionInfo]
+  base: [DimensionInfo]
 }
 
 interface BasicDimensionInfo {

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -100,18 +100,14 @@ A box can be moved in various ways:
 """
 type MovedBoxesResult {
   movedOn: Date!
-  boxState: BoxState!
-  locationId: Int
-  baseId: Int
+  targetId: ID!
   categoryId: Int!
   boxesCount: Int!
 }
 
 type MovedBoxDataDimensions {
   category: [DimensionInfo]
-  tag: [TagDimensionInfo]
-  location: [DimensionInfo]
-  base: [DimensionInfo]
+  target: [TargetDimensionInfo]
 }
 
 interface BasicDimensionInfo {
@@ -135,4 +131,15 @@ type ProductDimensionInfo implements BasicDimensionInfo {
   id: ID
   name: String
   gender: ProductGender
+}
+
+type TargetDimensionInfo implements BasicDimensionInfo {
+  id: ID
+  name: String
+  type: TargetType
+}
+
+enum TargetType {
+  Shipment
+  OutgoingLocation
 }

--- a/back/boxtribute_server/graph_ql/enums.py
+++ b/back/boxtribute_server/graph_ql/enums.py
@@ -12,6 +12,7 @@ from ..enums import (
     ShipmentState,
     TaggableObjectType,
     TagType,
+    TargetType,
     TransferAgreementState,
     TransferAgreementType,
 )
@@ -31,4 +32,8 @@ enum_types = [
     DistributionEventsTrackingGroupState,
     DistributionEventTrackingFlowDirection,
     DistributionEventTrackingFlowDirection,
+]
+
+public_api_enum_types = [
+    TargetType,
 ]

--- a/back/boxtribute_server/graph_ql/schema.py
+++ b/back/boxtribute_server/graph_ql/schema.py
@@ -9,7 +9,7 @@ from .bindables import (
     union_types,
 )
 from .definitions import definitions, public_api_definitions, query_api_definitions
-from .enums import enum_types
+from .enums import enum_types, public_api_enum_types
 from .scalars import date_scalar, datetime_scalar
 
 full_api_schema = make_executable_schema(
@@ -46,5 +46,6 @@ public_api_schema = make_executable_schema(
     date_scalar,
     statistics_query,
     *enum_types,
+    *public_api_enum_types,
     convert_names_case=True,
 )

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -1,4 +1,3 @@
-from boxtribute_server.business_logic.statistics.crud import TARGET_ID_SEPARATOR
 from boxtribute_server.enums import ProductGender, TargetType
 from utils import assert_successful_request
 
@@ -143,13 +142,13 @@ def test_query_top_products(
     }
 
 
-def test_query_moved_boxes(read_only_client, default_location, default_base):
+def test_query_moved_boxes(read_only_client, default_location):
     query = """query { movedBoxes(baseId: 1) {
         facts { movedOn targetId categoryId boxesCount }
         dimensions { target { id name type } }
         } }"""
     data = assert_successful_request(read_only_client, query, endpoint="public")
-    target_id = f"{default_base['name']}{TARGET_ID_SEPARATOR}{default_location['name']}"
+    target_id = default_location["name"]
     assert data == {
         "facts": [
             {

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -1,4 +1,5 @@
-from boxtribute_server.enums import ProductGender
+from boxtribute_server.business_logic.statistics.crud import TARGET_ID_SEPARATOR
+from boxtribute_server.enums import ProductGender, TargetType
 from utils import assert_successful_request
 
 
@@ -144,35 +145,27 @@ def test_query_top_products(
 
 def test_query_moved_boxes(read_only_client, default_location, default_base):
     query = """query { movedBoxes(baseId: 1) {
-        facts { movedOn boxState locationId baseId categoryId boxesCount }
-        dimensions {
-            location { id name }
-            base { id name }
-        } } }"""
+        facts { movedOn targetId categoryId boxesCount }
+        dimensions { target { id name type } }
+        } }"""
     data = assert_successful_request(read_only_client, query, endpoint="public")
+    target_id = f"{default_base['name']}{TARGET_ID_SEPARATOR}{default_location['name']}"
     assert data == {
         "facts": [
             {
-                "baseId": 1,
-                "boxState": "MarkedForShipment",
-                "boxesCount": 1,
-                "categoryId": 1,
-                "locationId": 1,
-                "movedOn": "2023-06-21",
-            },
-            {
-                "baseId": 1,
-                "boxState": "Donated",
                 "boxesCount": 3,
                 "categoryId": 1,
-                "locationId": 1,
+                "targetId": target_id,
                 "movedOn": "2022-12-05",
             },
         ],
         "dimensions": {
-            "location": [
-                {"id": str(default_location["id"]), "name": default_location["name"]}
+            "target": [
+                {
+                    "id": target_id,
+                    "name": target_id,
+                    "type": TargetType.OutgoingLocation.name,
+                }
             ],
-            "base": [{"id": str(default_base["id"]), "name": default_base["name"]}],
         },
     }

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -140,3 +140,39 @@ def test_query_top_products(
             ],
         },
     }
+
+
+def test_query_moved_boxes(read_only_client, default_location, default_base):
+    query = """query { movedBoxes(baseId: 1) {
+        facts { movedOn boxState locationId baseId categoryId boxesCount }
+        dimensions {
+            location { id name }
+            base { id name }
+        } } }"""
+    data = assert_successful_request(read_only_client, query, endpoint="public")
+    assert data == {
+        "facts": [
+            {
+                "baseId": 1,
+                "boxState": "MarkedForShipment",
+                "boxesCount": 1,
+                "categoryId": 1,
+                "locationId": 1,
+                "movedOn": "2023-06-21",
+            },
+            {
+                "baseId": 1,
+                "boxState": "Donated",
+                "boxesCount": 3,
+                "categoryId": 1,
+                "locationId": 1,
+                "movedOn": "2022-12-05",
+            },
+        ],
+        "dimensions": {
+            "location": [
+                {"id": str(default_location["id"]), "name": default_location["name"]}
+            ],
+            "base": [{"id": str(default_base["id"]), "name": default_base["name"]}],
+        },
+    }

--- a/statviz/src/types/generated/graphql.ts
+++ b/statviz/src/types/generated/graphql.ts
@@ -128,10 +128,8 @@ export enum Language {
 
 export type MovedBoxDataDimensions = {
   __typename?: 'MovedBoxDataDimensions';
-  base?: Maybe<Array<Maybe<DimensionInfo>>>;
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
-  location?: Maybe<Array<Maybe<DimensionInfo>>>;
-  tag?: Maybe<Array<Maybe<TagDimensionInfo>>>;
+  target?: Maybe<Array<Maybe<TargetDimensionInfo>>>;
 };
 
 export type MovedBoxesData = DataCube & {
@@ -150,12 +148,10 @@ export type MovedBoxesData = DataCube & {
  */
 export type MovedBoxesResult = {
   __typename?: 'MovedBoxesResult';
-  baseId?: Maybe<Scalars['Int']['output']>;
-  boxState: BoxState;
   boxesCount: Scalars['Int']['output'];
   categoryId: Scalars['Int']['output'];
-  locationId?: Maybe<Scalars['Int']['output']>;
   movedOn: Scalars['Date']['output'];
+  targetId: Scalars['ID']['output'];
 };
 
 export enum PackingListEntryState {
@@ -249,6 +245,18 @@ export enum TagType {
 export enum TaggableResourceType {
   Beneficiary = 'Beneficiary',
   Box = 'Box'
+}
+
+export type TargetDimensionInfo = BasicDimensionInfo & {
+  __typename?: 'TargetDimensionInfo';
+  id?: Maybe<Scalars['ID']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<TargetType>;
+};
+
+export enum TargetType {
+  OutgoingLocation = 'OutgoingLocation',
+  Shipment = 'Shipment'
 }
 
 export type TopProductsCheckedOutData = DataCube & {

--- a/statviz/src/types/generated/graphql.ts
+++ b/statviz/src/types/generated/graphql.ts
@@ -87,7 +87,7 @@ export type DimensionInfo = BasicDimensionInfo & {
   name?: Maybe<Scalars['String']['output']>;
 };
 
-export type Dimensions = BeneficiaryDemographicsDimensions | CreatedBoxDataDimensions | TopProductsDimensions;
+export type Dimensions = BeneficiaryDemographicsDimensions | CreatedBoxDataDimensions | MovedBoxDataDimensions | TopProductsDimensions;
 
 /** TODO: Add description here once specs are final/confirmed */
 export enum DistributionEventState {
@@ -126,6 +126,38 @@ export enum Language {
   Nl = 'nl'
 }
 
+export type MovedBoxDataDimensions = {
+  __typename?: 'MovedBoxDataDimensions';
+  base?: Maybe<Array<Maybe<DimensionInfo>>>;
+  category?: Maybe<Array<Maybe<DimensionInfo>>>;
+  location?: Maybe<Array<Maybe<DimensionInfo>>>;
+  tag?: Maybe<Array<Maybe<TagDimensionInfo>>>;
+};
+
+export type MovedBoxesData = DataCube & {
+  __typename?: 'MovedBoxesData';
+  dimensions?: Maybe<MovedBoxDataDimensions>;
+  facts?: Maybe<Array<Maybe<MovedBoxesResult>>>;
+};
+
+/**
+ * A box can be moved in various ways:
+ * - within a base (location ID with InStock/Donated)
+ * - because it's lost (Lost)
+ * - because it becomes scrap (Scrap)
+ * - because it's about to be shipped (target base ID with MarkedForShipment)
+ * - because it's being shipped (target base ID with InTransit/Receiving)
+ */
+export type MovedBoxesResult = {
+  __typename?: 'MovedBoxesResult';
+  baseId?: Maybe<Scalars['Int']['output']>;
+  boxState: BoxState;
+  boxesCount: Scalars['Int']['output'];
+  categoryId: Scalars['Int']['output'];
+  locationId?: Maybe<Scalars['Int']['output']>;
+  movedOn: Scalars['Date']['output'];
+};
+
 export enum PackingListEntryState {
   NotStarted = 'NotStarted',
   Packed = 'Packed',
@@ -157,6 +189,7 @@ export type Query = {
   __typename?: 'Query';
   beneficiaryDemographics?: Maybe<BeneficiaryDemographicsData>;
   createdBoxes?: Maybe<CreatedBoxesData>;
+  movedBoxes?: Maybe<MovedBoxesData>;
   topProductsCheckedOut?: Maybe<TopProductsCheckedOutData>;
   topProductsDonated?: Maybe<TopProductsDonatedData>;
 };
@@ -172,6 +205,11 @@ export type QueryCreatedBoxesArgs = {
 };
 
 
+export type QueryMovedBoxesArgs = {
+  baseId: Scalars['Int']['input'];
+};
+
+
 export type QueryTopProductsCheckedOutArgs = {
   baseId: Scalars['Int']['input'];
 };
@@ -181,7 +219,7 @@ export type QueryTopProductsDonatedArgs = {
   baseId: Scalars['Int']['input'];
 };
 
-export type Result = BeneficiaryDemographicsResult | CreatedBoxesResult | TopProductsCheckedOutResult | TopProductsDonatedResult;
+export type Result = BeneficiaryDemographicsResult | CreatedBoxesResult | MovedBoxesResult | TopProductsCheckedOutResult | TopProductsDonatedResult;
 
 export enum ShipmentState {
   Canceled = 'Canceled',


### PR DESCRIPTION
This PR brings the GraphQL interface for data about moved boxes.

It can be used to generate a Sankey diagram of the number of boxes donated from a base into "donation" locations, filterable by movement day and product category.
