### PR TITLE
ShipmentView: Change Style of Cannot Locat Shipment Button

### DIFF
--- a/front/src/views/Transfers/ShipmentView/components/ShipmentActionButtons.tsx
+++ b/front/src/views/Transfers/ShipmentView/components/ShipmentActionButtons.tsx
@@ -62,7 +62,7 @@ function ShipmentActionButtons({
     colorScheme: "red",
     isDisabled: shipmentContents.length === 0,
     isLoading: isLoadingFromMutation,
-    variant: "ghost",
+    variant: "outline",
     onClick: openShipmentOverlay,
     size: "md",
     marginTop: 2,


### PR DESCRIPTION
The PR changes the style of the "Cannot Locate Shipment" button from ghost to outline.