### PR TITLE
Update invoke_yarn script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
         types_or: [javascript, jsx, ts, tsx]
         language: script
         require_serial: true
+        exclude: Distributions|generated
       - id: prettier
         name: Format Typescript files
         entry: ./invoke_yarn format

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -284,6 +284,7 @@ export type CreatedBoxDataDimensions = {
   __typename?: 'CreatedBoxDataDimensions';
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
   product?: Maybe<Array<Maybe<ProductDimensionInfo>>>;
+  tag?: Maybe<Array<Maybe<TagDimensionInfo>>>;
 };
 
 export type CreatedBoxesData = DataCube & {
@@ -300,6 +301,7 @@ export type CreatedBoxesResult = {
   gender?: Maybe<ProductGender>;
   itemsCount?: Maybe<Scalars['Int']>;
   productId?: Maybe<Scalars['Int']>;
+  tagIds?: Maybe<Array<Scalars['Int']>>;
 };
 
 export type DataCube = {

--- a/invoke_yarn
+++ b/invoke_yarn
@@ -39,9 +39,9 @@ if [[ "$mode" = "lint" ]]; then
 elif [[ "$mode" = "format" ]]; then
     yarn statviz run format:write "$@"
 elif [[ "$mode" = "tsc" ]]; then
-    yarn front --cwd front run tsc:precommit --noEmit "${front_files[@]}"
-    yarn statviz --cwd statviz run tsc:precommit --noEmit "${statviz_files[@]}"
-    yarn statviz --cwd shared-components run tsc:precommit --noEmit "${shared_components_files[@]}"
+    yarn front --cwd front run tsc:precommit "${front_files[@]}"
+    yarn statviz --cwd statviz run tsc:precommit "${statviz_files[@]}"
+    yarn statviz --cwd shared-components run tsc:precommit "${shared_components_files[@]}"
 elif [[ "$mode" = "graphql-types" ]]; then
     yarn front --cwd front run generate-graphql-ts-types
     yarn statviz --cwd statviz run generate-graphql-ts-types

--- a/invoke_yarn
+++ b/invoke_yarn
@@ -21,17 +21,11 @@ for file in "$@"; do
 done
 
 yarn() {
-    local service container
+    local service
     service="$1"
-    container=boxtribute-"$service"-1
     shift
 
-    if ! [ "$(docker inspect -f '{{.State.Running}}' "$container")" = "true" ]; then
-        echo "$service not running"
-        docker-compose up -d "$service"
-    fi
-
-    docker exec -w /app "$container" yarn "$@"
+    docker-compose run --rm -w /app "$service" yarn "$@"
 }
 
 if [[ "$mode" = "lint" ]]; then

--- a/invoke_yarn
+++ b/invoke_yarn
@@ -1,36 +1,41 @@
 #!/usr/bin/env bash
-# Utility script to invoke front-end style checks in the front directory, or other
+# Utility script to invoke style checks in front-end directories, or other
 # tools in the repository using yarn
-# Usage: ./invoke_yarn lint|format|graphql-types FILE [FILE...]
+# Requires statviz docker-compose service running.
+# Usage: ./invoke_yarn lint|format|tsc|graphql-types FILE [FILE...]
 
 mode=$1
 shift
 
 declare -a front_files statviz_files shared_components_files
 
-# strip prefix from all given filepaths and add to file_collections
+# strip prefix from all given filepaths and add to *_files arrays
 for file in "$@"; do
     if [[ $file == front/* ]]; then
-        file_collections["front"]+=("${file#front/}")
+        front_files+=("${file#front/}")
     elif [[ $file == statviz/* ]]; then
-        file_collections["statviz"]+=("${file#statviz/}")
+        statviz_files+=("${file#statviz/}")
     elif [[ $file == shared-components/* ]]; then
         shared_components_files+=("${file#shared-components/}")
     fi
 done
 
-# TODO: move this to the pre-commit config. Otherwise people need to install yarn
+yarn() {
+    docker-compose exec -w /app statviz yarn "$@"
+}
+
 if [[ "$mode" = "lint" ]]; then
     yarn run lint:fix "$@"
 elif [[ "$mode" = "format" ]]; then
     yarn run format:write "$@"
 elif [[ "$mode" = "tsc" ]]; then
-    echo "${file_collections["shared-components"]}"
-    yarn --cwd front run tsc:precommit --noEmit "${file_collections["front"]}"
-    yarn --cwd statviz run tsc:precommit --noEmit "${file_collections["statviz"]}"
+    yarn --cwd front run tsc:precommit --noEmit "${front_files[@]}"
+    yarn --cwd statviz run tsc:precommit --noEmit "${statviz_files[@]}"
     yarn --cwd shared-components run tsc:precommit --noEmit "${shared_components_files[@]}"
 elif [[ "$mode" = "graphql-types" ]]; then
-    yarn --cwd front run generate-graphql-ts-types && yarn --cwd statviz run generate-graphql-ts-types
+    # yarn --cwd front run generate-graphql-ts-types
+    yarn --cwd statviz run generate-graphql-ts-types
+    yarn --cwd shared-components run generate-graphql-ts-types
 else
     echo "Unknown mode: $mode" >&2
     exit 1

--- a/invoke_yarn
+++ b/invoke_yarn
@@ -21,21 +21,31 @@ for file in "$@"; do
 done
 
 yarn() {
-    docker-compose exec -w /app statviz yarn "$@"
+    local service container
+    service="$1"
+    container=boxtribute-"$service"-1
+    shift
+
+    if ! [ "$(docker inspect -f '{{.State.Running}}' "$container")" = "true" ]; then
+        echo "$service not running"
+        docker-compose up -d "$service"
+    fi
+
+    docker exec -w /app "$container" yarn "$@"
 }
 
 if [[ "$mode" = "lint" ]]; then
-    yarn run lint:fix "$@"
+    yarn statviz run lint:fix "$@"
 elif [[ "$mode" = "format" ]]; then
-    yarn run format:write "$@"
+    yarn statviz run format:write "$@"
 elif [[ "$mode" = "tsc" ]]; then
-    yarn --cwd front run tsc:precommit --noEmit "${front_files[@]}"
-    yarn --cwd statviz run tsc:precommit --noEmit "${statviz_files[@]}"
-    yarn --cwd shared-components run tsc:precommit --noEmit "${shared_components_files[@]}"
+    yarn front --cwd front run tsc:precommit --noEmit "${front_files[@]}"
+    yarn statviz --cwd statviz run tsc:precommit --noEmit "${statviz_files[@]}"
+    yarn statviz --cwd shared-components run tsc:precommit --noEmit "${shared_components_files[@]}"
 elif [[ "$mode" = "graphql-types" ]]; then
-    # yarn --cwd front run generate-graphql-ts-types
-    yarn --cwd statviz run generate-graphql-ts-types
-    yarn --cwd shared-components run generate-graphql-ts-types
+    yarn front --cwd front run generate-graphql-ts-types
+    yarn statviz --cwd statviz run generate-graphql-ts-types
+    yarn statviz --cwd shared-components run generate-graphql-ts-types
 else
     echo "Unknown mode: $mode" >&2
     exit 1


### PR DESCRIPTION
This PR fixes the `invoke_yarn` script. Previously an array definition was missing (in the process of #1165).

Now yarn from the `statviz` docker-compose service is used, instead of requiring a local installation.

Test it via
```sh
pre-commit run --all-files eslint
pre-commit run --all-files prettier
pre-commit run --all-files tsc
pre-commit run --all-files graphql-types
```

Note: I'm not sure why `docker-compose exec -w /app statviz yarn --cwd front run generate-graphql-ts-types` produces so much output, can you check @haguesto?

Details:
- update comments
- replace unknown file_collections array
- add alias to invoke yarn in docker-compose service
