### PR TITLE
Increase group_concat_max_len for BoxHistory loader

### DIFF
--- a/back/boxtribute_server/graph_ql/loaders.py
+++ b/back/boxtribute_server/graph_ql/loaders.py
@@ -6,6 +6,7 @@ from aiodataloader import DataLoader as _DataLoader
 from peewee import SQL, Case, NodeList, fn
 
 from ..authz import authorize, authorized_bases_filter
+from ..db import db
 from ..enums import TaggableObjectType
 from ..models.definitions.base import Base
 from ..models.definitions.box import Box
@@ -163,6 +164,9 @@ class HistoryForBoxLoader(DataLoader):
         ToSize = Size.alias()
         ToBoxState = BoxState.alias()
 
+        # Increase the default of 1024 (would be exceeded for concat'ing the change_date
+        # column of a box with 54 or more history entries).
+        db.database.execute_sql("SET SESSION group_concat_max_len = 10000;")
         # Return formatted history entries of boxes with given IDs, sorted by most
         # recent first.
         # Group history entry IDs, change dates, user IDs, and formatted messages for


### PR DESCRIPTION
e.g. for Hermine's box with ID 26663 (and 65 history entries), the batch loader fails, causing all `history` fields to be returned as null.

Follow-up to #1233.

@MaikNeubert you could test it locally by running the webapp service connected to the prod DB via cloud SQL proxy, not sure if you've done it before.