### PR TITLE
Use GraphiQL explorer

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -335,16 +335,16 @@ For building a static web documentation of the schema, see [this directory](../d
 
 For the production schema, documentation can be found online at `api.boxtribute.org/docs`.
 
-### Playground
+### GraphQL API explorer
 
-You can experiment with the API in the GraphQL playground.
+You can experiment with the API in the `GraphiQL` GraphQL explorer.
 
 1. Activate the virtual environment
 1. Start the required services by `docker-compose up webapp`
-1. Open `localhost:5005/graphql` (or `/` for the query-only API; or `/public` for the statistics API, then the next steps can be skipped)
+1. Open `localhost:5005/graphql` (or `/` for the query-only API; or `/public` for the statviz API, then the next steps can be skipped)
 1. Simulate being a valid, logged-in user by fetching an authorization token: `./fetch_token --test`
 1. Copy the displayed token
-1. Insert the access token in the following format on the playground in the section on the bottom left of the playground called HTTP Headers.
+1. Insert the access token in the following format in the section called 'Headers' on the bottom left of the explorer.
 
         { "authorization": "Bearer <the token you retrieved from Auth0>"}
 
@@ -400,7 +400,7 @@ Launch the production server by
 
     ENVIRONMENT=production docker-compose up --build webapp
 
-In production mode, inspection of the GraphQL server is disabled, i.e. it's not possible to run the GraphQL playground.
+In production mode, inspection of the GraphQL server is disabled, i.e. it's not possible to use auto-completion the GraphQL explorer.
 
 ## Performance evaluation
 

--- a/back/boxtribute_server/app.py
+++ b/back/boxtribute_server/app.py
@@ -56,7 +56,7 @@ def main(*blueprints):
 
         error_class, error, _ = exc_info
         if issubclass(error_class, GraphQLError) and not error.extensions:
-            # Don't send GraphQLErrors from the Query API caused by GraphQL Playground
+            # Don't send GraphQLErrors from the Query API caused by GraphQL explorer
             # users during experimenting/typing. Authz and validation errors (custom
             # back-end exceptions) are still reported because they have the 'extensions'
             # attribute

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -22,8 +22,8 @@ app_bp = Blueprint("app_bp", __name__)
 # Allowed headers for CORS
 CORS_HEADERS = ["Content-Type", "Authorization", "x-clacks-overhead"]
 
-PLAYGROUND_TITLE = "boxtribute API"
-PLAYGROUND_HTML = ExplorerGraphiQL(title=PLAYGROUND_TITLE).html(None)
+EXPLORER_TITLE = "boxtribute API"
+EXPLORER_HTML = ExplorerGraphiQL(title=EXPLORER_TITLE).html(None)
 
 
 @api_bp.errorhandler(AuthenticationFailed)
@@ -35,8 +35,8 @@ def handle_auth_error(ex):
 
 
 @api_bp.route("/", methods=["GET"])
-def query_api_playground():
-    return PLAYGROUND_HTML, 200
+def query_api_explorer():
+    return EXPLORER_HTML, 200
 
 
 @api_bp.route("/", methods=["POST"])
@@ -115,13 +115,9 @@ def graphql_server():
 
 @app_bp.route("/graphql", methods=["GET"])
 def graphql_playgroud():
-    # On GET request serve GraphQL Playground
-    # You don't need to provide Playground if you don't want to
-    # but keep on mind this will not prohibit clients from
-    # exploring your API using desktop GraphQL Playground app.
-    return PLAYGROUND_HTML, 200
+    return EXPLORER_HTML, 200
 
 
 @api_bp.route("/public", methods=["GET"])
 def public():
-    return PLAYGROUND_HTML, 200
+    return EXPLORER_HTML, 200

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -1,7 +1,7 @@
 """Construction of routes for web app and API"""
 import os
 
-from ariadne.explorer import ExplorerPlayground
+from ariadne.explorer import ExplorerGraphiQL
 from flask import Blueprint, jsonify, request
 from flask_cors import cross_origin
 
@@ -23,7 +23,7 @@ app_bp = Blueprint("app_bp", __name__)
 CORS_HEADERS = ["Content-Type", "Authorization", "x-clacks-overhead"]
 
 PLAYGROUND_TITLE = "boxtribute API"
-PLAYGROUND_HTML = ExplorerPlayground(title=PLAYGROUND_TITLE).html(None)
+PLAYGROUND_HTML = ExplorerGraphiQL(title=PLAYGROUND_TITLE).html(None)
 
 
 @api_bp.errorhandler(AuthenticationFailed)

--- a/back/test/endpoint_tests/test_simple.py
+++ b/back/test/endpoint_tests/test_simple.py
@@ -1,15 +1,15 @@
 import pytest
-from boxtribute_server.routes import PLAYGROUND_TITLE
+from boxtribute_server.routes import EXPLORER_TITLE
 
 
 @pytest.mark.parametrize("endpoint", ["", "graphql"])
 def test_private_endpoint(read_only_client, endpoint):
     response = read_only_client.get(f"/{endpoint}")
     assert response.status_code == 200
-    assert PLAYGROUND_TITLE in response.data.decode()
+    assert EXPLORER_TITLE in response.data.decode()
 
 
 def test_public_endpoint(read_only_client):
     response = read_only_client.get("/public")
     assert response.status_code == 200
-    assert PLAYGROUND_TITLE in response.data.decode()
+    assert EXPLORER_TITLE in response.data.decode()

--- a/docs/adr/adr_sizes-in-api.md
+++ b/docs/adr/adr_sizes-in-api.md
@@ -91,7 +91,7 @@ OR:
 #### Pros/Cons
 
 ##### Pros
-* more user friendliness / easier documentation when users interact with the API via the GraphQL Playground
+* more user friendliness / easier documentation when users interact with the API via the GraphQL explorer
 * potentially a slightly better performance (but probably not making a difference for the User Experience)
 
 ##### Cons
@@ -161,7 +161,7 @@ Boxes Table
 * full freedom regarding the naming of the size values (no mapping needed from Enum values to user friendly names)
 ##### Cons
 * potentially a (very small) performance disadvantage compared to Option 1 (additional reference table when querying boxes)
-* no auto complete/suggestions for the possible values when users interact with the API in the GraphQL playground
+* no auto complete/suggestions for the possible values when users interact with the API in the GraphQL explorer
 
 ### 3. Alternative: Variation of 2, to support more fine grained details about sizes (e.g. differentiating between non-numeric and numeric sizes, adding units to numeric sizes) - more for a potential extension of 2 for the future
 

--- a/docs/graphql-api/full-api-config.yml
+++ b/docs/graphql-api/full-api-config.yml
@@ -254,7 +254,7 @@ info:
         1. Use the `fetch_token` script to obtain a test user JWT. See the back-end README for details.
         1. Copy the content of the `access_token` field of the response JSON
         1. Paste the token into the HTTP headers when sending a request to the API, like `{"Authorization": "Bearer TOKEN"}`
-        1. When using the GraphQL Playground, paste the header into the respective field in the bottom left.
+        1. When using the GraphQL explorer, paste the header into the respective field in the bottom left.
 
   # If you really want to hide the "Documentation by" at the bottom of your output, you can do so here
   # Default: false

--- a/docs/graphql-api/query-api-config.yml
+++ b/docs/graphql-api/query-api-config.yml
@@ -225,9 +225,9 @@ info:
   description: |
     These pages contain the documentation for the boxtribute GraphQL API (queries only). Have fun exploring!
 
-    You can interact with the API the following ways:
-    1. Open the endpoint address in your browser. This launches GraphQL Playground
-    1. Send POST requests to the endpoint from a script or the command line, passing your GraphQL query in the `query` field of the request JSON
+    You can interact with the API in either of the following ways:
+    - Open the endpoint address in your browser. This launches the GraphQL explorer
+    - Send POST requests to the endpoint from a script or the command line, passing your GraphQL query in the `query` field of the request JSON
   # Don't change the version number manually. It's substituted at deploy time in CircleCI
   version: 0.0.1
   title: Welcome!
@@ -263,7 +263,7 @@ info:
         1. You need your username and password that you log in to `app.boxtribute.org` with. Pass it in the JSON part of a POST response to `api.boxtribute.org/token`, like `{"username": "my-email-address", "password": "PASSWORD"}`
         1. Copy the content of the `access_token` field of the response JSON
         1. Paste the token into the HTTP headers when sending a request to the API, like `{"Authorization": "Bearer TOKEN"}`
-        1. When using the GraphQL Playground, paste the header into the respective field in the bottom left.
+        1. When using the GraphQL explorer, paste the header into the respective field in the bottom left.
 
   # If you really want to hide the "Documentation by" at the bottom of your output, you can do so here
   # Default: false


### PR DESCRIPTION
The old GraphQL playground was deprecated, long live GraphiQL explorer (see trello card).

Please check it out quickly: e.g. `localhost:5005/graphql`
It looks a bit different at first (but you can configure it to use a dark theme in the settings on the bottom left).