### PR TITLE
Update Box.lastModified fields when changing box state during transfer

### DIFF
--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -4,7 +4,7 @@ import pathlib
 
 from boxtribute_server.db import db
 
-from .base import default_base, default_bases
+from .base import another_base, default_base, default_bases
 from .beneficiary import (
     another_beneficiary,
     default_beneficiaries,
@@ -92,6 +92,7 @@ from .transfer_agreement import (
 from .user import another_user, default_user, default_users, god_user
 
 __all__ = [
+    "another_base",
     "another_beneficiary",
     "another_box",
     "another_in_transit_box",

--- a/back/test/data/base.py
+++ b/back/test/data/base.py
@@ -37,14 +37,19 @@ def data():
     ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_base():
     return data()[0]
 
 
-@pytest.fixture()
+@pytest.fixture
+def another_base():
+    return data()[2]
+
+
+@pytest.fixture
 def default_bases():
-    return {b["id"]: b for b in data()}
+    return data()
 
 
 def create():

--- a/back/test/endpoint_tests/test_base.py
+++ b/back/test/endpoint_tests/test_base.py
@@ -27,7 +27,6 @@ def test_bases_query(read_only_client, default_base, default_beneficiaries):
 def test_base_query(
     read_only_client,
     default_base,
-    default_distribution_event,
     default_tracking_group,
     distribution_spot,
     distro_spot5_distribution_events,
@@ -38,8 +37,7 @@ def test_base_query(
     base1_undeleted_products,
 ):
     # Test case 99.1.2
-    expected_base = default_base
-    test_id = default_base["id"]
+    test_id = str(default_base["id"])
     query = f"""query Base {{
                 base(id: {test_id}) {{
                     id
@@ -59,28 +57,28 @@ def test_base_query(
             }}"""
 
     base = assert_successful_request(read_only_client, query)
-    assert int(base["id"]) == expected_base["id"]
-    assert base["name"] == expected_base["name"]
-    assert base["currencyName"] == expected_base["currency_name"]
-    assert int(base["organisation"]["id"]) == expected_base["organisation"]
-    assert base["products"] == [{"id": str(p["id"])} for p in base1_undeleted_products]
-    assert base["tags"] == [{"id": str(t["id"])} for t in base1_active_tags]
-    assert base["locations"] == [
-        {"id": str(loc["id"])} for loc in base1_undeleted_classic_locations
-    ]
-    assert base["distributionSpots"] == [{"id": str(distribution_spot["id"])}]
-    assert base["distributionEvents"] == [
-        {"id": str(event["id"])} for event in distro_spot5_distribution_events
-    ]
-    assert base["distributionEventsBeforeReturnedFromDistributionState"] == [
-        {"id": str(event["id"])}
-        for event in distro_spot5_distribution_events_before_return_state
-    ]
-    assert base["distributionEventsInReturnedFromDistributionState"] == [
-        {"id": str(event["id"])}
-        for event in distro_spot5_distribution_events_in_return_state
-    ]
-    assert base["distributionEventsStatistics"] == []
-    assert base["distributionEventsTrackingGroups"] == [
-        {"id": str(default_tracking_group["id"])}
-    ]
+    assert base == {
+        "id": test_id,
+        "name": default_base["name"],
+        "currencyName": default_base["currency_name"],
+        "organisation": {"id": str(default_base["organisation"])},
+        "products": [{"id": str(p["id"])} for p in base1_undeleted_products],
+        "tags": [{"id": str(t["id"])} for t in base1_active_tags],
+        "locations": [
+            {"id": str(loc["id"])} for loc in base1_undeleted_classic_locations
+        ],
+        "distributionSpots": [{"id": str(distribution_spot["id"])}],
+        "distributionEvents": [
+            {"id": str(event["id"])} for event in distro_spot5_distribution_events
+        ],
+        "distributionEventsBeforeReturnedFromDistributionState": [
+            {"id": str(event["id"])}
+            for event in distro_spot5_distribution_events_before_return_state
+        ],
+        "distributionEventsInReturnedFromDistributionState": [
+            {"id": str(event["id"])}
+            for event in distro_spot5_distribution_events_in_return_state
+        ],
+        "distributionEventsStatistics": [],
+        "distributionEventsTrackingGroups": [{"id": str(default_tracking_group["id"])}],
+    }

--- a/back/test/endpoint_tests/test_base.py
+++ b/back/test/endpoint_tests/test_base.py
@@ -1,7 +1,7 @@
 from utils import assert_successful_request
 
 
-def test_bases_query(read_only_client, default_bases, default_beneficiaries):
+def test_bases_query(read_only_client, default_base, default_beneficiaries):
     # Test case 99.1.1
     query = """query {
                 bases {
@@ -12,22 +12,21 @@ def test_bases_query(read_only_client, default_bases, default_beneficiaries):
                 }
             }"""
 
-    all_bases = assert_successful_request(read_only_client, query)
-    assert len(all_bases) == 1
-
-    queried_base = all_bases[0]
-    queried_base_id = int(queried_base["id"])
-    expected_base = default_bases[queried_base_id]
-
-    assert queried_base_id == expected_base["id"]
-    assert queried_base["name"] == expected_base["name"]
-    assert queried_base["currencyName"] == expected_base["currency_name"]
-    assert len(queried_base["beneficiaries"]["elements"]) == len(default_beneficiaries)
+    bases = assert_successful_request(read_only_client, query)
+    assert len(bases[0]["beneficiaries"].pop("elements")) == len(default_beneficiaries)
+    assert bases == [
+        {
+            "id": str(default_base["id"]),
+            "name": default_base["name"],
+            "currencyName": default_base["currency_name"],
+            "beneficiaries": {},
+        }
+    ]
 
 
 def test_base_query(
     read_only_client,
-    default_bases,
+    default_base,
     default_distribution_event,
     default_tracking_group,
     distribution_spot,
@@ -39,7 +38,8 @@ def test_base_query(
     base1_undeleted_products,
 ):
     # Test case 99.1.2
-    test_id = 1
+    expected_base = default_base
+    test_id = default_base["id"]
     query = f"""query Base {{
                 base(id: {test_id}) {{
                     id
@@ -59,7 +59,6 @@ def test_base_query(
             }}"""
 
     base = assert_successful_request(read_only_client, query)
-    expected_base = default_bases[test_id]
     assert int(base["id"]) == expected_base["id"]
     assert base["name"] == expected_base["name"]
     assert base["currencyName"] == expected_base["currency_name"]

--- a/back/test/endpoint_tests/test_organisation.py
+++ b/back/test/endpoint_tests/test_organisation.py
@@ -25,13 +25,13 @@ def test_organisation_query(
         "name": default_organisation["name"],
         "bases": [
             {
-                "id": str(default_bases[1]["id"]),
-                "name": default_bases[1]["name"],
+                "id": str(default_bases[0]["id"]),
+                "name": default_bases[0]["name"],
                 "beneficiaries": {"totalCount": len(default_beneficiaries)},
             },
             {
-                "id": str(default_bases[2]["id"]),
-                "name": default_bases[2]["name"],
+                "id": str(default_bases[1]["id"]),
+                "name": default_bases[1]["name"],
                 "beneficiaries": None,
             },
         ],
@@ -53,7 +53,7 @@ def test_organisation_query(
         "id": organisation_id,
         "bases": [
             {"id": str(base["id"]), "name": base["name"], "beneficiaries": None}
-            for base in [default_bases[3], default_bases[4]]
+            for base in [default_bases[2], default_bases[3]]
         ],
     }
 

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -424,7 +424,7 @@ def test_invalid_permission_for_metrics(read_only_client, mocker):
         "delete-implies-read",
     ],
 )
-def test_permission_scope(read_only_client, mocker, default_bases, method):
+def test_permission_scope(read_only_client, mocker, method):
     mock_user_for_request(mocker, permissions=[f"base:{method}"])
     query = "query { bases { id } }"
     bases = assert_successful_request(read_only_client, query)

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -12,6 +12,8 @@ from utils import (
 # Define common prefix for change messages for shorter line length
 change_prefix = "changed box state from"
 today = date.today().isoformat()
+source_base_user_id = "8"
+target_base_user_id = "2"
 
 
 def test_shipment_query(read_only_client, default_shipment, prepared_shipment_detail):
@@ -162,7 +164,7 @@ def test_shipment_mutations_on_source_side(
         "sourceBase": {"id": str(source_base_id)},
         "targetBase": {"id": str(target_base_id)},
         "state": ShipmentState.Preparing.name,
-        "startedBy": {"id": "8"},
+        "startedBy": {"id": source_base_user_id},
         "sentBy": None,
         "sentOn": None,
         "receivingStartedBy": None,
@@ -278,7 +280,7 @@ def test_shipment_mutations_on_source_side(
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
                         {"changes": "created record"},
                     ],
-                    "lastModifiedBy": {"id": "8"},
+                    "lastModifiedBy": {"id": source_base_user_id},
                 },
                 "sourceProduct": {"id": str(default_box["product"])},
                 "targetProduct": None,
@@ -288,7 +290,7 @@ def test_shipment_mutations_on_source_side(
                 "targetSize": None,
                 "sourceQuantity": default_box["number_of_items"],
                 "targetQuantity": None,
-                "createdBy": {"id": "8"},
+                "createdBy": {"id": source_base_user_id},
                 "removedBy": None,
                 "removedOn": None,
             },
@@ -350,10 +352,10 @@ def test_shipment_mutations_on_source_side(
         "details": [
             {
                 "id": i,
-                "removedBy": {"id": "8"},
+                "removedBy": {"id": source_base_user_id},
                 "box": {
                     "state": BoxState.InStock.name,
-                    "lastModifiedBy": {"id": "8"},
+                    "lastModifiedBy": {"id": source_base_user_id},
                 },
             }
             for i in [prepared_shipment_detail_id, shipment_detail_id]
@@ -447,14 +449,14 @@ def test_shipment_mutations_on_source_side(
     assert shipment == {
         "id": shipment_id,
         "state": ShipmentState.Sent.name,
-        "sentBy": {"id": "8"},
+        "sentBy": {"id": source_base_user_id},
         "details": [
             # two boxes have been returned to stock
             {
                 "id": prepared_shipment_detail_id,
                 "box": {
                     "state": BoxState.InStock.name,
-                    "lastModifiedBy": {"id": "8"},
+                    "lastModifiedBy": {"id": source_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} MarkedForShipment to InStock"},
                         {"changes": "created record"},
@@ -466,7 +468,7 @@ def test_shipment_mutations_on_source_side(
                 "id": shipment_detail_id,
                 "box": {
                     "state": BoxState.InTransit.name,
-                    "lastModifiedBy": {"id": "8"},
+                    "lastModifiedBy": {"id": source_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} MarkedForShipment to InTransit"},
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
@@ -480,7 +482,7 @@ def test_shipment_mutations_on_source_side(
                 "id": newest_shipment_detail_id,
                 "box": {
                     "state": BoxState.InTransit.name,
-                    "lastModifiedBy": {"id": "8"},
+                    "lastModifiedBy": {"id": source_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} MarkedForShipment to InTransit"},
                         {"changes": f"{change_prefix} InStock to MarkedForShipment"},
@@ -528,14 +530,14 @@ def test_shipment_mutations_cancel(
     assert shipment == {
         "id": shipment_id,
         "state": ShipmentState.Canceled.name,
-        "canceledBy": {"id": "8"},
+        "canceledBy": {"id": source_base_user_id},
         "details": [
             {
                 "id": str(prepared_shipment_detail["id"]),
-                "removedBy": {"id": "8"},
+                "removedBy": {"id": source_base_user_id},
                 "box": {
                     "state": BoxState.InStock.name,
-                    "lastModifiedBy": {"id": "8"},
+                    "lastModifiedBy": {"id": source_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} MarkedForShipment to InStock"},
                         {"changes": "created record"},
@@ -674,13 +676,13 @@ def test_shipment_mutations_on_target_side(
     assert shipment == {
         "id": shipment_id,
         "state": ShipmentState.Receiving.name,
-        "receivingStartedBy": {"id": "2"},
+        "receivingStartedBy": {"id": target_base_user_id},
         "details": [
             {
                 "id": detail_id,
                 "box": {
                     "state": BoxState.Receiving.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} InTransit to Receiving"},
                         {"changes": "created record"},
@@ -691,7 +693,7 @@ def test_shipment_mutations_on_target_side(
                 "id": another_detail_id,
                 "box": {
                     "state": BoxState.Receiving.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} InTransit to Receiving"},
                         {"changes": "created record"},
@@ -734,7 +736,7 @@ def test_shipment_mutations_on_target_side(
                 "id": detail_id,
                 "box": {
                     "state": BoxState.InStock.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                     "history": [
                         {
                             "changes": f"{change_prefix} Receiving to InStock",
@@ -772,7 +774,7 @@ def test_shipment_mutations_on_target_side(
                 "id": another_detail_id,
                 "box": {
                     "state": BoxState.Receiving.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} InTransit to Receiving"},
                         {"changes": "created record"},
@@ -881,26 +883,26 @@ def test_shipment_mutations_on_target_side(
     assert shipment == {
         "id": shipment_id,
         "state": ShipmentState.Completed.name,
-        "completedBy": {"id": "2"},
+        "completedBy": {"id": target_base_user_id},
         "details": [
             {
                 "id": detail_id,
                 "removedBy": None,
                 "lostBy": None,
-                "receivedBy": {"id": "2"},
+                "receivedBy": {"id": target_base_user_id},
                 "box": {
                     "state": BoxState.InStock.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                 },
             },
             {
                 "id": another_detail_id,
                 "removedBy": None,
-                "lostBy": {"id": "2"},
+                "lostBy": {"id": target_base_user_id},
                 "receivedBy": None,
                 "box": {
                     "state": BoxState.NotDelivered.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} Receiving to NotDelivered"},
                         {"changes": f"{change_prefix} InTransit to Receiving"},
@@ -910,7 +912,7 @@ def test_shipment_mutations_on_target_side(
             },
             {
                 "id": removed_detail_id,
-                "removedBy": {"id": "2"},
+                "removedBy": {"id": target_base_user_id},
                 "lostBy": None,
                 "receivedBy": None,
                 "box": {
@@ -987,15 +989,15 @@ def test_shipment_mutations_on_target_side_mark_shipment_as_lost(
     assert shipment["details"][1]["box"].pop("lastModifiedOn").startswith(today)
     assert shipment == {
         "state": ShipmentState.Lost.name,
-        "completedBy": {"id": "2"},
+        "completedBy": {"id": target_base_user_id},
         "details": [
             {
                 "id": str(default_shipment_detail["id"]),
                 "removedBy": None,
-                "lostBy": {"id": "2"},
+                "lostBy": {"id": target_base_user_id},
                 "box": {
                     "state": BoxState.NotDelivered.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} InTransit to NotDelivered"},
                         {"changes": "created record"},
@@ -1005,10 +1007,10 @@ def test_shipment_mutations_on_target_side_mark_shipment_as_lost(
             {
                 "id": str(another_shipment_detail["id"]),
                 "removedBy": None,
-                "lostBy": {"id": "2"},
+                "lostBy": {"id": target_base_user_id},
                 "box": {
                     "state": BoxState.NotDelivered.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                     "history": [
                         {"changes": f"{change_prefix} InTransit to NotDelivered"},
                         {"changes": "created record"},
@@ -1017,7 +1019,7 @@ def test_shipment_mutations_on_target_side_mark_shipment_as_lost(
             },
             {
                 "id": str(removed_shipment_detail["id"]),
-                "removedBy": {"id": "2"},
+                "removedBy": {"id": target_base_user_id},
                 "lostBy": None,
                 "box": {
                     "state": BoxState.InStock.name,
@@ -1090,31 +1092,31 @@ def test_shipment_mutations_on_target_side_mark_all_boxes_as_lost(
     assert shipment["details"][1]["box"].pop("lastModifiedOn").startswith(today)
     assert shipment == {
         "state": ShipmentState.Lost.name,
-        "completedBy": {"id": "2"},
+        "completedBy": {"id": target_base_user_id},
         "details": [
             {
                 "id": str(default_shipment_detail["id"]),
                 "removedBy": None,
                 "receivedBy": None,
-                "lostBy": {"id": "2"},
+                "lostBy": {"id": target_base_user_id},
                 "box": {
                     "state": BoxState.NotDelivered.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                 },
             },
             {
                 "id": str(another_shipment_detail["id"]),
                 "removedBy": None,
                 "receivedBy": None,
-                "lostBy": {"id": "2"},
+                "lostBy": {"id": target_base_user_id},
                 "box": {
                     "state": BoxState.NotDelivered.name,
-                    "lastModifiedBy": {"id": "2"},
+                    "lastModifiedBy": {"id": target_base_user_id},
                 },
             },
             {
                 "id": str(removed_shipment_detail["id"]),
-                "removedBy": {"id": "2"},
+                "removedBy": {"id": target_base_user_id},
                 "receivedBy": None,
                 "lostBy": None,
                 "box": {
@@ -1424,7 +1426,6 @@ def test_move_not_delivered_box_instock_in_source_base(
     # sending.
     # The shipment remains Completed but the box is InStock instead of NotDelivered
     box_id = str(another_not_delivered_box["id"])
-    user_id = "8"
     mutation = _create_move_not_delivered_boxes_in_stock_mutation(box_id)
     shipment = assert_successful_request(client, mutation)
     assert shipment.pop("completedOn").startswith(today)
@@ -1435,7 +1436,7 @@ def test_move_not_delivered_box_instock_in_source_base(
         "state": ShipmentState.Completed.name,
         "details": [
             {
-                "removedBy": {"id": user_id},
+                "removedBy": {"id": source_base_user_id},
                 "lostOn": None,
                 "lostBy": None,
                 "box": {
@@ -1468,11 +1469,11 @@ def test_move_not_delivered_box_instock_in_source_base(
     assert shipment["details"][0].pop("removedOn").startswith(today)
     assert shipment == {
         "id": str(receiving_shipment["id"]),
-        "completedBy": {"id": user_id},
+        "completedBy": {"id": source_base_user_id},
         "state": ShipmentState.Completed.name,
         "details": [
             {
-                "removedBy": {"id": user_id},
+                "removedBy": {"id": source_base_user_id},
                 "lostOn": None,
                 "lostBy": None,
                 "box": {

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -16,6 +16,16 @@ source_base_user_id = "8"
 target_base_user_id = "2"
 
 
+@pytest.fixture
+def mock_default_target_base_user(mocker, default_bases, another_organisation):
+    mock_user_for_request(
+        mocker,
+        base_ids=[default_bases[3]["id"]],
+        organisation_id=another_organisation["id"],
+        user_id=target_base_user_id,
+    )
+
+
 def test_shipment_query(read_only_client, default_shipment, prepared_shipment_detail):
     # Test case 3.1.2
     shipment_id = str(default_shipment["id"])
@@ -567,6 +577,7 @@ def test_shipment_mutations_cancel(
 def test_shipment_mutations_on_target_side(
     client,
     mocker,
+    mock_default_target_base_user,
     default_transfer_agreement,
     unidirectional_transfer_agreement,
     default_bases,
@@ -583,8 +594,6 @@ def test_shipment_mutations_on_target_side(
     in_transit_box,
     another_in_transit_box,
 ):
-    mock_user_for_request(mocker, base_ids=[3], organisation_id=2, user_id=2)
-
     # Test cases 3.2.1b, 3.2.1c
     for agreement in [default_transfer_agreement, unidirectional_transfer_agreement]:
         source_base_id = str(default_bases[3]["id"])
@@ -956,6 +965,7 @@ def test_shipment_mutations_on_target_side(
 
 def test_shipment_mutations_on_target_side_mark_shipment_as_lost(
     mocker,
+    mock_default_target_base_user,
     client,
     default_box,
     in_transit_box,
@@ -964,8 +974,6 @@ def test_shipment_mutations_on_target_side_mark_shipment_as_lost(
     another_shipment_detail,
     removed_shipment_detail,
 ):
-    mock_user_for_request(mocker, base_ids=[3], organisation_id=2, user_id=2)
-
     shipment_id = str(sent_shipment["id"])
     mutation = f"""mutation {{ markShipmentAsLost(id: {shipment_id}) {{
                     state
@@ -1045,7 +1053,7 @@ def test_shipment_mutations_on_target_side_mark_shipment_as_lost(
 
 
 def test_shipment_mutations_on_target_side_mark_all_boxes_as_lost(
-    mocker,
+    mock_default_target_base_user,
     client,
     default_box,
     in_transit_box,
@@ -1055,8 +1063,6 @@ def test_shipment_mutations_on_target_side_mark_all_boxes_as_lost(
     another_shipment_detail,
     removed_shipment_detail,
 ):
-    mock_user_for_request(mocker, base_ids=[3], organisation_id=2, user_id=2)
-
     shipment_id = str(sent_shipment["id"])
     mutation = f"""mutation {{ startReceivingShipment(id: {shipment_id}) {{
                     state }} }}"""
@@ -1363,7 +1369,7 @@ def test_shipment_mutations_update_without_arguments(
 
 def test_shipment_mutations_update_checked_in_boxes_when_shipment_in_non_sent_state(
     read_only_client,
-    mocker,
+    mock_default_target_base_user,
     default_shipment,
     prepared_shipment_detail,
     another_location,
@@ -1371,7 +1377,6 @@ def test_shipment_mutations_update_checked_in_boxes_when_shipment_in_non_sent_st
     another_size,
 ):
     # Test case 3.2.36
-    mock_user_for_request(mocker, base_ids=[3], organisation_id=2, user_id=2)
     # This will use updateShipmentWhenReceiving
     assert_bad_user_input_when_updating_shipment(
         read_only_client,
@@ -1414,7 +1419,6 @@ def _create_move_not_delivered_boxes_in_stock_mutation(box_id):
 
 def test_move_not_delivered_box_instock_in_source_base(
     client,
-    mocker,
     not_delivered_box,
     another_not_delivered_box,
     another_box,
@@ -1499,14 +1503,13 @@ def test_move_not_delivered_box_instock_in_source_base(
 
 def test_move_not_delivered_box_instock_in_target_base(
     client,
-    mocker,
+    mock_default_target_base_user,
     not_delivered_box,
     another_not_delivered_box,
     another_box,
     receiving_shipment,
     completed_shipment,
 ):
-    mock_user_for_request(mocker, base_ids=[3], organisation_id=2, user_id=2)
     # The shipment is Receiving. Person A on the target side has extracted a box from
     # the shipment without registering. Person B on the target side can't find the box
     # and marks it as NotDelivered. The target side finds the box again.

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -165,7 +165,7 @@ def test_query_top_products(
 
 
 @pytest.mark.parametrize("endpoint", ["graphql", "public"])
-def test_query_moved_boxes(read_only_client, default_location, default_bases, endpoint):
+def test_query_moved_boxes(read_only_client, default_location, another_base, endpoint):
     query = """query { movedBoxes(baseId: 1) {
         facts {
             movedOn targetId categoryId productName gender sizeId tagIds
@@ -175,7 +175,7 @@ def test_query_moved_boxes(read_only_client, default_location, default_bases, en
         } }"""
     data = assert_successful_request(read_only_client, query, endpoint=endpoint)
     location_name = default_location["name"]
-    base_name = default_bases[3]["name"]
+    base_name = another_base["name"]
     assert data == {
         "facts": [
             {

--- a/back/test/endpoint_tests/test_tag.py
+++ b/back/test/endpoint_tests/test_tag.py
@@ -256,7 +256,7 @@ def test_update_tag_type(client, tag_id, tag_type, tagged_resource_ids, typename
 
 def test_mutate_tag_with_invalid_base(client, default_bases, tags):
     # Test case 4.2.2
-    base_id = default_bases[2]["id"]
+    base_id = default_bases[1]["id"]
     creation_input = f"""{{
         name: "new tag",
         color: "#112233",


### PR DESCRIPTION
First commit contains the actual change, the others are improvements in the test codebase for less code duplication and readability.