### PR TITLE
[6th viz] BE and GraphQL interface

### DIFF
--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -82,7 +82,7 @@ def compute_beneficiary_demographics(base_id):
     age = fn.IF(
         Beneficiary.date_of_birth > 0, compute_age(Beneficiary.date_of_birth), None
     )
-    tag_ids = fn.GROUP_CONCAT(TagsRelation.tag).python_value(convert_ids)
+    tag_ids = fn.GROUP_CONCAT(TagsRelation.tag.distinct()).python_value(convert_ids)
 
     demographics = (
         Beneficiary.select(
@@ -255,7 +255,7 @@ def compute_moved_boxes(base_id):
         .alias("sq")
     )
 
-    tag_ids = fn.GROUP_CONCAT(TagsRelation.tag).python_value(convert_ids)
+    tag_ids = fn.GROUP_CONCAT(TagsRelation.tag.distinct()).python_value(convert_ids)
     # This selects only information of boxes that were moved from InStock to Donated
     # state, and are now in the base of given base ID. It is NOT taken into account that
     # boxes can be moved back from Donated to InStock, nor that the product or other

--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -270,6 +270,7 @@ def compute_moved_boxes(base_id):
             Size.id.alias("size_id"),
             tag_ids.alias("tag_ids"),
             fn.COUNT(Box.id).alias("boxes_count"),
+            fn.SUM(Box.number_of_items).alias("items_count"),
         )
         .join(
             LatestMovedSubQuery,
@@ -328,6 +329,7 @@ def compute_moved_boxes(base_id):
             tag_ids.alias("tag_ids"),
             Base.name.alias("target_id"),
             fn.COUNT(ShipmentDetail.box).alias("boxes_count"),
+            fn.SUM(ShipmentDetail.source_quantity).alias("items_count"),
         )
         .join(
             Shipment,
@@ -385,6 +387,7 @@ def compute_moved_boxes(base_id):
             tag_ids.alias("tag_ids"),
             BoxStateModel.label.alias("target_id"),
             fn.COUNT(DbChangeHistory.id).alias("boxes_count"),
+            fn.SUM(Box.number_of_items).alias("items_count"),
         )
         .join(
             Box,

--- a/back/boxtribute_server/graph_ql/definitions/public/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public/types.graphql
@@ -94,11 +94,15 @@ type MovedBoxesResult {
   movedOn: Date!
   targetId: ID!
   categoryId: Int!
+  productName: String!
+  gender: ProductGender!
+  sizeId: Int!
   boxesCount: Int!
 }
 
 type MovedBoxDataDimensions {
   category: [DimensionInfo]
+  size: [DimensionInfo]
   target: [TargetDimensionInfo]
 }
 

--- a/back/boxtribute_server/graph_ql/definitions/public/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public/types.graphql
@@ -97,12 +97,14 @@ type MovedBoxesResult {
   productName: String!
   gender: ProductGender!
   sizeId: Int!
+  tagIds: [Int!]
   boxesCount: Int!
 }
 
 type MovedBoxDataDimensions {
   category: [DimensionInfo]
   size: [DimensionInfo]
+  tag: [TagDimensionInfo!]!
   target: [TargetDimensionInfo]
 }
 

--- a/back/boxtribute_server/graph_ql/definitions/public/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/public/types.graphql
@@ -98,6 +98,7 @@ type MovedBoxesResult {
   gender: ProductGender!
   sizeId: Int!
   tagIds: [Int!]
+  itemsCount: Int!
   boxesCount: Int!
 }
 

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -169,7 +169,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
     query = """query { movedBoxes(baseId: 1) {
         facts {
             movedOn targetId categoryId productName gender sizeId tagIds
-            boxesCount
+            boxesCount itemsCount
         }
         dimensions { target { id name type } }
         } }"""
@@ -180,6 +180,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
         "facts": [
             {
                 "boxesCount": 2,
+                "itemsCount": 22,
                 "categoryId": 1,
                 "productName": "indigestion tablets",
                 "sizeId": 1,
@@ -190,6 +191,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
             },
             {
                 "boxesCount": 1,
+                "itemsCount": 12,
                 "categoryId": 1,
                 "productName": "jackets",
                 "sizeId": 2,
@@ -200,6 +202,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
             },
             {
                 "boxesCount": 4,
+                "itemsCount": 40,
                 "categoryId": 1,
                 "productName": "indigestion tablets",
                 "sizeId": 1,
@@ -210,6 +213,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
             },
             {
                 "boxesCount": 1,
+                "itemsCount": 10,
                 "categoryId": 1,
                 "productName": "new product",
                 "sizeId": 1,
@@ -220,6 +224,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
             },
             {
                 "boxesCount": 1,
+                "itemsCount": 10,
                 "categoryId": 1,
                 "productName": "indigestion tablets",
                 "sizeId": 1,

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -167,7 +167,7 @@ def test_query_top_products(
 @pytest.mark.parametrize("endpoint", ["graphql", "public"])
 def test_query_moved_boxes(read_only_client, default_location, default_bases, endpoint):
     query = """query { movedBoxes(baseId: 1) {
-        facts { movedOn targetId categoryId boxesCount }
+        facts { movedOn targetId categoryId productName gender sizeId boxesCount }
         dimensions { target { id name type } }
         } }"""
     data = assert_successful_request(read_only_client, query, endpoint=endpoint)
@@ -176,20 +176,47 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
     assert data == {
         "facts": [
             {
-                "boxesCount": 3,
+                "boxesCount": 2,
                 "categoryId": 1,
+                "productName": "indigestion tablets",
+                "sizeId": 1,
+                "gender": "Women",
                 "targetId": location_name,
                 "movedOn": "2022-12-05",
             },
             {
-                "boxesCount": 5,
+                "boxesCount": 1,
                 "categoryId": 1,
+                "productName": "jackets",
+                "sizeId": 2,
+                "gender": "Women",
+                "targetId": location_name,
+                "movedOn": "2022-12-05",
+            },
+            {
+                "boxesCount": 4,
+                "categoryId": 1,
+                "productName": "indigestion tablets",
+                "sizeId": 1,
+                "gender": "Women",
                 "targetId": base_name,
                 "movedOn": date.today().isoformat(),
             },
             {
                 "boxesCount": 1,
                 "categoryId": 1,
+                "productName": "new product",
+                "sizeId": 1,
+                "gender": "Women",
+                "targetId": base_name,
+                "movedOn": date.today().isoformat(),
+            },
+            {
+                "boxesCount": 1,
+                "categoryId": 1,
+                "productName": "indigestion tablets",
+                "sizeId": 1,
+                "gender": "Women",
                 "targetId": BoxState.Lost.name,
                 "movedOn": "2023-02-01",
             },

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -167,7 +167,10 @@ def test_query_top_products(
 @pytest.mark.parametrize("endpoint", ["graphql", "public"])
 def test_query_moved_boxes(read_only_client, default_location, default_bases, endpoint):
     query = """query { movedBoxes(baseId: 1) {
-        facts { movedOn targetId categoryId productName gender sizeId boxesCount }
+        facts {
+            movedOn targetId categoryId productName gender sizeId tagIds
+            boxesCount
+        }
         dimensions { target { id name type } }
         } }"""
     data = assert_successful_request(read_only_client, query, endpoint=endpoint)
@@ -183,6 +186,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
                 "gender": "Women",
                 "targetId": location_name,
                 "movedOn": "2022-12-05",
+                "tagIds": [],
             },
             {
                 "boxesCount": 1,
@@ -192,6 +196,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
                 "gender": "Women",
                 "targetId": location_name,
                 "movedOn": "2022-12-05",
+                "tagIds": [],
             },
             {
                 "boxesCount": 4,
@@ -201,6 +206,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
                 "gender": "Women",
                 "targetId": base_name,
                 "movedOn": date.today().isoformat(),
+                "tagIds": [],
             },
             {
                 "boxesCount": 1,
@@ -210,6 +216,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
                 "gender": "Women",
                 "targetId": base_name,
                 "movedOn": date.today().isoformat(),
+                "tagIds": [],
             },
             {
                 "boxesCount": 1,
@@ -219,6 +226,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
                 "gender": "Women",
                 "targetId": BoxState.Lost.name,
                 "movedOn": "2023-02-01",
+                "tagIds": [],
             },
         ],
         "dimensions": {

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -582,6 +582,7 @@ export type MovedBoxesResult = {
   boxesCount: Scalars['Int'];
   categoryId: Scalars['Int'];
   gender: ProductGender;
+  itemsCount: Scalars['Int'];
   movedOn: Scalars['Date'];
   productName: Scalars['String'];
   sizeId: Scalars['Int'];

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -559,6 +559,7 @@ export type MovedBoxDataDimensions = {
   __typename?: 'MovedBoxDataDimensions';
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
   size?: Maybe<Array<Maybe<DimensionInfo>>>;
+  tag: Array<TagDimensionInfo>;
   target?: Maybe<Array<Maybe<TargetDimensionInfo>>>;
 };
 
@@ -584,6 +585,7 @@ export type MovedBoxesResult = {
   movedOn: Scalars['Date'];
   productName: Scalars['String'];
   sizeId: Scalars['Int'];
+  tagIds?: Maybe<Array<Scalars['Int']['output']>>;
   targetId: Scalars['ID'];
 };
 

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -558,6 +558,7 @@ export type MetricsNumberOfSalesArgs = {
 export type MovedBoxDataDimensions = {
   __typename?: 'MovedBoxDataDimensions';
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
+  size?: Maybe<Array<Maybe<DimensionInfo>>>;
   target?: Maybe<Array<Maybe<TargetDimensionInfo>>>;
 };
 
@@ -579,7 +580,10 @@ export type MovedBoxesResult = {
   __typename?: 'MovedBoxesResult';
   boxesCount: Scalars['Int'];
   categoryId: Scalars['Int'];
+  gender: ProductGender;
   movedOn: Scalars['Date'];
+  productName: Scalars['String'];
+  sizeId: Scalars['Int'];
   targetId: Scalars['ID'];
 };
 

--- a/statviz/src/types/generated/graphql.ts
+++ b/statviz/src/types/generated/graphql.ts
@@ -154,6 +154,7 @@ export type MovedBoxesResult = {
   boxesCount: Scalars['Int']['output'];
   categoryId: Scalars['Int']['output'];
   gender: ProductGender;
+  itemsCount: Scalars['Int']['output'];
   movedOn: Scalars['Date']['output'];
   productName: Scalars['String']['output'];
   sizeId: Scalars['Int']['output'];

--- a/statviz/src/types/generated/graphql.ts
+++ b/statviz/src/types/generated/graphql.ts
@@ -130,6 +130,7 @@ export enum Language {
 export type MovedBoxDataDimensions = {
   __typename?: 'MovedBoxDataDimensions';
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
+  size?: Maybe<Array<Maybe<DimensionInfo>>>;
   target?: Maybe<Array<Maybe<TargetDimensionInfo>>>;
 };
 
@@ -151,7 +152,10 @@ export type MovedBoxesResult = {
   __typename?: 'MovedBoxesResult';
   boxesCount: Scalars['Int']['output'];
   categoryId: Scalars['Int']['output'];
+  gender: ProductGender;
   movedOn: Scalars['Date']['output'];
+  productName: Scalars['String']['output'];
+  sizeId: Scalars['Int']['output'];
   targetId: Scalars['ID']['output'];
 };
 

--- a/statviz/src/types/generated/graphql.ts
+++ b/statviz/src/types/generated/graphql.ts
@@ -131,6 +131,7 @@ export type MovedBoxDataDimensions = {
   __typename?: 'MovedBoxDataDimensions';
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
   size?: Maybe<Array<Maybe<DimensionInfo>>>;
+  tag: Array<TagDimensionInfo>;
   target?: Maybe<Array<Maybe<TargetDimensionInfo>>>;
 };
 
@@ -156,6 +157,7 @@ export type MovedBoxesResult = {
   movedOn: Scalars['Date']['output'];
   productName: Scalars['String']['output'];
   sizeId: Scalars['Int']['output'];
+  tagIds?: Maybe<Array<Scalars['Int']['output']>>;
   targetId: Scalars['ID']['output'];
 };
 


### PR DESCRIPTION
UPDATE: most of the BE implementation is replaced by SQL script in #1190 . The changes in the GraphQL interface remain.

Added productName, gender, sizeId, tagIds, and itemsCount to MovedBoxesResult
