### PR TITLE
Add GraphQL playground for /public endpoint

### DIFF
--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -22,6 +22,9 @@ app_bp = Blueprint("app_bp", __name__)
 # Allowed headers for CORS
 CORS_HEADERS = ["Content-Type", "Authorization", "x-clacks-overhead"]
 
+PLAYGROUND_TITLE = "boxtribute API"
+PLAYGROUND_HTML = ExplorerPlayground(title=PLAYGROUND_TITLE).html(None)
+
 
 @api_bp.errorhandler(AuthenticationFailed)
 @app_bp.errorhandler(AuthenticationFailed)
@@ -31,15 +34,9 @@ def handle_auth_error(ex):
     return response
 
 
-@app_bp.route("/public", methods=["GET"])
+@api_bp.route("/public", methods=["GET"])
 def public():
-    response = (
-        "Hello from a public endpoint! You don't need to be authenticated to see this."
-    )
-    return jsonify(message=response)
-
-
-PLAYGROUND_HTML = ExplorerPlayground(title="boxtribute API").html(None)
+    return PLAYGROUND_HTML, 200
 
 
 @api_bp.route("/", methods=["GET"])

--- a/back/test/endpoint_tests/test_simple.py
+++ b/back/test/endpoint_tests/test_simple.py
@@ -1,17 +1,15 @@
 import pytest
+from boxtribute_server.routes import PLAYGROUND_TITLE
 
 
 @pytest.mark.parametrize("endpoint", ["", "graphql"])
 def test_private_endpoint(read_only_client, endpoint):
     response = read_only_client.get(f"/{endpoint}")
     assert response.status_code == 200
-    assert "boxtribute API" in response.data.decode()
+    assert PLAYGROUND_TITLE in response.data.decode()
 
 
 def test_public_endpoint(read_only_client):
     response = read_only_client.get("/public")
     assert response.status_code == 200
-    assert (
-        "Hello from a public endpoint! You don't need to be authenticated to see this."
-        == response.json["message"]
-    )
+    assert PLAYGROUND_TITLE in response.data.decode()


### PR DESCRIPTION
Can be invoked in demo/prod but any POST requests (and hence inspection of the GraphQL schema, or any GraphQL requests) will be blocked in the POST handler
