### PR TITLE
Inspect boxes-query performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,8 @@ yarn-error.log*
 node_modules
 **/node_modules
 
+**/dump*.sql
+
 # environments
 .env.*
 .env

--- a/back/boxtribute_server/business_logic/warehouse/box/queries.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/queries.py
@@ -25,13 +25,18 @@ def resolve_box(*_, label_identifier):
 def resolve_boxes(*_, base_id, pagination_input=None, filter_input=None):
     authorize(permission="stock:read", base_id=base_id)
 
-    # Join with Location model to filter for Location base ID below
-    selection = Box.select().join(Location)
+    selection = Box.select().join(
+        Location,
+        on=(
+            (Box.location == Location.id)
+            & (Location.base == base_id)
+            & ((Box.deleted == 0) | (Box.deleted.is_null()))
+        ),
+    )
     filter_condition, selection = derive_box_filter(filter_input, selection=selection)
 
     return load_into_page(
         Box,
-        Location.base == base_id,
         filter_condition,
         selection=selection,
         pagination_input=pagination_input,

--- a/back/boxtribute_server/graph_ql/pagination.py
+++ b/back/boxtribute_server/graph_ql/pagination.py
@@ -196,10 +196,11 @@ def load_into_page(model, *conditions, selection=None, pagination_input):
 
     if selection is None:
         selection = model.select()
-    query_result = (
+    query_result = list(
         selection.where(pagination_condition, *conditions)
         .order_by(model.id)
         .limit(limit + 1)
+        .iterator()
     )
     return generate_page(
         *conditions,

--- a/back/gunicorn.conf.py
+++ b/back/gunicorn.conf.py
@@ -3,5 +3,5 @@ https://docs.gunicorn.org/en/stable/settings.html#
 """
 workers = 1
 threads = 1
-bind = "0.0.0.0:5000"
+bind = "0.0.0.0:5005"
 # loglevel = "debug"


### PR DESCRIPTION
I inspected SQL generated by peewee, and profiled the stack of the app when executing the `boxes` GraphQL query while using a production DB dump.

### Findings

- I could improve filtering of the select-query (filter on join instead of where)
- I added a filter for non-deleted boxes
- when a large result is queried, there will be overhead with both peewee and ariadne
    - peewee as the ORM will have significant overhead transforming the raw SQL rows into Python objects (e.g. datetime parsing is quite costly)
    - ariadne will issue an enormous amount of function calls to resolve the query fields (e.g. for each box the location and product), and since these make use of batch-loading, the eventual resolving of awaitables has an overhead, too


### Possible solutions braindump

- smaller size of requested data (i.e. true pagination, only instock boxes, see #1157)
- hand-craft a single SQL query in the `boxes` resolver (this somewhat defeats the purpose of GraphQL)
- experiment with a new, synchronous [batch-loading library](https://github.com/jkimbo/graphql-sync-dataloaders): in order to use the `aiodataloader` library, currently an asyncio routine is patched into the (sync) Flask app with the (sync) ORM peewee. Maybe this generates significant overhead.
- in combination with the previous, try to speed up Python execution time using [gevent](https://docs.peewee-orm.com/en/latest/peewee/database.html#async-with-gevent) async execution
