### PR TITLE
ShipmentView: Sort for Completed Shipments Should Show Products Without Missing Boxes First

### DIFF
--- a/react/src/views/Transfers/ShipmentView/components/ShipmentTabs.tsx
+++ b/react/src/views/Transfers/ShipmentView/components/ShipmentTabs.tsx
@@ -65,6 +65,7 @@ function ShipmentTabs({
             } as Box),
         ),
       }))
+      .orderBy((value) => value.totalLosts, "asc")
       .mapKeys(
         (value) =>
           // eslint-disable-next-line max-len

--- a/react/src/views/Transfers/ShipmentView/components/ShipmentTabs.tsx
+++ b/react/src/views/Transfers/ShipmentView/components/ShipmentTabs.tsx
@@ -1,6 +1,6 @@
 import { TabList, TabPanels, Tabs, TabPanel, Tab, Center } from "@chakra-ui/react";
 import _ from "lodash";
-import { Box, BoxState, ShipmentDetail, ShipmentState, User } from "types/generated/graphql";
+import { Box, ShipmentDetail, ShipmentState, User } from "types/generated/graphql";
 import ShipmentContent, { IShipmentContent } from "./ShipmentContent";
 import ShipmentHistory from "./ShipmentHistory";
 
@@ -54,7 +54,7 @@ function ShipmentTabs({
         product: group[0]?.sourceProduct,
         totalItems: _.sumBy(group, (shipment) => shipment?.sourceQuantity || 0),
         totalBoxes: group.length,
-        totalLosts: group.filter((shipment) => shipment?.box?.state === BoxState.Lost).length,
+        totalLosts: group.filter((shipment) => shipment?.lostOn !== null).length,
         boxes: group.map(
           (shipment) =>
             ({


### PR DESCRIPTION
- fix sorting order on completed shipment
- using lostOn instead of box state to count total lost boxes
