### PR TITLE
cache settings for statviz in front

### DIFF
--- a/front/src/queries/cache.ts
+++ b/front/src/queries/cache.ts
@@ -13,6 +13,10 @@ export const cache = new InMemoryCache({
       // QR-Codes should be normalized by their hash
       keyFields: ["code"],
     },
+    DimensionInfo: {
+      // DimensionInfos must be normalized by id and name
+      keyFields: ["id", "name"],
+    },
   },
 });
 


### PR DESCRIPTION
@HaGuesto 

the visualizations showed wired and wrong results (like products in the stock overview when grouped by sizes) because i forgot to copy the cache configuration to the front folder. This PR should fix it.