### PR TITLE
Use DB replica only for GraphQL queries

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -410,6 +410,8 @@ Used in combination with [k6](https://k6.io/docs/). See the example [script](./s
 
 ### Profiling
 
+#### Execution time
+
 1. Add profiling middleware by extending `main.py`
 
         import pathlib
@@ -432,6 +434,18 @@ Used in combination with [k6](https://k6.io/docs/). See the example [script](./s
         snakeviz back/stats/some.profile
 
 1. Inspect the stack visualization in your web browser.
+
+#### Memory
+
+Several tools exist, e.g. [memray](https://github.com/bloomberg/memray) or [scalene](https://github.com/plasma-umass/scalene). Setting them up for analysing a complex application is not straightforward, and has only worked when running the Flask app outside of Docker, directly on the host machine.
+
+For using memray,
+
+1. the Flask app has to be registered in `setup.py` to be invoked from the CLI. Add the following to the `console_scripts` list: `"bserve = boxtribute_server.dev_main:run"`
+1. Install the new CLI command: `pip install -U -e back/`
+1. Start the server while recording profiling data: `memray run $(which bserve)`
+1. Make requests to the server. Eventually stop the server.
+1. Generate graphs with `memray flamegraph` or `memray table` and inspect them in your web browser.
 
 ## Authentication and Authorization
 

--- a/back/boxtribute_server/app.py
+++ b/back/boxtribute_server/app.py
@@ -24,6 +24,7 @@ def configure_app(
         app.register_blueprint(blueprint)
 
     app.config["DATABASE"] = database_interface or create_db_interface(**mysql_kwargs)
+    app.config["FLASKDB_EXCLUDED_ROUTES"] = ["api_bp.api_token"]
 
     if replica_socket or mysql_kwargs:
         # In deployed environment: replica_socket is set

--- a/back/boxtribute_server/business_logic/statistics/__init__.py
+++ b/back/boxtribute_server/business_logic/statistics/__init__.py
@@ -1,0 +1,9 @@
+from ariadne import QueryType
+
+# Defined in separate module to circumvent circular import of db module
+query = QueryType()
+
+
+def statistics_queries():
+    """Return names of all resolvers registered on the QueryType at runtime."""
+    return list(query._resolvers.keys())

--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from peewee import JOIN, SQL, fn
 
 from ...db import db
@@ -17,6 +19,36 @@ from ...models.definitions.tag import Tag
 from ...models.definitions.tags_relation import TagsRelation
 from ...models.definitions.transaction import Transaction
 from ...models.utils import compute_age, convert_ids
+
+
+def use_db_replica(f):
+    """Decorator for a resolver that should use the DB replica for database selects."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if db.replica is not None:
+            with db.replica.bind_ctx(
+                [
+                    Base,
+                    Beneficiary,
+                    Box,
+                    DbChangeHistory,
+                    Location,
+                    Product,
+                    ProductCategory,
+                    Shipment,
+                    ShipmentDetail,
+                    Size,
+                    Tag,
+                    TagsRelation,
+                    Transaction,
+                ]
+            ):
+                return f(*args, **kwargs)
+
+        return f(*args, **kwargs)
+
+    return decorated
 
 
 def _generate_dimensions(*names, target_type=None, facts):

--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -27,23 +27,7 @@ def use_db_replica(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         if db.replica is not None:
-            with db.replica.bind_ctx(
-                [
-                    Base,
-                    Beneficiary,
-                    Box,
-                    DbChangeHistory,
-                    Location,
-                    Product,
-                    ProductCategory,
-                    Shipment,
-                    ShipmentDetail,
-                    Size,
-                    Tag,
-                    TagsRelation,
-                    Transaction,
-                ]
-            ):
+            with db.replica.bind_ctx(db.Model.__subclasses__()):
                 return f(*args, **kwargs)
 
         return f(*args, **kwargs)

--- a/back/boxtribute_server/business_logic/statistics/queries.py
+++ b/back/boxtribute_server/business_logic/statistics/queries.py
@@ -2,6 +2,7 @@ from ariadne import QueryType
 
 from ...authz import authorize, authorize_cross_organisation_access
 from ...models.definitions.base import Base
+from . import query
 from .crud import (
     compute_beneficiary_demographics,
     compute_created_boxes,
@@ -9,9 +10,9 @@ from .crud import (
     compute_stock_overview,
     compute_top_products_checked_out,
     compute_top_products_donated,
+    use_db_replica,
 )
 
-query = QueryType()
 public_query = QueryType()
 
 
@@ -23,6 +24,7 @@ def _validate_existing_base(base_id):
 
 
 @query.field("beneficiaryDemographics")
+@use_db_replica
 def resolve_beneficiary_demographics(*_, base_id):
     # No cross-organisational access for beneficiary-related data
     authorize(permission="beneficiary:read", base_id=base_id)
@@ -31,6 +33,7 @@ def resolve_beneficiary_demographics(*_, base_id):
 
 
 @query.field("createdBoxes")
+@use_db_replica
 def resolve_created_boxes(*_, base_id):
     authorize_cross_organisation_access(
         "stock",
@@ -42,6 +45,7 @@ def resolve_created_boxes(*_, base_id):
 
 
 @query.field("topProductsCheckedOut")
+@use_db_replica
 def resolve_top_products_checked_out(*_, base_id):
     # No cross-organisational access for beneficiary-related data
     authorize(permission="transaction:read")
@@ -51,6 +55,7 @@ def resolve_top_products_checked_out(*_, base_id):
 
 
 @query.field("topProductsDonated")
+@use_db_replica
 def resolve_top_products_donated(*_, base_id):
     authorize_cross_organisation_access(
         "stock",
@@ -64,6 +69,7 @@ def resolve_top_products_donated(*_, base_id):
 
 
 @query.field("movedBoxes")
+@use_db_replica
 def resolve_moved_boxes(*_, base_id=None):
     authorize_cross_organisation_access(
         "stock",
@@ -79,6 +85,7 @@ def resolve_moved_boxes(*_, base_id=None):
 
 
 @query.field("stockOverview")
+@use_db_replica
 def resolve_stock_overview(*_, base_id):
     authorize_cross_organisation_access(
         "stock",
@@ -93,36 +100,42 @@ def resolve_stock_overview(*_, base_id):
 
 
 @public_query.field("beneficiaryDemographics")
+@use_db_replica
 def public_resolve_beneficiary_demographics(*_, base_id):
     _validate_existing_base(base_id)
     return compute_beneficiary_demographics(base_id)
 
 
 @public_query.field("createdBoxes")
+@use_db_replica
 def public_resolve_created_boxes(*_, base_id):
     _validate_existing_base(base_id)
     return compute_created_boxes(base_id)
 
 
 @public_query.field("topProductsCheckedOut")
+@use_db_replica
 def public_resolve_top_products_checked_out(*_, base_id):
     _validate_existing_base(base_id)
     return compute_top_products_checked_out(base_id)
 
 
 @public_query.field("topProductsDonated")
+@use_db_replica
 def public_resolve_top_products_donated(*_, base_id):
     _validate_existing_base(base_id)
     return compute_top_products_donated(base_id)
 
 
 @public_query.field("movedBoxes")
+@use_db_replica
 def public_resolve_moved_boxes(*_, base_id=None):
     _validate_existing_base(base_id)
     return compute_moved_boxes(base_id)
 
 
 @public_query.field("stockOverview")
+@use_db_replica
 def public_resolve_stock_overview(*_, base_id):
     _validate_existing_base(base_id)
     return compute_stock_overview(base_id)

--- a/back/boxtribute_server/dev_main.py
+++ b/back/boxtribute_server/dev_main.py
@@ -5,5 +5,9 @@ from .routes import api_bp, app_bp
 app = main(api_bp, app_bp)
 
 
-if __name__ == "__main__":
+def run():
     app.run(host="0.0.0", port=5005, debug=True)
+
+
+if __name__ == "__main__":
+    run()

--- a/back/test/conftest.py
+++ b/back/test/conftest.py
@@ -78,11 +78,11 @@ def _create_app(database_interface, *blueprints):
         db.database.drop_tables(MODELS)
         db.database.create_tables(MODELS)
         setup_models()
-        db.close_db(None)
+        db.database.close()
         with app.app_context():
             yield app
 
-    db.close_db(None)
+    db.database.close()
 
 
 @pytest.fixture(scope="session")
@@ -131,7 +131,9 @@ def dropapp_dev_client(monkeypatch):
 
     with db.database.bind_ctx(MODELS):
         db.database.create_tables(MODELS)
-        db.close_db(None)
+        db.database.close()
+        db.replica.close()
         with app.app_context():
             yield app.test_client()
-    db.close_db(None)
+    db.database.close()
+    db.replica.close()

--- a/back/test/integration_tests/test_operations.py
+++ b/back/test/integration_tests/test_operations.py
@@ -38,6 +38,10 @@ def test_queries(auth0_client, endpoint):
         response = _assert_successful_request(auth0_client, query, field=resource)
         assert len(response) > 0
 
+    query = "query { beneficiaryDemographics(baseId: 1) { facts { age count } } }"
+    demographics = _assert_successful_request(auth0_client, query)
+    assert len(demographics["facts"]) == 154
+
 
 def test_mutations(auth0_client):
     mutation = "mutation { createQrCode { id } }"


### PR DESCRIPTION
Follow-up to #1104.

When a GraphQL request contains a mutation, the database operations will be executed on the primary instance.
See commit messages for details.

This PR includes small improvements of the DatabaseManager, too.
