### PR TITLE
Resolve qr hash forwarded from dropapp

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -27,6 +27,7 @@ import ShipmentView from "views/Transfers/ShipmentView/ShipmentView";
 import QrReaderView from "views/QrReader/QrReaderView";
 import NotFoundView from "views/NotFoundView/NotFoundView";
 import { useAuthorization } from "hooks/useAuthorization";
+import ResolveHash from "views/QrReader/components/ResolveHash";
 
 interface IProtectedRouteProps {
   minBeta: number;
@@ -65,20 +66,13 @@ function App() {
   return (
     <Routes>
       <Route index />
-      <Route path="bases" element={<Layout />}>
+      <Route path="bases">
         <Route index />
-        <Route path=":baseId">
+        <Route path=":baseId" element={<Layout />}>
           <Route index element={<BaseDashboardView />} />
-          <Route path="transfers" element={<ProtectedRoute minBeta={2} redirectPath="/qrreader" />}>
-            <Route path="agreements">
-              <Route index element={<TransferAgreementOverviewView />} />
-              <Route path="create" element={<CreateTransferAgreementView />} />
-            </Route>
-            <Route path="shipments">
-              <Route index element={<ShipmentsOverviewView />} />
-              <Route path="create" element={<CreateShipmentView />} />
-              <Route path=":id" element={<ShipmentView />} />
-            </Route>
+          <Route path="qrreader">
+            <Route index element={<QrReaderView />} />
+            <Route path=":hash" element={<ResolveHash />} />
           </Route>
           <Route path="boxes">
             <Route index element={<Boxes />} />
@@ -88,6 +82,17 @@ function App() {
             <Route path=":labelIdentifier">
               <Route index element={<BTBox />} />
               <Route path="edit" element={<BoxEditView />} />
+            </Route>
+          </Route>
+          <Route path="transfers" element={<ProtectedRoute minBeta={2} redirectPath="/qrreader" />}>
+            <Route path="agreements">
+              <Route index element={<TransferAgreementOverviewView />} />
+              <Route path="create" element={<CreateTransferAgreementView />} />
+            </Route>
+            <Route path="shipments">
+              <Route index element={<ShipmentsOverviewView />} />
+              <Route path="create" element={<CreateShipmentView />} />
+              <Route path=":id" element={<ShipmentView />} />
             </Route>
           </Route>
           <Route path="distributions">
@@ -116,7 +121,6 @@ function App() {
               </Route>
             </Route>
           </Route>
-          <Route path="qrreader" element={<QrReaderView />} />
         </Route>
       </Route>
       <Route path="/*" element={<NotFoundView />} />

--- a/front/src/views/QrReader/components/ResolveHash.test.tsx
+++ b/front/src/views/QrReader/components/ResolveHash.test.tsx
@@ -1,6 +1,6 @@
 import { useAuth0 } from "@auth0/auth0-react";
 import { QrReaderScanner } from "components/QrReader/components/QrReaderScanner";
-// import { GraphQLError } from "graphql";
+import { GraphQLError } from "graphql";
 import { useErrorHandling } from "hooks/useErrorHandling";
 import { generateMockBox } from "mocks/boxes";
 import { mockImplementationOfQrReader } from "mocks/components";
@@ -8,7 +8,7 @@ import { mockAuthenticatedUser } from "mocks/hooks";
 import { cache } from "queries/cache";
 import { GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE } from "queries/queries";
 import { BoxState } from "types/generated/graphql";
-import { render, screen } from "tests/test-utils";
+import { render, screen, waitFor } from "tests/test-utils";
 import ResolveHash from "./ResolveHash";
 
 // extracting a cacheObject to reset the cache correctly later
@@ -86,37 +86,81 @@ SuccessfulQrScanningTests.forEach(({ name, hash, mocks, endRoute }) => {
       cache,
     });
 
+    expect(screen.queryByTestId("ReturnScannedQr")).not.toBeInTheDocument();
+
     expect(await screen.findByTestId("box-sections")).toBeInTheDocument();
+
+    expect(screen.queryByTestId("ReturnScannedQr")).not.toBeInTheDocument();
 
     expect(await screen.findByRole("heading", { name: endRoute })).toBeInTheDocument();
   });
 });
 
-// const mockFailedQrQuery = ({
-//   query = GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE,
-//   hash = "",
-//   errorCode = "",
-//   resultQrCode = null as string | null | undefined,
-//   networkError = false,
-// }) => ({
-//   request: {
-//     query,
-//     variables: { qrCode: hash },
-//   },
-//   result: networkError
-//     ? undefined
-//     : {
-//         data:
-//           resultQrCode != null
-//             ? {
-//                 qrCode: {
-//                   _typename: "QrCode",
-//                   code: hash,
-//                   box: null,
-//                 },
-//               }
-//             : null,
-//         errors: [new GraphQLError("Error!", { extensions: { code: errorCode } })],
-//       },
-//   error: networkError ? new Error() : undefined,
-// });
+const mockFailedQrQuery = ({
+  query = GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE,
+  hash = "",
+  errorCode = "",
+  networkError = false,
+}) => ({
+  request: {
+    query,
+    variables: { qrCode: hash },
+  },
+  result: networkError
+    ? undefined
+    : {
+        data: null,
+        errors: [new GraphQLError("Error!", { extensions: { code: errorCode } })],
+      },
+  error: networkError ? new Error() : undefined,
+});
+
+const FailedQrScanningTests = [
+  {
+    name: "3.4.8.4 - User scans QR code of different org with associated box",
+    hash: "QrWithBoxFromDifferentBase",
+    mocks: [mockFailedQrQuery({ hash: "QrWithBoxFromDifferentBase", errorCode: "FORBIDDEN" })],
+    toast: /You don't have permission to access this box/i,
+  },
+  {
+    name: "3.4.8.7 - User scans QR code where hash is not found in db",
+    hash: "NoBoxtributeQr",
+    mocks: [mockFailedQrQuery({ hash: "NoBoxtributeQr", errorCode: "BAD_USER_INPUT" })],
+    toast: /No box found for this QR code/i,
+  },
+  {
+    name: "3.4.8.8 - User scans QR code and server returns unexpected error",
+    hash: "QrServerFailure",
+    mocks: [mockFailedQrQuery({ hash: "QrServerFailure", errorCode: "SERVER_ERROR" })],
+    toast: /QR code lookup failed. Please wait a bit and try again./i,
+  },
+  {
+    name: "3.4.8.9 - User scans QR code and a network error is returned",
+    hash: "QrNetworkError",
+    mocks: [mockFailedQrQuery({ hash: "QrNetworkError", networkError: true })],
+    toast: /QR code lookup failed. Please wait a bit and try again./i,
+  },
+];
+
+FailedQrScanningTests.forEach(({ name, hash, mocks, toast }) => {
+  it(name, async () => {
+    mockImplementationOfQrReader(mockedQrReader, hash, true, true);
+    render(<ResolveHash />, {
+      routePath: "/bases/1/qrreader/:hash",
+      initialUrl: `/bases/1/qrreader/${hash}`,
+      mocks,
+      cache,
+    });
+
+    expect(await screen.findByTestId("ReturnScannedQr")).toBeInTheDocument();
+
+    // toast shown
+    await waitFor(() =>
+      expect(mockedTriggerError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(toast),
+        }),
+      ),
+    );
+  });
+});

--- a/front/src/views/QrReader/components/ResolveHash.test.tsx
+++ b/front/src/views/QrReader/components/ResolveHash.test.tsx
@@ -1,0 +1,122 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import { QrReaderScanner } from "components/QrReader/components/QrReaderScanner";
+// import { GraphQLError } from "graphql";
+import { useErrorHandling } from "hooks/useErrorHandling";
+import { generateMockBox } from "mocks/boxes";
+import { mockImplementationOfQrReader } from "mocks/components";
+import { mockAuthenticatedUser } from "mocks/hooks";
+import { cache } from "queries/cache";
+import { GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE } from "queries/queries";
+import { BoxState } from "types/generated/graphql";
+import { render, screen } from "tests/test-utils";
+import ResolveHash from "./ResolveHash";
+
+// extracting a cacheObject to reset the cache correctly later
+const emptyCache = cache.extract();
+
+// Toasts are persisting throughout the tests since they are rendered in the wrapper and not in the render.
+// Therefore, we need to mock them since otherwise we easily get false negatives
+// Everywhere where we have more than one occation of a toast we should do this.
+const mockedTriggerError = jest.fn();
+jest.mock("hooks/useErrorHandling");
+jest.mock("@auth0/auth0-react");
+jest.mock("components/QrReader/components/QrReaderScanner");
+
+// .mocked() is a nice helper function from jest for typescript support
+// https://jestjs.io/docs/mock-function-api/#typescript-usage
+const mockedUseAuth0 = jest.mocked(useAuth0);
+const mockedQrReader = jest.mocked(QrReaderScanner);
+
+beforeEach(() => {
+  mockAuthenticatedUser(mockedUseAuth0, "dev_volunteer@boxaid.org");
+  const mockedUseErrorHandling = jest.mocked(useErrorHandling);
+  mockedUseErrorHandling.mockReturnValue({ triggerError: mockedTriggerError });
+});
+
+afterEach(() => {
+  cache.restore(emptyCache);
+});
+
+const mockSuccessfulQrQuery = ({
+  query = GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE,
+  hash = "abc",
+  isBoxAssociated = true,
+  labelIdentifier = "123",
+  state = BoxState.InStock,
+}) => ({
+  delay: 100,
+  request: {
+    query,
+    variables: { qrCode: hash },
+  },
+  result: {
+    data: {
+      qrCode: {
+        _typename: "QrCode",
+        code: hash,
+        box: isBoxAssociated ? generateMockBox({ labelIdentifier, state }) : null,
+      },
+    },
+  },
+});
+
+const SuccessfulQrScanningTests = [
+  {
+    name: "3.4.8.2 - User scans QR code of same org without previously associated box",
+    hash: "QrWithoutBox",
+    mocks: [mockSuccessfulQrQuery({ hash: "QrWithoutBox", isBoxAssociated: false })],
+    endRoute: "/bases/1/boxes/create/QrWithoutBox",
+  },
+  {
+    name: "3.4.8.3 - User scans QR code of same org with associated box",
+    hash: "QrWithBoxFromSameBase",
+    mocks: [mockSuccessfulQrQuery({ hash: "QrWithBoxFromSameBase" })],
+    endRoute: "/bases/1/boxes/123",
+  },
+];
+
+SuccessfulQrScanningTests.forEach(({ name, hash, mocks, endRoute }) => {
+  it(name, async () => {
+    mockImplementationOfQrReader(mockedQrReader, hash, true, true);
+    render(<ResolveHash />, {
+      routePath: "/bases/1/qrreader/:hash",
+      initialUrl: `/bases/1/qrreader/${hash}`,
+      additionalRoute: endRoute,
+      mocks,
+      cache,
+    });
+
+    expect(await screen.findByTestId("box-sections")).toBeInTheDocument();
+
+    expect(await screen.findByRole("heading", { name: endRoute })).toBeInTheDocument();
+  });
+});
+
+// const mockFailedQrQuery = ({
+//   query = GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE,
+//   hash = "",
+//   errorCode = "",
+//   resultQrCode = null as string | null | undefined,
+//   networkError = false,
+// }) => ({
+//   request: {
+//     query,
+//     variables: { qrCode: hash },
+//   },
+//   result: networkError
+//     ? undefined
+//     : {
+//         data:
+//           resultQrCode != null
+//             ? {
+//                 qrCode: {
+//                   _typename: "QrCode",
+//                   code: hash,
+//                   box: null,
+//                 },
+//               }
+//             : null,
+//         errors: [new GraphQLError("Error!", { extensions: { code: errorCode } })],
+//       },
+//   error: networkError ? new Error() : undefined,
+// });

--- a/front/src/views/QrReader/components/ResolveHash.tsx
+++ b/front/src/views/QrReader/components/ResolveHash.tsx
@@ -1,0 +1,53 @@
+import { IQrResolvedValue, IQrResolverResultKind, useQrResolver } from "hooks/useQrResolver";
+import { useNavigate, useParams } from "react-router-dom";
+import { useContext, useEffect, useState } from "react";
+import { GlobalPreferencesContext } from "providers/GlobalPreferencesProvider";
+import { BoxViewSkeleton } from "components/Skeletons";
+import QrReaderView from "../QrReaderView";
+
+function ResolveHash() {
+  const navigate = useNavigate();
+  const { resolveQrHash } = useQrResolver();
+  const { globalPreferences } = useContext(GlobalPreferencesContext);
+  const baseId = globalPreferences.selectedBase?.id!;
+  const [resolvedValue, setResolvedValue] = useState<IQrResolvedValue | undefined>(undefined);
+
+  const hash = useParams<{ hash: string }>().hash!;
+
+  useEffect(() => {
+    resolveQrHash(hash, "network-only")
+      .then((value) => {
+        setResolvedValue(value);
+      })
+      .catch(() => {
+        setResolvedValue({
+          kind: IQrResolverResultKind.FAIL,
+          qrHash: hash,
+        } as IQrResolvedValue);
+      });
+  }, [hash, resolveQrHash]);
+
+  if (!resolvedValue) {
+    return <BoxViewSkeleton data-testid="loader" />;
+  }
+
+  switch (resolvedValue.kind) {
+    case IQrResolverResultKind.SUCCESS: {
+      const boxLabelIdentifier = resolvedValue.box.labelIdentifier;
+      const boxBaseId = resolvedValue.box.location.base.id;
+      navigate(`/bases/${boxBaseId}/boxes/${boxLabelIdentifier}`);
+      break;
+    }
+    case IQrResolverResultKind.NOT_ASSIGNED_TO_BOX: {
+      navigate(`/bases/${baseId}/boxes/create/${resolvedValue.qrHash}`);
+
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+  return <QrReaderView />;
+}
+
+export default ResolveHash;

--- a/front/src/views/QrReader/components/ResolveHash.tsx
+++ b/front/src/views/QrReader/components/ResolveHash.tsx
@@ -28,7 +28,7 @@ function ResolveHash() {
   }, [hash, resolveQrHash]);
 
   if (!resolvedValue) {
-    return <BoxViewSkeleton data-testid="loader" />;
+    return <BoxViewSkeleton />;
   }
 
   switch (resolvedValue.kind) {


### PR DESCRIPTION
@pylipp and @aerinsol:

## What has changed?
Since we disabled the [mobile part of dropapp](https://github.com/boxwise/dropapp/pull/566), there is a bit of routing that moved to v2 for the case that a user scans a QR-code with an external QR-Reader.
In this case, the external QR-Reader requests the mobile.php url from dropapp which now just forwards the qr hash to v2. The business logic if BoxView should be shown or BoxCreate or an Error lies no in v2.

## Test cases
Generally, I would like to ask you both to test most of the test cases of 3.4.8 of the FE functional tests of the test plan.
You can use the following hashes from the staging seed for the tests:

- QR-Code without Box: '168df347206ed26cd2213c0e4767ccb'
- QR-Code with Box in base 1: 'db7d22cebdc57632bfc0a23a504424b'
- QR-Code with Box in base 2: '0a85f8d3bc751ce1469bd357e56e922'
- QR-Code with Box in base 3: 'dc89000023e5fe7148bfd77bc9ddbfb'
- QR-Code connected to soft-deleted Box in base 1: You have to delete a box first through dropapp or set the deleted value in stock for a box
- legacy QR-Code connected to Box in base 1: I do not know yet how to recreate this, but I checked production and there are only 5 InStock Boxes left in Nea Kavala that are still relevant for this case.

## How to test
@pylipp: If you don't wanna run dropapp in parallel, I'd suggest you always start with requesting `/qrreader/<hash>` and use a hash that is true for the test cases in 3.4.8.

@aerinsol: Once it is merged and deployed to master, I would like you to always start from dropapp and also check if the redirecting works properly. --> start your tests with requesting `staging.boxtribute.org/mobile.php?barcode=<hash>`
Of course, you can also just scan then qr-codes generated and used on staging.
