### PR TITLE
Rename RBP to 'product_category'

### DIFF
--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -18,11 +18,11 @@ from .utils import (
 
 BASE_AGNOSTIC_RESOURCES = (
     "box_state",
-    "category",
     "gender",
     "history",
     "language",
     "organisation",
+    "product_category",
     "qr",
     "shipment_detail",
     "size",

--- a/back/boxtribute_server/business_logic/core/product_category/queries.py
+++ b/back/boxtribute_server/business_logic/core/product_category/queries.py
@@ -8,11 +8,11 @@ query = QueryType()
 
 @query.field("productCategory")
 def resolve_product_category(*_, id):
-    authorize(permission="category:read")
+    authorize(permission="product_category:read")
     return ProductCategory.get_by_id(id)
 
 
 @query.field("productCategories")
 def resolve_product_categories(*_):
-    authorize(permission="category:read")
+    authorize(permission="product_category:read")
     return ProductCategory.select()

--- a/back/boxtribute_server/graph_ql/loaders.py
+++ b/back/boxtribute_server/graph_ql/loaders.py
@@ -43,9 +43,6 @@ class SimpleDataLoader(DataLoader):
     async def batch_load_fn(self, ids):
         if not self.skip_authorize:
             resource = convert_pascal_to_snake_case(self.model.__name__)
-            # work-around for inconsistent RBP naming
-            if resource == "product_category":
-                resource = "category"
             permission = f"{resource}:read"
             authorize(permission=permission)
 

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -89,7 +89,7 @@ def _create_jwt_payload(
         payload[f"{JWT_CLAIM_PREFIX}/permissions"] = [
             f"{base_prefix}/base:read",
             f"{base_prefix}/beneficiary:read",
-            f"{base_prefix}/category:read",
+            f"{base_prefix}/product_category:read",
             f"{base_prefix}/distro_event:write",
             f"{base_prefix}/distro_event:read",
             f"{base_prefix}/location:read",

--- a/back/test/unit_tests/test_authz.py
+++ b/back/test/unit_tests/test_authz.py
@@ -27,7 +27,7 @@ BASE_RELATED_PERMISSIONS = {
 }
 BASE_AGNOSTIC_PERMISSIONS = {
     "box_state:read": [BASE_ID],
-    "category:read": [BASE_ID],
+    "product_category:read": [BASE_ID],
     "gender:read": [BASE_ID],
     "language:read": [BASE_ID],
     "organisation:read": [BASE_ID],
@@ -50,7 +50,7 @@ def test_authorized_user():
     user = CurrentUser(id=3, organisation_id=2, base_ids=ALL_PERMISSIONS)
     assert authorize(user, permission="base:read", base_id=BASE_ID)
     assert authorize(user, permission="beneficiary:read", base_id=BASE_ID)
-    assert authorize(user, permission="category:read")
+    assert authorize(user, permission="product_category:read")
     assert authorize(user, permission="location:read", base_id=BASE_ID)
     assert authorize(user, permission="product:read", base_id=BASE_ID)
     assert authorize(user, permission="shipment:read", base_id=BASE_ID)
@@ -134,7 +134,7 @@ def test_user_with_insufficient_permissions():
         authorize(user, permission="product:read", base_id=1)
     with pytest.raises(Forbidden):
         # The base-agnostic permission field is not part of the user's permissions
-        authorize(user, permission="category:read")
+        authorize(user, permission="product_category:read")
 
 
 def test_invalid_authorize_function_call():


### PR DESCRIPTION
More precise naming matching the model name (ProductCategory)

- :heavy_check_mark: Auth0 actions updated for dev, staging, and production tenants
- :heavy_check_mark: [RBP google sheet](https://docs.google.com/spreadsheets/d/1W4YWcc59wUFUWgReumdH6DQ4zU7JcTgvf6WEbdqaGHQ/edit#gid=593366918) updated
