### PR TITLE
Raise BadUserInput error for invalid box reconciliation input

### DIFF
--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -137,6 +137,15 @@ class InvalidShipmentState(_InvalidResourceState):
         )
 
 
+class InvalidShipmentDetailUpdateInput(Exception):
+    def __init__(self, *args, model, detail, **kwargs):
+        self.extensions = {
+            "code": "BAD_USER_INPUT",
+            "description": f"Input {model.__class__.__name__} is not valid for base of"
+            f"shipment detail {detail.id}",
+        }
+
+
 class NotEnoughItemsInBox(Exception):
     def __init__(
         self,

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -758,7 +758,7 @@ def test_shipment_mutations_on_target_side(
     # Verify that another_detail_id is not updated (invalid product)
     # Test cases 3.2.39ab
     for product in [default_product, {"id": 0}]:
-        shipment = assert_successful_request(
+        shipment = assert_bad_user_input(
             client,
             _create_mutation(
                 detail_id=another_detail_id,
@@ -768,12 +768,11 @@ def test_shipment_mutations_on_target_side(
                 target_quantity=target_quantity,
             ),
         )
-        assert shipment == expected_shipment
 
     # Verify that another_detail_id is not updated (invalid location)
     # Test cases 3.2.38ab
     for location in [default_location, {"id": 0}]:
-        shipment = assert_successful_request(
+        assert_bad_user_input(
             client,
             _create_mutation(
                 detail_id=another_detail_id,
@@ -783,7 +782,6 @@ def test_shipment_mutations_on_target_side(
                 target_quantity=target_quantity,
             ),
         )
-        assert shipment == expected_shipment
 
     # Test case 3.2.40, 3.2.34b
     box_label_identifier = another_in_transit_box["label_identifier"]

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -783,6 +783,18 @@ def test_shipment_mutations_on_target_side(
             ),
         )
 
+    # Test case 3.2.37
+    assert_bad_user_input(
+        client,
+        _create_mutation(
+            detail_id=removed_detail_id,
+            target_product_id=target_product_id,
+            target_location_id=target_location_id,
+            target_size_id=target_size_id,
+            target_quantity=target_quantity,
+        ),
+    )
+
     # Test case 3.2.40, 3.2.34b
     box_label_identifier = another_in_transit_box["label_identifier"]
     mutation = f"""mutation {{ updateShipmentWhenReceiving( updateInput: {{


### PR DESCRIPTION
E.g. if given target location or product are not part of the target
base of the underlying shipment.
Previously this was silently ignored, giving the impression that the
updateShipmentWhenReceiving mutation succeeded.

Test e.g. with Shipment 1, and location 22 (part of base 3 but shipment target base is 2).
Or you test via the FE (steps to reproduce in Trello card).
