### PR TITLE
GraphQL interface for products

### DIFF
--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -9,7 +9,7 @@ from peewee import Model
 from .auth import CurrentUser
 from .business_logic.statistics import statistics_queries
 from .enums import BoxState, TransferAgreementState
-from .errors import InsufficientPermission
+from .errors import InsufficientPermission, UnauthorizedForBase
 from .exceptions import Forbidden
 from .models.definitions.base import Base
 from .models.definitions.shipment import Shipment
@@ -62,7 +62,11 @@ def handle_unauthorized(f):
         try:
             return f(*args, **kwargs)
         except Forbidden as e:
-            return InsufficientPermission(name=e.permission)
+            if e.permission is not None:
+                return InsufficientPermission(name=e.permission)
+            elif e.resource == "base":
+                return UnauthorizedForBase(id=e.value, name="")
+            raise e
 
     return inner
 

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -316,6 +316,11 @@ ALL_ALLOWED_MUTATIONS: Dict[int, Tuple[str, ...]] = {
     ),
 }
 ALL_ALLOWED_MUTATIONS[3] = ALL_ALLOWED_MUTATIONS[2]
+ALL_ALLOWED_MUTATIONS[4] = ALL_ALLOWED_MUTATIONS[3] + (
+    "createCustomProduct",
+    "editCustomProduct",
+    "deleteProduct",
+)
 ALL_ALLOWED_MUTATIONS[99] = ALL_ALLOWED_MUTATIONS[2] + (
     # + mutations for mobile distribution pages
     "createDistributionSpot",

--- a/back/boxtribute_server/business_logic/warehouse/product/crud.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/crud.py
@@ -1,4 +1,5 @@
 from ....db import db
+from ....errors import InvalidPrice
 from ....models.definitions.product import Product
 from ....models.utils import handle_non_existing_resource, utcnow
 
@@ -16,6 +17,9 @@ def create_custom_product(
     comment=None,
     in_shop=False,
 ):
+    if price < 0:
+        return InvalidPrice(value=price)
+
     product = Product()
     product.base = base_id
     product.category = category_id

--- a/back/boxtribute_server/business_logic/warehouse/product/crud.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/crud.py
@@ -1,0 +1,31 @@
+from ....db import db
+from ....models.definitions.product import Product
+from ....models.utils import utcnow
+
+
+def create_custom_product(
+    *,
+    user_id,
+    category_id,
+    size_range_id,
+    gender,
+    base_id,
+    price=0,
+    name=None,
+    comment=None,
+    in_shop=False,
+):
+    product = Product()
+    product.base = base_id
+    product.category = category_id
+    product.comment = comment
+    product.created_on = utcnow()
+    product.created_by = user_id
+    product.gender = gender
+    product.name = name or ""
+    product.size_range = size_range_id
+    product.in_shop = in_shop
+    product.price = price
+    with db.database.atomic():
+        product.save()
+        return product

--- a/back/boxtribute_server/business_logic/warehouse/product/crud.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/crud.py
@@ -1,5 +1,5 @@
 from ....db import db
-from ....errors import InvalidPrice
+from ....errors import EmptyName, InvalidPrice
 from ....models.definitions.product import Product
 from ....models.utils import (
     handle_non_existing_resource,
@@ -24,6 +24,9 @@ def create_custom_product(
 ):
     if price < 0:
         return InvalidPrice(value=price)
+
+    if not name:
+        return EmptyName()
 
     product = Product()
     product.base = base_id

--- a/back/boxtribute_server/business_logic/warehouse/product/crud.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/crud.py
@@ -17,8 +17,8 @@ def create_custom_product(
     size_range_id,
     gender,
     base_id,
+    name,
     price=0,
-    name=None,
     comment=None,
     in_shop=False,
 ):
@@ -32,7 +32,7 @@ def create_custom_product(
     product.created_on = utcnow()
     product.created_by = user_id
     product.gender = gender
-    product.name = name or ""
+    product.name = name
     product.size_range = size_range_id
     product.in_shop = in_shop
     product.price = price

--- a/back/boxtribute_server/business_logic/warehouse/product/crud.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/crud.py
@@ -1,8 +1,9 @@
 from ....db import db
 from ....models.definitions.product import Product
-from ....models.utils import utcnow
+from ....models.utils import handle_non_existing_resource, utcnow
 
 
+@handle_non_existing_resource
 def create_custom_product(
     *,
     user_id,

--- a/back/boxtribute_server/business_logic/warehouse/product/crud.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/crud.py
@@ -1,9 +1,14 @@
 from ....db import db
 from ....errors import InvalidPrice
 from ....models.definitions.product import Product
-from ....models.utils import handle_non_existing_resource, utcnow
+from ....models.utils import (
+    handle_non_existing_resource,
+    save_creation_to_history,
+    utcnow,
+)
 
 
+@save_creation_to_history
 @handle_non_existing_resource
 def create_custom_product(
     *,

--- a/back/boxtribute_server/business_logic/warehouse/product/mutations.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/mutations.py
@@ -2,6 +2,7 @@ from ariadne import MutationType
 from flask import g
 
 from ....authz import authorize
+from ....errors import ResourceDoesNotExist
 from ....models.definitions.base import Base
 from .crud import create_custom_product
 
@@ -10,9 +11,13 @@ mutation = MutationType()
 
 @mutation.field("createCustomProduct")
 def resolve_create_custom_product(*_, creation_input):
-    # Base might not exist
-    base = Base.get_by_id(creation_input["base_id"])
+    try:
+        input_base_id = creation_input["base_id"]
+        base_id = Base.select(Base.id).where(Base.id == input_base_id).get().id
+    except Base.DoesNotExist:
+        return ResourceDoesNotExist(name="Base", id=input_base_id)
+
     # permission might be missing; or not granted for this base
-    authorize(permission="product:write", base_id=base.id)
+    authorize(permission="product:write", base_id=base_id)
 
     return create_custom_product(user_id=g.user.id, **creation_input)

--- a/back/boxtribute_server/business_logic/warehouse/product/mutations.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/mutations.py
@@ -2,8 +2,6 @@ from ariadne import MutationType
 from flask import g
 
 from ....authz import authorize, handle_unauthorized
-from ....errors import ResourceDoesNotExist
-from ....models.definitions.base import Base
 from .crud import create_custom_product
 
 mutation = MutationType()
@@ -12,12 +10,7 @@ mutation = MutationType()
 @mutation.field("createCustomProduct")
 @handle_unauthorized
 def resolve_create_custom_product(*_, creation_input):
-    try:
-        input_base_id = creation_input["base_id"]
-        base_id = Base.select(Base.id).where(Base.id == input_base_id).get().id
-    except Base.DoesNotExist:
-        return ResourceDoesNotExist(name="Base", id=input_base_id)
-
+    base_id = creation_input["base_id"]
     authorize(permission="product:write", base_id=base_id)
 
     return create_custom_product(user_id=g.user.id, **creation_input)

--- a/back/boxtribute_server/business_logic/warehouse/product/mutations.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/mutations.py
@@ -1,7 +1,7 @@
 from ariadne import MutationType
 from flask import g
 
-from ....authz import authorize
+from ....authz import authorize, handle_unauthorized
 from ....errors import ResourceDoesNotExist
 from ....models.definitions.base import Base
 from .crud import create_custom_product
@@ -10,6 +10,7 @@ mutation = MutationType()
 
 
 @mutation.field("createCustomProduct")
+@handle_unauthorized
 def resolve_create_custom_product(*_, creation_input):
     try:
         input_base_id = creation_input["base_id"]
@@ -17,7 +18,6 @@ def resolve_create_custom_product(*_, creation_input):
     except Base.DoesNotExist:
         return ResourceDoesNotExist(name="Base", id=input_base_id)
 
-    # permission might be missing; or not granted for this base
     authorize(permission="product:write", base_id=base_id)
 
     return create_custom_product(user_id=g.user.id, **creation_input)

--- a/back/boxtribute_server/business_logic/warehouse/product/mutations.py
+++ b/back/boxtribute_server/business_logic/warehouse/product/mutations.py
@@ -1,0 +1,18 @@
+from ariadne import MutationType
+from flask import g
+
+from ....authz import authorize
+from ....models.definitions.base import Base
+from .crud import create_custom_product
+
+mutation = MutationType()
+
+
+@mutation.field("createCustomProduct")
+def resolve_create_custom_product(*_, creation_input):
+    # Base might not exist
+    base = Base.get_by_id(creation_input["base_id"])
+    # permission might be missing; or not granted for this base
+    authorize(permission="product:write", base_id=base.id)
+
+    return create_custom_product(user_id=g.user.id, **creation_input)

--- a/back/boxtribute_server/errors.py
+++ b/back/boxtribute_server/errors.py
@@ -9,3 +9,8 @@ class ResourceDoesNotExist(UserError):
     def __init__(self, *, name, id=None):
         self.id = id
         self.name = name
+
+
+class InvalidPrice(UserError):
+    def __init__(self, *, value):
+        self.value = value

--- a/back/boxtribute_server/errors.py
+++ b/back/boxtribute_server/errors.py
@@ -14,3 +14,8 @@ class ResourceDoesNotExist(UserError):
 class InvalidPrice(UserError):
     def __init__(self, *, value):
         self.value = value
+
+
+class InsufficientPermission(UserError):
+    def __init__(self, *, name):
+        self.name = name

--- a/back/boxtribute_server/errors.py
+++ b/back/boxtribute_server/errors.py
@@ -1,0 +1,11 @@
+"""Representation of user errors that possibly occur during usage of the back-end."""
+
+
+class UserError:
+    pass
+
+
+class ResourceDoesNotExist(UserError):
+    def __init__(self, *, name, id=None):
+        self.id = id
+        self.name = name

--- a/back/boxtribute_server/errors.py
+++ b/back/boxtribute_server/errors.py
@@ -19,3 +19,9 @@ class InvalidPrice(UserError):
 class InsufficientPermission(UserError):
     def __init__(self, *, name):
         self.name = name
+
+
+class UnauthorizedForBase(UserError):
+    def __init__(self, *, id, name):
+        self.id = id
+        self.name = name

--- a/back/boxtribute_server/errors.py
+++ b/back/boxtribute_server/errors.py
@@ -16,6 +16,10 @@ class InvalidPrice(UserError):
         self.value = value
 
 
+class EmptyName(UserError):
+    _ = None
+
+
 class InsufficientPermission(UserError):
     def __init__(self, *, name):
         self.name = name

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -62,8 +62,15 @@ class QrCodeAlreadyAssignedToBox(Exception):
 
 
 class Forbidden(Exception):
-    def __init__(self, *args, reason, **kwargs):
-        self.reason = reason
+    def __init__(self, *args, permission=None, resource=None, value=None, **kwargs):
+        if permission is not None and resource is not None and value is not None:
+            raise ValueError(
+                "Invalid input: set either 'permission', or 'resource'+'value'."
+            )
+        self.permission = permission
+        self.resource = resource
+        self.value = value
+        reason = f"{resource}={value}" if permission is None else permission
         self.extensions = {
             "code": "FORBIDDEN",
             "description": f"You don't have access to '{reason}'",

--- a/back/boxtribute_server/exceptions.py
+++ b/back/boxtribute_server/exceptions.py
@@ -63,6 +63,7 @@ class QrCodeAlreadyAssignedToBox(Exception):
 
 class Forbidden(Exception):
     def __init__(self, *args, reason, **kwargs):
+        self.reason = reason
         self.extensions = {
             "code": "FORBIDDEN",
             "description": f"You don't have access to '{reason}'",

--- a/back/boxtribute_server/graph_ql/bindables.py
+++ b/back/boxtribute_server/graph_ql/bindables.py
@@ -78,11 +78,13 @@ from ..business_logic.warehouse.box.queries import query as box_query
 from ..business_logic.warehouse.location.fields import classic_location
 from ..business_logic.warehouse.location.queries import query as location_query
 from ..business_logic.warehouse.product.fields import product
+from ..business_logic.warehouse.product.mutations import mutation as product_mutation
 from ..business_logic.warehouse.product.queries import query as product_query
 from ..business_logic.warehouse.qr_code.fields import qr_code
 from ..business_logic.warehouse.qr_code.mutations import mutation as qr_code_mutation
 from ..business_logic.warehouse.qr_code.queries import query as qr_code_query
 from ..models.definitions.box import Box
+from ..models.definitions.product import Product
 
 # Container for QueryTypes
 query_types = (
@@ -114,6 +116,7 @@ mutation_types = (
     distribution_event_mutation,
     mobile_distribution_mutation,
     packing_list_entry_mutation,
+    product_mutation,
     qr_code_mutation,
     shipment_mutation,
     tag_mutation,
@@ -153,6 +156,11 @@ def resolve_taggable_resource_type(obj, *_):
     return "Beneficiary"
 
 
+def resolve_create_custom_product_result_type(obj, *_):
+    if isinstance(obj, Product):
+        return "Product"
+
+
 def resolve_location_type(obj, *_):
     return obj.type.name
 
@@ -163,7 +171,10 @@ def resolve_items_collection_type(obj, *_):
     return "UnboxedItemsCollection"
 
 
-union_types = (UnionType("TaggableResource", resolve_taggable_resource_type),)
+union_types = (
+    UnionType("TaggableResource", resolve_taggable_resource_type),
+    UnionType("CreateCustomProductResult", resolve_create_custom_product_result_type),
+)
 interface_types = (
     InterfaceType("Location", resolve_location_type),
     InterfaceType("ItemsCollection", resolve_items_collection_type),

--- a/back/boxtribute_server/graph_ql/bindables.py
+++ b/back/boxtribute_server/graph_ql/bindables.py
@@ -83,6 +83,7 @@ from ..business_logic.warehouse.product.queries import query as product_query
 from ..business_logic.warehouse.qr_code.fields import qr_code
 from ..business_logic.warehouse.qr_code.mutations import mutation as qr_code_mutation
 from ..business_logic.warehouse.qr_code.queries import query as qr_code_query
+from ..errors import UserError
 from ..models.definitions.box import Box
 from ..models.definitions.product import Product
 
@@ -159,6 +160,8 @@ def resolve_taggable_resource_type(obj, *_):
 def resolve_create_custom_product_result_type(obj, *_):
     if isinstance(obj, Product):
         return "Product"
+    if isinstance(obj, UserError):
+        return obj.__class__.__name__
 
 
 def resolve_location_type(obj, *_):

--- a/back/boxtribute_server/graph_ql/definitions/basic/enums.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/basic/enums.graphql
@@ -28,6 +28,12 @@ enum BoxState {
   NotDelivered
 }
 
+enum ProductTypeFilter {
+  Custom
+  StandardInstantiation
+  All
+}
+
 """
 Classificators for [`Tag`]({{Types.Tag}}) type.
 """

--- a/back/boxtribute_server/graph_ql/definitions/protected/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/inputs.graphql
@@ -26,8 +26,7 @@ input BoxUpdateInput {
 }
 
 input CustomProductCreationInput {
-  " Name can be empty acc. to products table definition "
-  name: String
+  name: String!
   categoryId: Int!
   sizeRangeId: Int!
   gender: ProductGender!
@@ -39,7 +38,6 @@ input CustomProductCreationInput {
 
 input CustomProductEditInput {
   id: ID!
-  " Name can be empty acc. to products table definition "
   name: String
   categoryId: Int
   sizeRangeId: Int

--- a/back/boxtribute_server/graph_ql/definitions/protected/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/inputs.graphql
@@ -25,6 +25,31 @@ input BoxUpdateInput {
   tagIdsToBeAdded: [Int!]
 }
 
+input CustomProductCreationInput {
+  " Name can be empty acc. to products table definition "
+  name: String
+  categoryId: Int!
+  sizeRangeId: Int!
+  gender: ProductGender!
+  baseId: Int!
+  price: Int
+  comment: String
+  inShop: Boolean
+}
+
+input CustomProductEditInput {
+  id: ID!
+  " Name can be empty acc. to products table definition "
+  name: String
+  categoryId: Int
+  sizeRangeId: Int
+  gender: ProductGender
+  # baseId: Int  " not possible to change product base
+  price: Int
+  comment: String
+  inShop: Boolean
+}
+
 input BeneficiaryCreationInput {
   firstName: String!
   lastName: String!

--- a/back/boxtribute_server/graph_ql/definitions/protected/mutations.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/mutations.graphql
@@ -30,6 +30,10 @@ type Mutation {
   markShipmentAsLost(id: ID!): Shipment
   moveNotDeliveredBoxesInStock(boxIds: [String!]!): Shipment
 
+  createCustomProduct(creationInput: CustomProductCreationInput): CreateCustomProductResult
+  editCustomProduct(editInput: CustomProductEditInput): EditCustomProductResult
+  deleteProduct(id: ID!): DeleteProductResult
+
   createDistributionSpot(creationInput: DistributionSpotCreationInput): DistributionSpot
   createDistributionEvent(creationInput: DistributionEventCreationInput): DistributionEvent
 

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -540,13 +540,12 @@ type ResourceDoesNotExist {
 }
 type UnauthorizedForBase {
   " e.g. 'product:write' present but not for requested base "
-  baseId: ID!
-  baseName: String!
+  id: ID!
+  name: String!
 }
 type InvalidPrice {
   value: Int!
 }
-" The *DoesNotExist and UnauthorizedFor* types can probably be generalized "
 union CreateCustomProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase | InvalidPrice
 union EditCustomProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase | InvalidPrice
 union DeleteProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -535,7 +535,7 @@ type InsufficientPermission {
   permission: String!
 }
 type ResourceDoesNotExist {
-  id: ID!
+  id: ID
   name: String!
 }
 type UnauthorizedForBase {

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -532,7 +532,7 @@ type ShipmentDetail {
 
 type InsufficientPermission {
   " e.g. 'product:write' missing "
-  permission: String!
+  name: String!
 }
 type ResourceDoesNotExist {
   id: ID

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -85,6 +85,7 @@ type Product {
   price: Float
   gender: ProductGender
   comment: String
+  inShop: Boolean!
   createdBy: User
   createdOn: Datetime
   lastModifiedBy: User
@@ -192,7 +193,7 @@ type Base {
   " List of all undeleted [`ClassicLocations`]({{Types.ClassicLocation}}) present in this base "
   locations: [ClassicLocation!]!
   " List of all undeleted [`Products`]({{Types.Product}}) registered in this base "
-  products: [Product!]!
+  products(filterInput: FilterProductInput): [Product!]!
   " List of all [`Tags`]({{Types.Tag}}) registered in this base. Optionally filter for a [`resource type`]({{Types.TaggableResourceType}}) "
   tags(resourceType: TaggableResourceType): [Tag!]
   distributionSpots: [DistributionSpot!]!
@@ -441,6 +442,11 @@ input FilterBoxInput {
   tagIds: [Int!]
 }
 
+input FilterProductInput {
+  includeDeleted: Boolean = False
+  type: ProductTypeFilter = Custom
+}
+
 """
 Optional input for queries/fields that return a page of elements.
 The specified fields must be either none OR `first` OR `after, first` OR `before, last`. Other combinations result in unexpected behavior and/or errors.
@@ -523,6 +529,27 @@ type ShipmentDetail {
   receivedBy: User
   receivedOn: Datetime
 }
+
+type InsufficientPermission {
+  " e.g. 'product:write' missing "
+  permission: String!
+}
+type ResourceDoesNotExist {
+  id: ID!
+  name: String!
+}
+type UnauthorizedForBase {
+  " e.g. 'product:write' present but not for requested base "
+  baseId: ID!
+  baseName: String!
+}
+type InvalidPrice {
+  value: Int!
+}
+" The *DoesNotExist and UnauthorizedFor* types can probably be generalized "
+union CreateCustomProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase | InvalidPrice
+union EditCustomProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase | InvalidPrice
+union DeleteProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase
 
 type Metrics {
   """

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -546,8 +546,12 @@ type UnauthorizedForBase {
 type InvalidPrice {
   value: Int!
 }
-union CreateCustomProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase | InvalidPrice
-union EditCustomProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase | InvalidPrice
+type EmptyName {
+  " Dummy field since type definitions without fields are not possible "
+  _: Boolean
+}
+union CreateCustomProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase | InvalidPrice | EmptyName
+union EditCustomProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase | InvalidPrice | EmptyName
 union DeleteProductResult = Product | InsufficientPermission | ResourceDoesNotExist | UnauthorizedForBase
 
 type Metrics {

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -109,6 +109,7 @@ def _create_jwt_payload(
             f"{base_prefix}/packing_list_entry:write",
             f"{base_prefix}/packing_list_entry:read",
             f"{base_prefix}/product:read",
+            f"{base_prefix}/product:write",
             f"{base_prefix}/organisation:read",
             f"{base_prefix}/qr:read",
             f"{base_prefix}/stock:read",

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -1,7 +1,11 @@
 import peewee
 import pytest
 from auth import mock_user_for_request
-from utils import assert_bad_user_input, assert_internal_server_error
+from utils import (
+    assert_bad_user_input,
+    assert_internal_server_error,
+    assert_successful_request,
+)
 
 
 def test_base_specific_permissions(client, mocker):
@@ -211,6 +215,32 @@ def test_update_non_existent_resource(
     mutation = f"mutation {{ {operation}({mutation_input}) {{ {field} }} }}"
     response = assert_bad_user_input(read_only_client, mutation, field=operation)
     assert "SQL" not in response.json["errors"][0]["message"]
+
+
+@pytest.mark.parametrize(
+    "operation,mutation_input,field,response",
+    [
+        # Test case X
+        [
+            "createCustomProduct",
+            "creationInput: { baseId: 0, categoryId: 12, sizeRangeId: 1, gender: none}",
+            "...on ResourceDoesNotExist { id name }",
+            {"id": "0", "name": "Base"},
+        ],
+        [
+            "createCustomProduct",
+            "creationInput: { baseId: 1, categoryId: 99, sizeRangeId: 1, gender: none}",
+            "...on ResourceDoesNotExist { id name }",
+            {"id": None, "name": "ProductCategory"},
+        ],
+    ],
+)
+def test_create_resource_does_not_exist(
+    read_only_client, operation, mutation_input, field, response
+):
+    mutation = f"mutation {{ {operation}({mutation_input}) {{ {field} }} }}"
+    actual_response = assert_successful_request(read_only_client, mutation)
+    assert actual_response == response
 
 
 def test_mutation_arbitrary_database_error(read_only_client, mocker):

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -225,8 +225,8 @@ def test_update_non_existent_resource(
             "createCustomProduct",
             """creationInput:
             { baseId: 0, name: "a", categoryId: 1, sizeRangeId: 1, gender: none}""",
-            "...on ResourceDoesNotExist { id name }",
-            {"id": "0", "name": "Base"},
+            "...on UnauthorizedForBase { id }",
+            {"id": "0"},
         ],
         # Test case 8.2.37
         [

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -220,13 +220,21 @@ def test_update_non_existent_resource(
 @pytest.mark.parametrize(
     "operation,mutation_input,field,response",
     [
-        # Test case X
+        # Test case 8.2.36
         [
             "createCustomProduct",
             "creationInput: { baseId: 0, categoryId: 12, sizeRangeId: 1, gender: none}",
             "...on ResourceDoesNotExist { id name }",
             {"id": "0", "name": "Base"},
         ],
+        # Test case 8.2.37
+        [
+            "createCustomProduct",
+            "creationInput: { baseId: 1, categoryId: 12, sizeRangeId: 0, gender: none}",
+            "...on ResourceDoesNotExist { id name }",
+            {"id": None, "name": "SizeRange"},
+        ],
+        # Test case 8.2.38
         [
             "createCustomProduct",
             "creationInput: { baseId: 1, categoryId: 99, sizeRangeId: 1, gender: none}",

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -223,21 +223,24 @@ def test_update_non_existent_resource(
         # Test case 8.2.36
         [
             "createCustomProduct",
-            "creationInput: { baseId: 0, categoryId: 12, sizeRangeId: 1, gender: none}",
+            """creationInput:
+            { baseId: 0, name: "a", categoryId: 1, sizeRangeId: 1, gender: none}""",
             "...on ResourceDoesNotExist { id name }",
             {"id": "0", "name": "Base"},
         ],
         # Test case 8.2.37
         [
             "createCustomProduct",
-            "creationInput: { baseId: 1, categoryId: 12, sizeRangeId: 0, gender: none}",
+            """creationInput:
+            { baseId: 1, name: "a", categoryId: 1, sizeRangeId: 0, gender: none}""",
             "...on ResourceDoesNotExist { id name }",
             {"id": None, "name": "SizeRange"},
         ],
         # Test case 8.2.38
         [
             "createCustomProduct",
-            "creationInput: { baseId: 1, categoryId: 99, sizeRangeId: 1, gender: none}",
+            """creationInput:
+            { baseId: 1, name: "a", categoryId: 0, sizeRangeId: 1, gender: none}""",
             "...on ResourceDoesNotExist { id name }",
             {"id": None, "name": "ProductCategory"},
         ],

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -488,3 +488,23 @@ def test_mutate_insufficient_permission(
     mutation = f"mutation {{ {operation}({mutation_input}) {{ {field} }} }}"
     actual_response = assert_successful_request(read_only_client, mutation)
     assert actual_response == response
+
+
+@pytest.mark.parametrize(
+    "operation,mutation_input,field,response",
+    [
+        # Test case X
+        [
+            "createCustomProduct",
+            "creationInput: { baseId: 2, categoryId: 12, sizeRangeId: 1, gender: none}",
+            "...on UnauthorizedForBase { id }",
+            {"id": "2"},
+        ],
+    ],
+)
+def test_mutate_unauthorized_for_base(
+    read_only_client, operation, mutation_input, field, response
+):
+    mutation = f"mutation {{ {operation}({mutation_input}) {{ {field} }} }}"
+    actual_response = assert_successful_request(read_only_client, mutation)
+    assert actual_response == response

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -473,7 +473,7 @@ def test_invalid_permission_for_user_read(
 @pytest.mark.parametrize(
     "operation,mutation_input,field,response",
     [
-        # Test case X
+        # Test case 8.2.40
         [
             "createCustomProduct",
             "creationInput: { baseId: 1, categoryId: 12, sizeRangeId: 1, gender: none}",
@@ -493,7 +493,7 @@ def test_mutate_insufficient_permission(
 @pytest.mark.parametrize(
     "operation,mutation_input,field,response",
     [
-        # Test case X
+        # Test case 8.2.39
         [
             "createCustomProduct",
             "creationInput: { baseId: 2, categoryId: 12, sizeRangeId: 1, gender: none}",

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -468,3 +468,23 @@ def test_invalid_permission_for_user_read(
         query,
         value={"createdBy": {"email": None, "name": default_user["name"]}},
     )
+
+
+@pytest.mark.parametrize(
+    "operation,mutation_input,field,response",
+    [
+        # Test case X
+        [
+            "createCustomProduct",
+            "creationInput: { baseId: 1, categoryId: 12, sizeRangeId: 1, gender: none}",
+            "...on InsufficientPermission { name }",
+            {"name": "product:write"},
+        ],
+    ],
+)
+def test_mutate_insufficient_permission(
+    unauthorized, read_only_client, operation, mutation_input, field, response
+):
+    mutation = f"mutation {{ {operation}({mutation_input}) {{ {field} }} }}"
+    actual_response = assert_successful_request(read_only_client, mutation)
+    assert actual_response == response

--- a/back/test/endpoint_tests/test_permissions.py
+++ b/back/test/endpoint_tests/test_permissions.py
@@ -476,7 +476,8 @@ def test_invalid_permission_for_user_read(
         # Test case 8.2.40
         [
             "createCustomProduct",
-            "creationInput: { baseId: 1, categoryId: 12, sizeRangeId: 1, gender: none}",
+            """creationInput:
+            { baseId: 1, name: "a", categoryId: 12, sizeRangeId: 1, gender: none}""",
             "...on InsufficientPermission { name }",
             {"name": "product:write"},
         ],
@@ -496,7 +497,8 @@ def test_mutate_insufficient_permission(
         # Test case 8.2.39
         [
             "createCustomProduct",
-            "creationInput: { baseId: 2, categoryId: 12, sizeRangeId: 1, gender: none}",
+            """creationInput:
+            { baseId: 2, name: "a", categoryId: 12, sizeRangeId: 1, gender: none}""",
             "...on UnauthorizedForBase { id }",
             {"id": "2"},
         ],

--- a/back/test/endpoint_tests/test_product.py
+++ b/back/test/endpoint_tests/test_product.py
@@ -69,6 +69,7 @@ def _create_mutation(creation_input):
                     deletedOn
                 }}
                 ...on InvalidPrice {{ value }}
+                ...on EmptyName {{ _ }}
                 }} }}"""
 
 
@@ -154,6 +155,18 @@ def test_product_mutations(
     mutation = _create_mutation(creation_input)
     response = assert_successful_request(client, mutation)
     assert response == {"value": price}
+
+    # Test case 8.2.42
+    creation_input = f"""{{
+            categoryId: {category_id}
+            sizeRangeId: {size_range_id}
+            gender: {gender}
+            baseId: {base_id}
+            name: ""
+            }}"""
+    mutation = _create_mutation(creation_input)
+    response = assert_successful_request(client, mutation)
+    assert response == {"_": None}
 
     history_entries = list(
         DbChangeHistory.select(

--- a/back/test/endpoint_tests/test_product.py
+++ b/back/test/endpoint_tests/test_product.py
@@ -79,6 +79,7 @@ def test_product_mutations(
     category_id = str(default_product_category["id"])
     size_range_id = str(default_size_range["id"])
     gender = ProductGender.UnisexAdult.name
+    name = "Sweater"
 
     # Test case 8.2.34
     creation_input = f"""{{
@@ -86,13 +87,14 @@ def test_product_mutations(
             sizeRangeId: {size_range_id}
             gender: {gender}
             baseId: {base_id}
+            name: "{name}"
             }}"""
     mutation = _create_mutation(creation_input)
     created_product = assert_successful_request(client, mutation)
     product_id = created_product.pop("id")
     assert created_product.pop("createdOn").startswith(today)
     assert created_product == {
-        "name": "",
+        "name": name,
         "category": {"id": category_id},
         "sizeRange": {"id": size_range_id},
         "gender": gender,
@@ -107,7 +109,6 @@ def test_product_mutations(
     }
 
     # Test case 8.2.35
-    name = "Sweater"
     price = 12
     comment = "new"
     in_shop = True
@@ -147,6 +148,7 @@ def test_product_mutations(
             sizeRangeId: {size_range_id}
             gender: {gender}
             baseId: {base_id}
+            name: "{name}"
             price: {price}
             }}"""
     mutation = _create_mutation(creation_input)

--- a/back/test/endpoint_tests/test_product.py
+++ b/back/test/endpoint_tests/test_product.py
@@ -66,7 +66,9 @@ def _create_mutation(creation_input):
                     lastModifiedBy {{ id }}
                     lastModifiedOn
                     deletedOn
-                }} }} }}"""
+                }}
+                ...on InvalidPrice {{ value }}
+                }} }}"""
 
 
 def test_product_mutations(
@@ -136,3 +138,16 @@ def test_product_mutations(
         "lastModifiedOn": None,
         "deletedOn": None,
     }
+
+    # Test case X
+    price = -10
+    creation_input = f"""{{
+            categoryId: {category_id}
+            sizeRangeId: {size_range_id}
+            gender: {gender}
+            baseId: {base_id}
+            price: {price}
+            }}"""
+    mutation = _create_mutation(creation_input)
+    response = assert_successful_request(client, mutation)
+    assert response == {"value": price}

--- a/back/test/endpoint_tests/test_product.py
+++ b/back/test/endpoint_tests/test_product.py
@@ -1,4 +1,9 @@
+from datetime import date
+
+from boxtribute_server.enums import ProductGender
 from utils import assert_successful_request
+
+today = date.today().isoformat()
 
 
 def test_product_query(read_only_client, default_product, default_size, another_size):
@@ -41,3 +46,93 @@ def test_products_query(read_only_client, base1_products):
     query = """query { products { elements { name } } }"""
     products = assert_successful_request(read_only_client, query)["elements"]
     assert products == [{"name": p["name"]} for p in base1_products]
+
+
+def _create_mutation(creation_input):
+    return f"""mutation {{
+                createCustomProduct(creationInput: {creation_input}) {{
+                ...on Product {{
+                    id
+                    name
+                    category {{ id }}
+                    sizeRange {{ id }}
+                    gender
+                    base {{ id }}
+                    price
+                    comment
+                    inShop
+                    createdBy {{ id }}
+                    createdOn
+                    lastModifiedBy {{ id }}
+                    lastModifiedOn
+                    deletedOn
+                }} }} }}"""
+
+
+def test_product_mutations(
+    client, default_base, default_product_category, default_size_range
+):
+    base_id = str(default_base["id"])
+    category_id = str(default_product_category["id"])
+    size_range_id = str(default_size_range["id"])
+    gender = ProductGender.UnisexAdult.name
+
+    # Test case X
+    creation_input = f"""{{
+            categoryId: {category_id}
+            sizeRangeId: {size_range_id}
+            gender: {gender}
+            baseId: {base_id}
+            }}"""
+    mutation = _create_mutation(creation_input)
+    created_product = assert_successful_request(client, mutation)
+    created_product.pop("id")
+    assert created_product.pop("createdOn").startswith(today)
+    assert created_product == {
+        "name": "",
+        "category": {"id": category_id},
+        "sizeRange": {"id": size_range_id},
+        "gender": gender,
+        "base": {"id": base_id},
+        "price": 0.0,
+        "comment": None,
+        "inShop": False,
+        "createdBy": {"id": "8"},
+        "lastModifiedBy": None,
+        "lastModifiedOn": None,
+        "deletedOn": None,
+    }
+
+    # Test case Y
+    name = "Sweater"
+    price = 12
+    comment = "new"
+    in_shop = True
+    creation_input = f"""{{
+            categoryId: {category_id}
+            sizeRangeId: {size_range_id}
+            gender: {gender}
+            baseId: {base_id}
+            name: "{name}"
+            price: {price}
+            comment: "{comment}"
+            inShop: {str(in_shop).lower()}
+            }}"""
+    mutation = _create_mutation(creation_input)
+    created_product = assert_successful_request(client, mutation)
+    created_product.pop("id")
+    assert created_product.pop("createdOn").startswith(today)
+    assert created_product == {
+        "name": name,
+        "category": {"id": category_id},
+        "sizeRange": {"id": size_range_id},
+        "gender": gender,
+        "base": {"id": base_id},
+        "price": price,
+        "comment": comment,
+        "inShop": in_shop,
+        "createdBy": {"id": "8"},
+        "lastModifiedBy": None,
+        "lastModifiedOn": None,
+        "deletedOn": None,
+    }

--- a/back/test/endpoint_tests/test_product.py
+++ b/back/test/endpoint_tests/test_product.py
@@ -80,7 +80,7 @@ def test_product_mutations(
     size_range_id = str(default_size_range["id"])
     gender = ProductGender.UnisexAdult.name
 
-    # Test case X
+    # Test case 8.2.34
     creation_input = f"""{{
             categoryId: {category_id}
             sizeRangeId: {size_range_id}
@@ -106,7 +106,7 @@ def test_product_mutations(
         "deletedOn": None,
     }
 
-    # Test case Y
+    # Test case 8.2.35
     name = "Sweater"
     price = 12
     comment = "new"
@@ -140,7 +140,7 @@ def test_product_mutations(
         "deletedOn": None,
     }
 
-    # Test case X
+    # Test case 8.2.41
     price = -10
     creation_input = f"""{{
             categoryId: {category_id}

--- a/back/test/integration_tests/test_operations.py
+++ b/back/test/integration_tests/test_operations.py
@@ -124,3 +124,60 @@ def test_mutations(auth0_client):
     mutation = f"""mutation {{ cancelShipment(id: {shipment_id}) {{ state }} }}"""
     response = assert_successful_request(auth0_client, mutation)
     assert response == {"state": "Canceled"}
+
+    mutation = """mutation { createCustomProduct(creationInput: {
+                    name: "bags"
+                    categoryId: 12
+                    sizeRangeId: 1
+                    gender: UnisexKid
+                    baseId: 1
+                }) {
+                ...on Product {
+                    id
+                    name
+                    base { id }
+                    price
+                    comment
+                    inShop
+                    createdBy { id }
+                } } }"""
+    response = assert_successful_request(auth0_client, mutation)
+    product_id = int(response.pop("id"))
+    assert response == {
+        "name": "bags",
+        "base": {"id": "1"},
+        "price": 0.0,
+        "comment": None,
+        "inShop": False,
+        "createdBy": {"id": "8"},
+    }
+
+    mutation = """mutation { createCustomProduct(creationInput: {
+                    name: "bags"
+                    categoryId: 12
+                    sizeRangeId: 1
+                    gender: UnisexKid
+                    baseId: 1
+                    price: 4
+                    comment: "good quality"
+                    inShop: true
+                }) {
+                ...on Product {
+                    id
+                    name
+                    base { id }
+                    price
+                    comment
+                    inShop
+                    createdBy { id }
+                } } }"""
+    response = assert_successful_request(auth0_client, mutation)
+    assert int(response.pop("id")) == product_id + 1
+    assert response == {
+        "name": "bags",
+        "base": {"id": "1"},
+        "price": 4.0,
+        "comment": "good quality",
+        "inShop": True,
+        "createdBy": {"id": "8"},
+    }

--- a/back/test/model_tests/test_utils.py
+++ b/back/test/model_tests/test_utils.py
@@ -1,9 +1,11 @@
+import peewee
 import pytest
 from boxtribute_server.business_logic.box_transfer.shipment.fields import (
     first_letters_of_base_name,
 )
-from boxtribute_server.db import DatabaseManager
+from boxtribute_server.db import DatabaseManager, db
 from boxtribute_server.models.definitions.base import Base
+from boxtribute_server.models.utils import handle_non_existing_resource
 
 
 @pytest.mark.parametrize("base_id,result", [[1, "TH"], [2, "AS"], [3, "WÜ"]])
@@ -16,3 +18,11 @@ def test_unitialized_database_manager():
     manager = DatabaseManager()
     with pytest.raises(RuntimeError):
         manager.get_model_class()
+
+    # Verify dev error in handle_non_existing_resource()
+    @handle_non_existing_resource
+    def func():
+        db.database.execute_sql("""UPDATE stock SET box_state_id = 0 WHERE id = 2;""")
+
+    with pytest.raises(peewee.IntegrityError, match="REFERENCES `box_state`"):
+        func()

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -321,8 +321,7 @@ export type CustomProductCreationInput = {
   comment?: InputMaybe<Scalars['String']>;
   gender: ProductGender;
   inShop?: InputMaybe<Scalars['Boolean']>;
-  /**  Name can be empty acc. to products table definition  */
-  name?: InputMaybe<Scalars['String']>;
+  name: Scalars['String'];
   price?: InputMaybe<Scalars['Int']>;
   sizeRangeId: Scalars['Int'];
 };
@@ -333,7 +332,6 @@ export type CustomProductEditInput = {
   gender?: InputMaybe<ProductGender>;
   id: Scalars['ID'];
   inShop?: InputMaybe<Scalars['Boolean']>;
-  /**  Name can be empty acc. to products table definition  */
   name?: InputMaybe<Scalars['String']>;
   price?: InputMaybe<Scalars['Int']>;
   sizeRangeId?: InputMaybe<Scalars['Int']>;

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -73,6 +73,15 @@ export type BaseDistributionEventsTrackingGroupsArgs = {
  * Representation of a base.
  * The base is managed by a specific [`Organisation`]({{Types.Organisation}}).
  */
+export type BaseProductsArgs = {
+  filterInput?: InputMaybe<FilterProductInput>;
+};
+
+
+/**
+ * Representation of a base.
+ * The base is managed by a specific [`Organisation`]({{Types.Organisation}}).
+ */
 export type BaseTagsArgs = {
   resourceType?: InputMaybe<TaggableResourceType>;
 };
@@ -280,6 +289,8 @@ export type ClassicLocationBoxesArgs = {
   paginationInput?: InputMaybe<PaginationInput>;
 };
 
+export type CreateCustomProductResult = InsufficientPermission | InvalidPrice | Product | ResourceDoesNotExist | UnauthorizedForBase;
+
 export type CreatedBoxDataDimensions = {
   __typename?: 'CreatedBoxDataDimensions';
   category?: Maybe<Array<Maybe<DimensionInfo>>>;
@@ -304,10 +315,36 @@ export type CreatedBoxesResult = {
   tagIds?: Maybe<Array<Scalars['Int']>>;
 };
 
+export type CustomProductCreationInput = {
+  baseId: Scalars['Int'];
+  categoryId: Scalars['Int'];
+  comment?: InputMaybe<Scalars['String']>;
+  gender: ProductGender;
+  inShop?: InputMaybe<Scalars['Boolean']>;
+  /**  Name can be empty acc. to products table definition  */
+  name?: InputMaybe<Scalars['String']>;
+  price?: InputMaybe<Scalars['Int']>;
+  sizeRangeId: Scalars['Int'];
+};
+
+export type CustomProductEditInput = {
+  categoryId?: InputMaybe<Scalars['Int']>;
+  comment?: InputMaybe<Scalars['String']>;
+  gender?: InputMaybe<ProductGender>;
+  id: Scalars['ID'];
+  inShop?: InputMaybe<Scalars['Boolean']>;
+  /**  Name can be empty acc. to products table definition  */
+  name?: InputMaybe<Scalars['String']>;
+  price?: InputMaybe<Scalars['Int']>;
+  sizeRangeId?: InputMaybe<Scalars['Int']>;
+};
+
 export type DataCube = {
   dimensions?: Maybe<Dimensions>;
   facts?: Maybe<Array<Maybe<Result>>>;
 };
+
+export type DeleteProductResult = InsufficientPermission | Product | ResourceDoesNotExist | UnauthorizedForBase;
 
 export type DimensionInfo = BasicDimensionInfo & {
   __typename?: 'DimensionInfo';
@@ -427,6 +464,8 @@ export type DistributionSpotCreationInput = {
   name?: InputMaybe<Scalars['String']>;
 };
 
+export type EditCustomProductResult = InsufficientPermission | InvalidPrice | Product | ResourceDoesNotExist | UnauthorizedForBase;
+
 /**
  * Optional filter values when retrieving [`Beneficiaries`]({{Types.Beneficiary}}).
  * If several fields are defined (not null), they are combined into a filter expression using logical AND (i.e. the filter returns only elements for which *all* fields are true).
@@ -462,6 +501,11 @@ export type FilterBoxInput = {
   tagIds?: InputMaybe<Array<Scalars['Int']>>;
 };
 
+export type FilterProductInput = {
+  includeDeleted?: InputMaybe<Scalars['Boolean']>;
+  type?: InputMaybe<ProductTypeFilter>;
+};
+
 export type HistoryEntry = {
   __typename?: 'HistoryEntry';
   changeDate?: Maybe<Scalars['Datetime']>;
@@ -475,6 +519,17 @@ export enum HumanGender {
   Female = 'Female',
   Male = 'Male'
 }
+
+export type InsufficientPermission = {
+  __typename?: 'InsufficientPermission';
+  /**  e.g. 'product:write' missing  */
+  name: Scalars['String'];
+};
+
+export type InvalidPrice = {
+  __typename?: 'InvalidPrice';
+  value: Scalars['Int'];
+};
 
 export type ItemsCollection = {
   distributionEvent?: Maybe<DistributionEvent>;
@@ -600,13 +655,16 @@ export type Mutation = {
   completeDistributionEventsTrackingGroup?: Maybe<DistributionEventsTrackingGroup>;
   createBeneficiary?: Maybe<Beneficiary>;
   createBox?: Maybe<Box>;
+  createCustomProduct?: Maybe<CreateCustomProductResult>;
   createDistributionEvent?: Maybe<DistributionEvent>;
   createDistributionSpot?: Maybe<DistributionSpot>;
   createQrCode?: Maybe<QrCode>;
   createShipment?: Maybe<Shipment>;
   createTag?: Maybe<Tag>;
   createTransferAgreement?: Maybe<TransferAgreement>;
+  deleteProduct?: Maybe<DeleteProductResult>;
   deleteTag?: Maybe<Tag>;
+  editCustomProduct?: Maybe<EditCustomProductResult>;
   markShipmentAsLost?: Maybe<Shipment>;
   moveItemsFromBoxToDistributionEvent?: Maybe<UnboxedItemsCollection>;
   moveItemsFromReturnTrackingGroupToBox?: Maybe<DistributionEventsTrackingEntry>;
@@ -738,6 +796,16 @@ export type MutationCreateBoxArgs = {
  * - input argument: creationInput/updateInput
  * - input type: <Resource>CreationInput/UpdateInput
  */
+export type MutationCreateCustomProductArgs = {
+  creationInput?: InputMaybe<CustomProductCreationInput>;
+};
+
+
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationCreateDistributionEventArgs = {
   creationInput?: InputMaybe<DistributionEventCreationInput>;
 };
@@ -798,8 +866,28 @@ export type MutationCreateTransferAgreementArgs = {
  * - input argument: creationInput/updateInput
  * - input type: <Resource>CreationInput/UpdateInput
  */
+export type MutationDeleteProductArgs = {
+  id: Scalars['ID'];
+};
+
+
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
 export type MutationDeleteTagArgs = {
   id: Scalars['ID'];
+};
+
+
+/**
+ * Naming convention:
+ * - input argument: creationInput/updateInput
+ * - input type: <Resource>CreationInput/UpdateInput
+ */
+export type MutationEditCustomProductArgs = {
+  editInput?: InputMaybe<CustomProductEditInput>;
 };
 
 
@@ -1106,6 +1194,7 @@ export type Product = {
   deletedOn?: Maybe<Scalars['Datetime']>;
   gender?: Maybe<ProductGender>;
   id: Scalars['ID'];
+  inShop: Scalars['Boolean'];
   lastModifiedBy?: Maybe<User>;
   lastModifiedOn?: Maybe<Scalars['Datetime']>;
   name: Scalars['String'];
@@ -1159,6 +1248,12 @@ export type ProductPage = {
   pageInfo: PageInfo;
   totalCount: Scalars['Int'];
 };
+
+export enum ProductTypeFilter {
+  All = 'All',
+  Custom = 'Custom',
+  StandardInstantiation = 'StandardInstantiation'
+}
 
 /** Representation of a QR code, possibly associated with a [`Box`]({{Types.Box}}). */
 export type QrCode = {
@@ -1372,6 +1467,12 @@ export type QueryTransferAgreementsArgs = {
 
 export type QueryUserArgs = {
   id?: InputMaybe<Scalars['ID']>;
+};
+
+export type ResourceDoesNotExist = {
+  __typename?: 'ResourceDoesNotExist';
+  id?: Maybe<Scalars['ID']>;
+  name: Scalars['String'];
 };
 
 export type Result = BeneficiaryDemographicsResult | CreatedBoxesResult | MovedBoxesResult | StockOverviewResult | TopProductsCheckedOutResult | TopProductsDonatedResult;
@@ -1679,6 +1780,13 @@ export enum TransferAgreementType {
   ReceivingFrom = 'ReceivingFrom',
   SendingTo = 'SendingTo'
 }
+
+export type UnauthorizedForBase = {
+  __typename?: 'UnauthorizedForBase';
+  /**  e.g. 'product:write' present but not for requested base  */
+  id: Scalars['ID'];
+  name: Scalars['String'];
+};
 
 export type UnboxedItemsCollection = ItemsCollection & {
   __typename?: 'UnboxedItemsCollection';

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -289,7 +289,7 @@ export type ClassicLocationBoxesArgs = {
   paginationInput?: InputMaybe<PaginationInput>;
 };
 
-export type CreateCustomProductResult = InsufficientPermission | InvalidPrice | Product | ResourceDoesNotExist | UnauthorizedForBase;
+export type CreateCustomProductResult = EmptyName | InsufficientPermission | InvalidPrice | Product | ResourceDoesNotExist | UnauthorizedForBase;
 
 export type CreatedBoxDataDimensions = {
   __typename?: 'CreatedBoxDataDimensions';
@@ -462,7 +462,13 @@ export type DistributionSpotCreationInput = {
   name?: InputMaybe<Scalars['String']>;
 };
 
-export type EditCustomProductResult = InsufficientPermission | InvalidPrice | Product | ResourceDoesNotExist | UnauthorizedForBase;
+export type EditCustomProductResult = EmptyName | InsufficientPermission | InvalidPrice | Product | ResourceDoesNotExist | UnauthorizedForBase;
+
+export type EmptyName = {
+  __typename?: 'EmptyName';
+  /**  Dummy field since type definitions without fields are not possible  */
+  _?: Maybe<Scalars['Boolean']>;
+};
 
 /**
  * Optional filter values when retrieving [`Beneficiaries`]({{Types.Beneficiary}}).


### PR DESCRIPTION
new:
- GraphQL interface for products (mutations, input types, etc.): [files in `graphql/definitions/`](https://github.com/boxwise/boxtribute/pull/1266/files#diff-78d6e340f0803294242d845e5d92985a7bbd1b5d95d4dc6af0818053594750549)
- implementation of `createCustomProduct` mutation incl. error handling (using error result defined via GraphQL schema)

[Test plan](https://docs.google.com/spreadsheets/d/1sDhSsaVwNxAhGn1VYACDPVepZpvlwTkgy9nmeTaRy2Q/edit?pli=1#gid=1709672082) has been updated.


### Guideline for review
- start with `mutations.graphql` and check `inputs.graphql` and `types.graphql` as references
- the mutation resolver is implemented in `.../product/mutations.py`, check authorization there
- the resolver calls into a function in `.../product/crud.py`, check validation and creation of database entries (products and history table)
- error results that might occur according to the schema are defined in `errors.py` and tight to the schema in `bindables.py`