### PR TITLE
Remove redundant Metrics.movedStockOverview field

### DIFF
--- a/back/boxtribute_server/business_logic/metrics/fields.py
+++ b/back/boxtribute_server/business_logic/metrics/fields.py
@@ -1,7 +1,6 @@
 from ariadne import ObjectType
 
 from .crud import (
-    compute_moved_stock_overview,
     compute_number_of_beneficiaries_served,
     compute_number_of_families_served,
     compute_number_of_sales,
@@ -37,10 +36,3 @@ def resolve_metrics_number_of_sales(metrics_obj, _, after=None, before=None):
 @metrics.field("stockOverview")
 def resolve_metrics_stock_overview(metrics_obj, _):
     return compute_stock_overview(organisation_id=metrics_obj["organisation_id"])
-
-
-@metrics.field("movedStockOverview")
-def resolve_metrics_moved_stock_overview(metrics_obj, _, after=None, before=None):
-    return compute_moved_stock_overview(
-        organisation_id=metrics_obj["organisation_id"], after=after, before=before
-    )

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -543,11 +543,6 @@ type Metrics {
   Return number of boxes, and number of contained items, managed by client's organisation.
   """
   stockOverview: StockOverview
-  """
-  Return number of boxes, and contained items, moved by client's organisation in optional date range. Sorted by product category.
-  See `numberOfFamiliesServed` about using the `after` and `before` parameters.
-  """
-  movedStockOverview(after: Date, before: Date): [StockOverview]
 }
 
 type StockOverview {

--- a/back/test/endpoint_tests/test_metrics.py
+++ b/back/test/endpoint_tests/test_metrics.py
@@ -79,46 +79,6 @@ def test_metrics_query_stock_overview(
 
 
 @pytest.mark.parametrize(
-    "filters,box_ids",
-    [
-        ["", [2, 3, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15]],
-        ["""(after: "2021-01-01")""", [6, 7]],
-        ["""(after: "2022-01-01")""", []],
-        ["""(before: "2022-01-01")""", [2, 3, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15]],
-        ["""(before: "2021-01-01")""", [2, 3, 5, 9, 10, 11, 12, 13, 14, 15]],
-        ["""(before: "2019-01-01")""", []],
-        [
-            """(after: "2020-01-01", before: "2021-01-01")""",
-            [2, 3, 5, 9, 10, 11, 12, 13, 14, 15],
-        ],
-        ["""(after: "2021-01-01", before: "2022-01-01")""", [6, 7]],
-        ["""(after: "2022-01-01", before: "2023-01-01")""", []],
-    ],
-)
-def test_metrics_query_moved_stock_overview(
-    read_only_client, default_transaction, default_boxes, filters, box_ids
-):
-    query = f"""query {{ metrics {{ movedStockOverview{filters} {{
-                productCategoryName numberOfBoxes numberOfItems }} }} }}"""
-    response = assert_successful_request(read_only_client, query, field="metrics")
-
-    boxes = [b for b in default_boxes if b["id"] in box_ids]
-    number_of_boxes = len(boxes)
-    if number_of_boxes == 0:
-        assert response == {"movedStockOverview": []}
-    else:
-        assert response == {
-            "movedStockOverview": [
-                {
-                    "productCategoryName": "Underwear / Nightwear",
-                    "numberOfBoxes": number_of_boxes,
-                    "numberOfItems": sum(b["number_of_items"] for b in boxes),
-                }
-            ]
-        }
-
-
-@pytest.mark.parametrize(
     "organisation_id,number_of_families_served,number_of_sales", [[1, 2, 16], [2, 0, 0]]
 )
 def test_metrics_query_for_god_user(

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -508,11 +508,6 @@ export type LocationBoxesArgs = {
 
 export type Metrics = {
   __typename?: 'Metrics';
-  /**
-   * Return number of boxes, and contained items, moved by client's organisation in optional date range. Sorted by product category.
-   * See `numberOfFamiliesServed` about using the `after` and `before` parameters.
-   */
-  movedStockOverview?: Maybe<Array<Maybe<StockOverview>>>;
   /**  Like `numberOfFamiliesServed` but add up all members of served families  */
   numberOfBeneficiariesServed?: Maybe<Scalars['Int']>;
   /**


### PR DESCRIPTION
- superseded by movedBoxes query
- was incorrect anyways (no change of box state taken into account,
  only last_modified_on date)
- box IDs had to be added to test case whenever a new test box was added
