### PR TITLE
[4th viz] Extend movedBoxes data with info about shipped/lost/scrap boxes

### DIFF
--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -15,9 +15,11 @@ from ...models.definitions.transaction import Transaction
 from ...models.utils import compute_age, convert_ids
 
 
-def _generate_dimensions(*names, facts):
+def _generate_dimensions(*names, target_type=None, facts):
     """Return a dictionary holding information (ID, name) about dimensions with
     specified names.
+    If `target_type` is set, add a 'target' field containing information about a target
+    with given type.
     """
     dimensions = {}
 
@@ -48,12 +50,11 @@ def _generate_dimensions(*names, facts):
             .dicts()
         )
 
-    if "target" in names:
+    if target_type is not None:
         target_ids = {f["target_id"] for f in facts}
         # Target ID and name are identical for now
         dimensions["target"] = [
-            {"id": i, "name": i, "type": TargetType.OutgoingLocation}
-            for i in target_ids
+            {"id": i, "name": i, "type": target_type} for i in target_ids
         ]
 
     return dimensions
@@ -286,5 +287,7 @@ def compute_moved_boxes(base_id):
     for row in facts:
         row["moved_on"] = row["moved_on"].date()
 
-    dimensions = _generate_dimensions("category", "target", facts=facts)
+    dimensions = _generate_dimensions(
+        "category", target_type=TargetType.OutgoingLocation, facts=facts
+    )
     return {"facts": facts, "dimensions": dimensions}

--- a/back/boxtribute_server/enums.py
+++ b/back/boxtribute_server/enums.py
@@ -119,3 +119,4 @@ class TaggableObjectType(enum.Enum):
 class TargetType(enum.IntEnum):
     Shipment = 1
     OutgoingLocation = enum.auto()
+    BoxState = enum.auto()

--- a/back/boxtribute_server/graph_ql/definitions/public_api.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public_api.graphql
@@ -142,4 +142,5 @@ type TargetDimensionInfo implements BasicDimensionInfo {
 enum TargetType {
   Shipment
   OutgoingLocation
+  BoxState
 }

--- a/back/test/data/history.py
+++ b/back/test/data/history.py
@@ -6,7 +6,7 @@ from boxtribute_server.models.definitions.history import DbChangeHistory
 
 from .box import another_marked_for_shipment_box_data
 from .box import data as box_data
-from .box import donated_boxes_data
+from .box import donated_boxes_data, lost_box_data
 
 
 def data():
@@ -20,6 +20,15 @@ def data():
                 "to_int": 3,
                 "record_id": another_marked_for_shipment_box_data()["id"],
                 "change_date": datetime(2023, 6, 21),
+                "table_name": "stock",
+            },
+            {
+                "id": 111,
+                "changes": "box_state_id",
+                "from_int": BoxState.InStock,
+                "to_int": BoxState.Lost,
+                "record_id": lost_box_data()["id"],
+                "change_date": datetime(2023, 2, 1),
                 "table_name": "stock",
             },
             {"id": 112, "changes": "Changes"},

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -300,7 +300,7 @@ def test_box_mutations(
         .dicts()
     )
     box_id = int(updated_box["id"])
-    assert history[19:] == [
+    assert history[20:] == [
         {
             "changes": "Record created",
             "from_int": None,

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from boxtribute_server.enums import ProductGender, TargetType
 from boxtribute_server.models.utils import compute_age
 from utils import assert_successful_request
@@ -159,29 +161,41 @@ def test_query_top_products(
     }
 
 
-def test_query_moved_boxes(read_only_client, default_location):
+def test_query_moved_boxes(read_only_client, default_location, default_bases):
     query = """query { movedBoxes(baseId: 1) {
         facts { movedOn targetId categoryId boxesCount }
         dimensions { target { id name type } }
         } }"""
     data = assert_successful_request(read_only_client, query, endpoint="public")
-    target_id = default_location["name"]
+    location_name = default_location["name"]
+    base_name = default_bases[3]["name"]
     assert data == {
         "facts": [
             {
                 "boxesCount": 3,
                 "categoryId": 1,
-                "targetId": target_id,
+                "targetId": location_name,
                 "movedOn": "2022-12-05",
+            },
+            {
+                "boxesCount": 5,
+                "categoryId": 1,
+                "targetId": base_name,
+                "movedOn": date.today().isoformat(),
             },
         ],
         "dimensions": {
             "target": [
                 {
-                    "id": target_id,
-                    "name": target_id,
+                    "id": location_name,
+                    "name": location_name,
                     "type": TargetType.OutgoingLocation.name,
-                }
+                },
+                {
+                    "id": base_name,
+                    "name": base_name,
+                    "type": TargetType.Shipment.name,
+                },
             ],
         },
     }

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from boxtribute_server.enums import ProductGender, TargetType
+from boxtribute_server.enums import BoxState, ProductGender, TargetType
 from boxtribute_server.models.utils import compute_age
 from utils import assert_successful_request
 
@@ -183,6 +183,12 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases):
                 "targetId": base_name,
                 "movedOn": date.today().isoformat(),
             },
+            {
+                "boxesCount": 1,
+                "categoryId": 1,
+                "targetId": BoxState.Lost.name,
+                "movedOn": "2023-02-01",
+            },
         ],
         "dimensions": {
             "target": [
@@ -195,6 +201,11 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases):
                     "id": base_name,
                     "name": base_name,
                     "type": TargetType.Shipment.name,
+                },
+                {
+                    "id": BoxState.Lost.name,
+                    "name": BoxState.Lost.name,
+                    "type": TargetType.BoxState.name,
                 },
             ],
         },

--- a/statviz/src/types/generated/graphql.ts
+++ b/statviz/src/types/generated/graphql.ts
@@ -256,6 +256,7 @@ export type TargetDimensionInfo = BasicDimensionInfo & {
 };
 
 export enum TargetType {
+  BoxState = 'BoxState',
   OutgoingLocation = 'OutgoingLocation',
   Shipment = 'Shipment'
 }


### PR DESCRIPTION
This PR brings two new target types ("Shipment" and "BoxState") and collect info about shipped boxes, and lost/scrap boxes, resp.) into the result of the `movedBoxes` query.

Test by connecting with prod DB and running the FE for Moved Boxes.

### Explanation

Target type | movedOn | targetId
--- | --- | ---
Shipment | timestamp of when the shipment was sent | name of target base
BoxState | timestamp of when the box was set to Lost/Scrap state | name of box state
