### PR TITLE
Avoid triggering 'select * from stock'

### DIFF
--- a/back/boxtribute_server/graph_ql/filtering.py
+++ b/back/boxtribute_server/graph_ql/filtering.py
@@ -58,7 +58,8 @@ def derive_box_filter(filter_input, selection=None):
     corresponding model selection. If no parameters given, return True (i.e. no
     filtering applied) and `Box.select()`.
     """
-    selection = selection or Box.select()
+    if selection is None:
+        selection = Box.select()
     if not filter_input:
         return True, selection
 


### PR DESCRIPTION
See 4f22adc2d or https://github.com/coleifer/peewee/issues/2586 for
details.
This hopefully fixes excessive memory usage when the BE tries to fetch
and cache 100k of rows from the stock table.
