### PR TITLE
Tighten back-end security

### DIFF
--- a/back/app-api.yaml
+++ b/back/app-api.yaml
@@ -5,9 +5,6 @@ handlers:
 - url: /
   script: auto
   secure: always
-- url: /public
-  script: auto
-  secure: always
 - url: /docs
   secure: always
   static_files: graphql-docs/index.html

--- a/back/boxtribute_server/app.py
+++ b/back/boxtribute_server/app.py
@@ -25,7 +25,6 @@ def configure_app(
         app.register_blueprint(blueprint)
 
     app.config["DATABASE"] = database_interface or create_db_interface(**mysql_kwargs)
-    app.config["FLASKDB_EXCLUDED_ROUTES"] = ["api_bp.api_token"]
 
     if replica_socket or mysql_kwargs:
         # In deployed environment: replica_socket is set

--- a/back/boxtribute_server/app.py
+++ b/back/boxtribute_server/app.py
@@ -12,7 +12,7 @@ from .db import create_db_interface, db
 
 
 def create_app():
-    return Flask(__name__)
+    return Flask(__name__, static_folder=None)
 
 
 def configure_app(

--- a/back/boxtribute_server/blueprints.py
+++ b/back/boxtribute_server/blueprints.py
@@ -1,0 +1,10 @@
+from flask import Blueprint
+
+# Blueprint for query-only API. Deployed on the 'api*' subdomains
+api_bp = Blueprint("api_bp", __name__)
+
+# Blueprint for app GraphQL server. Deployed on v2-* subdomains
+app_bp = Blueprint("app_bp", __name__)
+
+API_GRAPHQL_PATH = "/"
+APP_GRAPHQL_PATH = "/graphql"

--- a/back/boxtribute_server/db.py
+++ b/back/boxtribute_server/db.py
@@ -2,6 +2,7 @@ from flask import request
 from peewee import MySQLDatabase
 from playhouse.flask_utils import FlaskDB  # type: ignore
 
+from .blueprints import API_GRAPHQL_PATH, APP_GRAPHQL_PATH, api_bp, app_bp
 from .business_logic.statistics import statistics_queries
 from .utils import in_development_environment
 
@@ -30,10 +31,10 @@ class DatabaseManager(FlaskDB):
         # Don't open database connection for URLs other than the GraphQL endpoints
         # defined in routes.py
         if not (
-            (request.blueprint == "api_bp" and request.path == "/")
-            or (request.blueprint == "app_bp" and request.path == "/graphql")
+            (request.blueprint == api_bp.name and request.path == API_GRAPHQL_PATH)
+            or (request.blueprint == app_bp.name and request.path == APP_GRAPHQL_PATH)
             or (
-                request.blueprint == "api_bp"
+                request.blueprint == api_bp.name
                 and request.path == "/public"
                 and in_development_environment()
             )

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -12,7 +12,7 @@ from .exceptions import AuthenticationFailed
 from .graph_ql.execution import execute_async
 from .graph_ql.schema import full_api_schema, public_api_schema, query_api_schema
 from .logging import API_CONTEXT, WEBAPP_CONTEXT, log_request_to_gcloud
-from .utils import in_ci_environment, in_development_environment
+from .utils import in_development_environment
 
 # Blueprint for query-only API. Deployed on the 'api*' subdomains
 api_bp = Blueprint("api_bp", __name__)
@@ -49,22 +49,18 @@ def query_api_server():
 
 @api_bp.route("/public", methods=["POST"])
 @cross_origin(
-    # Allow dev localhost ports, and in staging
+    # Allow dev localhost ports
     origins=[
         "http://localhost:5005",
         "http://localhost:3000",
         "http://localhost:5173",
-        "https://v2-staging.boxtribute.org",
-        "https://v2-staging-dot-dropapp-242214.ew.r.appspot.com",
     ],
     methods=["POST"],
     allow_headers="*" if in_development_environment() else CORS_HEADERS,
 )
 def public_api_server():
-    # Block access unless in CI, or in staging/development
-    if (
-        os.getenv("ENVIRONMENT") not in ["staging", "development"]
-    ) and not in_ci_environment():
+    # Block access unless in development
+    if not in_development_environment():
         return {"error": "No permission to access public API"}, 401
 
     log_request_to_gcloud(context=API_CONTEXT)

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -106,7 +106,7 @@ def graphql_server():
 
 
 @app_bp.get(APP_GRAPHQL_PATH)
-def graphql_playgroud():
+def graphql_explorer():
     return EXPLORER_HTML, 200
 
 

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -30,19 +30,19 @@ def handle_auth_error(ex):
     return response
 
 
-@api_bp.route(API_GRAPHQL_PATH, methods=["GET"])
+@api_bp.get(API_GRAPHQL_PATH)
 def query_api_explorer():
     return EXPLORER_HTML, 200
 
 
-@api_bp.route(API_GRAPHQL_PATH, methods=["POST"])
+@api_bp.post(API_GRAPHQL_PATH)
 @requires_auth
 def query_api_server():
     log_request_to_gcloud(context=API_CONTEXT)
     return execute_async(schema=query_api_schema, introspection=True)
 
 
-@api_bp.route("/public", methods=["POST"])
+@api_bp.post("/public")
 @cross_origin(
     # Allow dev localhost ports
     origins=[
@@ -62,7 +62,7 @@ def public_api_server():
     return execute_async(schema=public_api_schema, introspection=True)
 
 
-@api_bp.route("/token", methods=["POST"])
+@api_bp.post("/token")
 def api_token():
     success, result = request_jwt(
         **request.get_json(),  # must contain username and password
@@ -78,7 +78,7 @@ def api_token():
 # Due to a bug in the flask-cors package, the function decorated with cross_origin must
 # be listed before any other function that has the same route
 # see https://github.com/corydolphin/flask-cors/issues/280
-@app_bp.route("/graphql", methods=["POST"])
+@app_bp.post("/graphql")
 @cross_origin(
     # Allow dev localhost ports, and boxtribute subdomains as origins
     origins=[
@@ -105,11 +105,11 @@ def graphql_server():
     return execute_async(schema=full_api_schema)
 
 
-@app_bp.route(APP_GRAPHQL_PATH, methods=["GET"])
+@app_bp.get(APP_GRAPHQL_PATH)
 def graphql_playgroud():
     return EXPLORER_HTML, 200
 
 
-@api_bp.route("/public", methods=["GET"])
+@api_bp.get("/public")
 def public():
     return EXPLORER_HTML, 200

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -3,22 +3,17 @@
 import os
 
 from ariadne.explorer import ExplorerGraphiQL
-from flask import Blueprint, jsonify, request
+from flask import jsonify, request
 from flask_cors import cross_origin
 
 from .auth import request_jwt, requires_auth
 from .authz import check_beta_feature_access
+from .blueprints import API_GRAPHQL_PATH, APP_GRAPHQL_PATH, api_bp, app_bp
 from .exceptions import AuthenticationFailed
 from .graph_ql.execution import execute_async
 from .graph_ql.schema import full_api_schema, public_api_schema, query_api_schema
 from .logging import API_CONTEXT, WEBAPP_CONTEXT, log_request_to_gcloud
 from .utils import in_development_environment
-
-# Blueprint for query-only API. Deployed on the 'api*' subdomains
-api_bp = Blueprint("api_bp", __name__)
-
-# Blueprint for app GraphQL server. Deployed on v2-* subdomains
-app_bp = Blueprint("app_bp", __name__)
 
 # Allowed headers for CORS
 CORS_HEADERS = ["Content-Type", "Authorization", "x-clacks-overhead"]
@@ -35,12 +30,12 @@ def handle_auth_error(ex):
     return response
 
 
-@api_bp.route("/", methods=["GET"])
+@api_bp.route(API_GRAPHQL_PATH, methods=["GET"])
 def query_api_explorer():
     return EXPLORER_HTML, 200
 
 
-@api_bp.route("/", methods=["POST"])
+@api_bp.route(API_GRAPHQL_PATH, methods=["POST"])
 @requires_auth
 def query_api_server():
     log_request_to_gcloud(context=API_CONTEXT)
@@ -110,7 +105,7 @@ def graphql_server():
     return execute_async(schema=full_api_schema)
 
 
-@app_bp.route("/graphql", methods=["GET"])
+@app_bp.route(APP_GRAPHQL_PATH, methods=["GET"])
 def graphql_playgroud():
     return EXPLORER_HTML, 200
 

--- a/back/test/conftest.py
+++ b/back/test/conftest.py
@@ -42,7 +42,11 @@ def _create_database(database_name):
     with pymysql.connect(**MYSQL_CONNECTION_PARAMETERS) as connection:
         with connection.cursor() as cursor:
             cursor.execute(f"CREATE DATABASE IF NOT EXISTS {database_name}")
-    yield create_db_interface(**MYSQL_CONNECTION_PARAMETERS, database=database_name)
+    database = create_db_interface(
+        **MYSQL_CONNECTION_PARAMETERS, database=database_name
+    )
+    yield database
+    database.execute_sql(f"DROP DATABASE IF EXISTS {database_name}")
 
 
 @pytest.fixture(scope="session")

--- a/back/test/conftest.py
+++ b/back/test/conftest.py
@@ -16,6 +16,13 @@ import pymysql
 import pytest
 from boxtribute_server.app import configure_app, create_app, main
 from boxtribute_server.db import create_db_interface, db
+
+# It's crucial to import the blueprints from the routes module (NOT the blueprints
+# module) because only then
+# a) they actually have routes registered
+# b) all data models are registered as db.Model subclasses (because the GraphQL schema
+#    is imported into the routes module which in turn imports all data models down the
+#    line); this is relevant for setup_models() to work
 from boxtribute_server.routes import api_bp, app_bp
 
 # Imports fixtures into tests


### PR DESCRIPTION
- Remove `/public` route from staging (not helpful since staging DB does not contain history data)
- Whitelist URL paths that need database connection (otherwise DB connection is opened for any route requested, causing errors like [here](https://boxwise.sentry.io/issues/5067454591/?environment=production&project=6584296&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0))
- Drop test databases at end of test session (improved clean-up)
- Define blueprints in separate module (more consistent)
- Remove Flask default route `/static/<filename>` (although not reachable due to our GAE configuration, it's not needed)
