### PR TITLE
Use batch-loader for Box.history

### DIFF
--- a/back/boxtribute_server/business_logic/warehouse/box/crud.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/crud.py
@@ -10,11 +10,8 @@ from ....exceptions import (
     QrCodeAlreadyAssignedToBox,
 )
 from ....models.definitions.box import Box
-from ....models.definitions.history import DbChangeHistory
 from ....models.definitions.location import Location
-from ....models.definitions.product import Product
 from ....models.definitions.qr_code import QrCode
-from ....models.definitions.size import Size
 from ....models.definitions.tags_relation import TagsRelation
 from ....models.utils import save_creation_to_history, save_update_to_history, utcnow
 from ...tag.crud import assign_tag, unassign_tag
@@ -199,56 +196,3 @@ def update_box(
     box.last_modified_on = utcnow()
     box.save()
     return box
-
-
-def get_box_history(box_id):
-    """Return formatted history entries of box with given ID, sorted by most recent
-    first.
-    """
-    entries = []
-    for raw_entry in DbChangeHistory.select().where(
-        DbChangeHistory.table_name == "stock",
-        DbChangeHistory.record_id == box_id,
-    ):
-        changes = raw_entry.changes
-        if changes == "items":
-            changes = (
-                f"changed the number of items from {raw_entry.from_int} to "
-                + f"{raw_entry.to_int}"
-            )
-
-        elif changes == "product_id":
-            old_product = Product.get_by_id(raw_entry.from_int)
-            new_product = Product.get_by_id(raw_entry.to_int)
-            changes = (
-                f"changed product type from {old_product.name} to "
-                + f"{new_product.name}"
-            )
-
-        elif changes == "location_id":
-            old_location = Location.get_by_id(raw_entry.from_int)
-            new_location = Location.get_by_id(raw_entry.to_int)
-            changes = (
-                f"changed box location from {old_location.name} to "
-                + f"{new_location.name}"
-            )
-
-        elif changes == "size_id":
-            old_size = Size.get_by_id(raw_entry.from_int)
-            new_size = Size.get_by_id(raw_entry.to_int)
-            changes = f"changed size from {old_size.label} to {new_size.label}"
-
-        elif changes == "box_state_id":
-            old_state = BoxState(raw_entry.from_int)
-            new_state = BoxState(raw_entry.to_int)
-            changes = f"changed box state from {old_state.name} to {new_state.name}"
-
-        elif changes.startswith("comments"):
-            changes = changes.replace("comments changed", "changed comments")
-
-        elif changes.startswith("Record"):
-            changes = changes.replace("Record created", "created record")
-
-        raw_entry.changes = changes
-        entries.append(raw_entry)
-    return sorted(entries, key=lambda e: e.id, reverse=True)

--- a/back/boxtribute_server/business_logic/warehouse/box/fields.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/fields.py
@@ -2,7 +2,6 @@ from ariadne import ObjectType
 
 from ....authz import authorize
 from ....exceptions import Forbidden
-from .crud import get_box_history
 
 box = ObjectType("Box")
 unboxed_items_collection = ObjectType("UnboxedItemsCollection")
@@ -20,9 +19,9 @@ def resolve_box_tags(box_obj, info):
 
 
 @box.field("history")
-def resolve_box_history(box_obj, _):
+def resolve_box_history(box_obj, info):
     authorize(permission="history:read")
-    return get_box_history(box_obj.id)
+    return info.context["history_for_box_loader"].load(box_obj.id)
 
 
 @box.field("product")

--- a/back/boxtribute_server/business_logic/warehouse/box/fields.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/fields.py
@@ -5,6 +5,7 @@ from ....exceptions import Forbidden
 
 box = ObjectType("Box")
 unboxed_items_collection = ObjectType("UnboxedItemsCollection")
+history_entry = ObjectType("HistoryEntry")
 
 
 @box.field("qrCode")
@@ -64,3 +65,8 @@ def resolve_box_state(box_obj, _):
 def resolve_box_shipment_detail(box_obj, info):
     authorize(permission="shipment_detail:read")
     return info.context["shipment_detail_for_box_loader"].load(box_obj.id)
+
+
+@history_entry.field("user")
+def resolve_history_entry_user(history_entry_obj, info):
+    return info.context["user_loader"].load(history_entry_obj.user_id)

--- a/back/boxtribute_server/graph_ql/bindables.py
+++ b/back/boxtribute_server/graph_ql/bindables.py
@@ -68,7 +68,11 @@ from ..business_logic.tag.mutations import mutation as tag_mutation
 from ..business_logic.tag.queries import query as tag_query
 from ..business_logic.user.fields import user
 from ..business_logic.user.queries import query as user_query
-from ..business_logic.warehouse.box.fields import box, unboxed_items_collection
+from ..business_logic.warehouse.box.fields import (
+    box,
+    history_entry,
+    unboxed_items_collection,
+)
 from ..business_logic.warehouse.box.mutations import mutation as box_mutation
 from ..business_logic.warehouse.box.queries import query as box_query
 from ..business_logic.warehouse.location.fields import classic_location
@@ -125,6 +129,7 @@ object_types = (
     distribution_spot,
     distribution_event,
     distribution_events_tracking_group,
+    history_entry,
     metrics,
     organisation,
     packing_list_entry,

--- a/back/boxtribute_server/graph_ql/execution.py
+++ b/back/boxtribute_server/graph_ql/execution.py
@@ -7,6 +7,7 @@ from ..exceptions import format_database_errors
 from .loaders import (
     BaseLoader,
     BoxLoader,
+    HistoryForBoxLoader,
     LocationLoader,
     OrganisationLoader,
     ProductCategoryLoader,
@@ -36,6 +37,7 @@ def execute_async(*, schema, introspection=None):
         context = {
             "base_loader": BaseLoader(),
             "box_loader": BoxLoader(),
+            "history_for_box_loader": HistoryForBoxLoader(),
             "location_loader": LocationLoader(),
             "organisation_loader": OrganisationLoader(),
             "product_category_loader": ProductCategoryLoader(),

--- a/back/boxtribute_server/graph_ql/loaders.py
+++ b/back/boxtribute_server/graph_ql/loaders.py
@@ -1,11 +1,16 @@
 from collections import defaultdict
+from datetime import datetime
+from functools import partial
 
 from aiodataloader import DataLoader as _DataLoader
+from peewee import SQL, Case, fn
 
 from ..authz import authorize, authorized_bases_filter
 from ..enums import TaggableObjectType
 from ..models.definitions.base import Base
 from ..models.definitions.box import Box
+from ..models.definitions.box_state import BoxState
+from ..models.definitions.history import DbChangeHistory
 from ..models.definitions.location import Location
 from ..models.definitions.organisation import Organisation
 from ..models.definitions.product import Product
@@ -18,6 +23,7 @@ from ..models.definitions.tag import Tag
 from ..models.definitions.tags_relation import TagsRelation
 from ..models.definitions.transfer_agreement import TransferAgreement
 from ..models.definitions.user import User
+from ..models.utils import convert_ids
 from ..utils import convert_pascal_to_snake_case
 
 
@@ -147,6 +153,173 @@ class TagsForBoxLoader(DataLoader):
 
         # Keys are in fact box IDs. Return empty list if box has no tags assigned
         return [tags.get(i, []) for i in keys]
+
+
+class HistoryForBoxLoader(DataLoader):
+    async def batch_load_fn(self, box_ids):
+        History = DbChangeHistory.alias()
+        ToProduct = Product.alias()
+        ToLocation = Location.alias()
+        ToSize = Size.alias()
+        ToBoxState = BoxState.alias()
+
+        # Return formatted history entries of boxes with given IDs, sorted by most
+        # recent first.
+        # Group history entry IDs, change dates, user IDs, and formatted messages for
+        # each box. Convert these into Python lists of appropriate data type
+        result = (
+            History.select(
+                fn.GROUP_CONCAT(History.id).python_value(convert_ids).alias("ids"),
+                fn.GROUP_CONCAT(History.change_date)
+                .python_value(partial(convert_ids, converter=datetime.fromisoformat))
+                .alias("change_dates"),
+                fn.GROUP_CONCAT(fn.IFNULL(History.user, SQL("NULL")))
+                .python_value(convert_ids)
+                .alias("user_ids"),
+                fn.GROUP_CONCAT(
+                    Case(
+                        None,
+                        (
+                            (
+                                (History.changes == "location_id"),
+                                fn.CONCAT(
+                                    "changed box location from ",
+                                    Location.name,
+                                    " to ",
+                                    ToLocation.name,
+                                ),
+                            ),
+                            (
+                                (History.changes == "product_id"),
+                                fn.CONCAT(
+                                    "changed product type from ",
+                                    Product.name,
+                                    " to ",
+                                    ToProduct.name,
+                                ),
+                            ),
+                            (
+                                (History.changes == "size_id"),
+                                fn.CONCAT(
+                                    "changed size from ",
+                                    Size.label,
+                                    " to ",
+                                    ToSize.label,
+                                ),
+                            ),
+                            (
+                                (History.changes == "box_state_id"),
+                                fn.CONCAT(
+                                    "changed box state from ",
+                                    BoxState.label,
+                                    " to ",
+                                    ToBoxState.label,
+                                ),
+                            ),
+                            (
+                                (History.changes == "items"),
+                                fn.CONCAT(
+                                    "changed the number of items from ",
+                                    History.from_int,
+                                    " to ",
+                                    History.to_int,
+                                ),
+                            ),
+                            (
+                                (History.changes.startswith("comments")),
+                                fn.REPLACE(
+                                    History.changes,
+                                    "comments changed",
+                                    "changed comments",
+                                ),
+                            ),
+                            (
+                                (History.changes.startswith("Record")),
+                                fn.REPLACE(
+                                    History.changes,
+                                    "Record created",
+                                    "created record",
+                                ),
+                            ),
+                        ),
+                        History.changes,
+                    )
+                )
+                .python_value(partial(convert_ids, converter=str))
+                .alias("messages"),
+                History.record_id,
+            )
+            .left_outer_join(
+                Product,
+                on=(
+                    (Product.id == History.from_int) & (History.changes == "product_id")
+                ),
+            )
+            .left_outer_join(
+                ToProduct,
+                on=(
+                    (ToProduct.id == History.to_int) & (History.changes == "product_id")
+                ),
+            )
+            .left_outer_join(
+                Location,
+                on=(
+                    (Location.id == History.from_int)
+                    & (History.changes == "location_id")
+                ),
+            )
+            .left_outer_join(
+                ToLocation,
+                on=(
+                    (ToLocation.id == History.to_int)
+                    & (History.changes == "location_id")
+                ),
+            )
+            .left_outer_join(
+                Size,
+                on=((Size.id == History.from_int) & (History.changes == "size_id")),
+            )
+            .left_outer_join(
+                ToSize,
+                on=((ToSize.id == History.to_int) & (History.changes == "size_id")),
+            )
+            .left_outer_join(
+                BoxState,
+                on=(
+                    (BoxState.id == History.from_int)
+                    & (History.changes == "box_state_id")
+                ),
+            )
+            .left_outer_join(
+                ToBoxState,
+                on=(
+                    (ToBoxState.id == History.to_int)
+                    & (History.changes == "box_state_id")
+                ),
+            )
+            .where(History.table_name == "stock", History.record_id << box_ids)
+            .group_by(History.record_id)
+            .dicts()
+        )
+
+        # Construct mapping of box IDs and their history information
+        box_histories = {}
+        for row in result:
+            box_histories[row["record_id"]] = list(
+                reversed(
+                    [
+                        DbChangeHistory(id=i, user=u, changes=c, change_date=d)
+                        for i, u, c, d in zip(
+                            row["ids"],
+                            row["user_ids"],
+                            row["messages"],
+                            row["change_dates"],
+                        )
+                    ]
+                )
+            )
+
+        return [box_histories.get(i, []) for i in box_ids]
 
 
 class ShipmentDetailsForShipmentLoader(DataLoader):

--- a/back/boxtribute_server/models/utils.py
+++ b/back/boxtribute_server/models/utils.py
@@ -17,11 +17,11 @@ def utcnow():
     return datetime.now(tz=timezone.utc).replace(microsecond=0)
 
 
-def convert_ids(concat_ids):
+def convert_ids(concat_ids, converter=int):
     """Convert a string of comma-separated IDs (returned from GROUP_CONCAT) into a
-    list of integers.
+    list using given convert (default: int).
     """
-    return [int(i) for i in (concat_ids or "").split(",") if i]
+    return [converter(i) for i in (concat_ids or "").split(",") if i]
 
 
 today = date.today()

--- a/back/test/data/history.py
+++ b/back/test/data/history.py
@@ -7,6 +7,9 @@ from boxtribute_server.models.definitions.history import DbChangeHistory
 from .box import another_marked_for_shipment_box_data
 from .box import data as box_data
 from .box import donated_boxes_data, lost_box_data
+from .user import default_user_data
+
+USER_ID = default_user_data()["id"]
 
 
 def data():
@@ -18,6 +21,7 @@ def data():
                 "record_id": box["id"],
                 "change_date": box["created_on"],
                 "table_name": "stock",
+                "user": USER_ID,
                 "from_int": None,
                 "to_int": None,
             }
@@ -30,6 +34,7 @@ def data():
                 "record_id": box["id"],
                 "change_date": "2022-12-05",
                 "table_name": "stock",
+                "user": USER_ID,
                 "from_int": BoxState.InStock,
                 "to_int": BoxState.Donated,
             }
@@ -45,6 +50,7 @@ def data():
                 "record_id": another_marked_for_shipment_box_data()["id"],
                 "change_date": datetime(2023, 6, 21),
                 "table_name": "stock",
+                "user": USER_ID,
             },
             {
                 "id": 111,
@@ -54,6 +60,7 @@ def data():
                 "record_id": lost_box_data()["id"],
                 "change_date": datetime(2023, 2, 1),
                 "table_name": "stock",
+                "user": USER_ID,
             },
         ]
     )

--- a/back/test/endpoint_tests/test_box.py
+++ b/back/test/endpoint_tests/test_box.py
@@ -125,10 +125,12 @@ def test_box_mutations(
     size_id = str(default_size["id"])
     location_id = str(default_location["id"])
     product_id = str(products[0]["id"])
+    original_number_of_items = 10
     creation_input = f"""{{
                     productId: {product_id},
                     locationId: {location_id},
                     sizeId: {size_id},
+                    numberOfItems: {original_number_of_items},
                 }}"""
     mutation = f"""mutation {{
             createBox( creationInput : {creation_input} ) {{
@@ -149,7 +151,7 @@ def test_box_mutations(
             }}
         }}"""
     created_box = assert_successful_request(client, mutation)
-    assert created_box["numberOfItems"] is None
+    assert created_box["numberOfItems"] == original_number_of_items
     assert created_box["state"] == BoxState.InStock.name
     assert created_box["location"]["id"] == location_id
     assert created_box["product"]["id"] == product_id
@@ -263,7 +265,8 @@ def test_box_mutations(
         },
         {
             "id": "116",
-            "changes": f"changed the number of items from None to {nr_items}",
+            "changes": f"changed the number of items from {original_number_of_items} "
+            + f"to {nr_items}",
             "user": {"name": "coord"},
         },
         {
@@ -339,7 +342,7 @@ def test_box_mutations(
         },
         {
             "changes": "items",
-            "from_int": None,
+            "from_int": original_number_of_items,
             "to_int": nr_items,
             "record_id": box_id,
             "table_name": "stock",


### PR DESCRIPTION
When formatting the messages of box history, batch-load for all requested boxes, and format using SQL joins (i.e. insert product, size, box state, location name), instead of iterating over each raw change and fetching property names.

The following query

```graphql
{
  boxes(baseId: 27, paginationInput: {first: 500}) {
    elements {
      history {
        id
        user { id }
        changes
        changeDate
      }
    }
  }
}
```

previously took ~8s and caused about 1800 DB calls.

Now it's <0.5s with 5 DB calls (3 due to pagination, 2 for the history and user batch-loaders).

Also found and fixed the bug that the `Box.history.user` field was missing a batch-loader call.


The generated SQL is somewhat like this (didnt replace all placeholders)
```sql
select
	GROUP_CONCAT(`t1`.`id`) as `ids`,
	GROUP_CONCAT(`t1`.`changedate`) as `change_dates`,
	GROUP_CONCAT(IFNULL(`t1`.`user_id`, "NULL")) as `user_ids`,
	GROUP_CONCAT(case when (`t1`.`changes` = %s) then CONCAT(%s, `t2`.`label`, %s, `t3`.`label`) when (`t1`.`changes` = %s) then CONCAT(%s, `t4`.`name`, %s, `t5`.`name`) when (`t1`.`changes` = %s) then CONCAT(%s, `t6`.`label`, %s, `t7`.`label`) when (`t1`.`changes` = %s) then CONCAT(%s, `t8`.`label`, %s, `t9`.`label`) when (`t1`.`changes` = %s) then CONCAT(%s, `t1`.`from_int`, %s, `t1`.`to_int`) when (`t1`.`changes` like %s) then replace(`t1`.`changes`, %s, %s) when (`t1`.`changes` like %s) then replace(`t1`.`changes`, %s, %s) else `t1`.`changes` end) as `all_changes`,
	`t1`.`record_id`
from
	`history` as `t1`
left outer join `products` as `t4` on
	((`t4`.`id` = `t1`.`from_int`)
		and (`t1`.`changes` = "product_id"))
left outer join `products` as `t5` on
	((`t5`.`id` = `t1`.`to_int`)
		and (`t1`.`changes` = "product_id"))
left outer join `location
s` as `t2` on
	((`t2`.`id` = `t1`.`from_int`)
		and (`t1`.`changes` = "location_id"))
left outer join `locations` as `t3` on
	((`t3`.`id` = `t1`.`to_int`)
		and (`t1`.`changes` = "location_id"))
left outer join `sizes` as `t6` on
	((`t6`.
`id` = `t1`.`from_int`)
		and (`t1`.`changes` = "size_id"))
left outer join `sizes` as `t7` on
	((`t7`.`id` = `t1`.`to_int`)
		and (`t1`.`changes` = "size_id"))
left outer join `box_state` as `t8` on
	((`t8`.`id` = `t1`.`from_int
`)
		and (`t1`.`changes` = "box_state_id"))
left outer join `box_state` as `t9` on
	((`t9`.`id` = `t1`.`to_int`)
		and (`t1`.`changes` = "box_state_id"))
where
	((`t1`.`tablename` = "stock")
		and (`t1`.`record_id` in (...)))
group by
	record_id;
```