### PR TITLE
Enable cron-job to reseed staging DB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,7 @@ jobs:
           name: Deploy to GAE
           command: |
             gcloud app deploy app-<< parameters.serviceName >>.yaml
+            gcloud app deploy cron.yaml
       - slack/notify-on-failure:
           only_for_branches: master,production
 

--- a/back/.gcloudignore
+++ b/back/.gcloudignore
@@ -23,7 +23,6 @@ __pycache__/
 .circleci
 Dockerfile
 docker-compose.yml
-init.sql
 .venv
 *.pyc
 .vscode

--- a/back/app.yaml
+++ b/back/app.yaml
@@ -5,6 +5,9 @@ handlers:
   - url: /graphql
     script: auto
     secure: always
+  - url: /cron/(.*)
+    script: auto
+    secure: always
   - url: /
     secure: always
     static_files: front-build/index.html

--- a/back/boxtribute_server/blueprints.py
+++ b/back/boxtribute_server/blueprints.py
@@ -8,3 +8,4 @@ app_bp = Blueprint("app_bp", __name__)
 
 API_GRAPHQL_PATH = "/"
 APP_GRAPHQL_PATH = "/graphql"
+CRON_PATH = "/cron"

--- a/back/boxtribute_server/cron/reseed_db.py
+++ b/back/boxtribute_server/cron/reseed_db.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+from pathlib import Path
+
+from flask import current_app
+
+DATABASE_DUMP_FILEPATH = Path(__file__).parent.resolve().parent.parent / "init.sql"
+
+
+def reseed_db():
+    command = [
+        "mysql",
+        "-u",
+        os.environ["MYSQL_USER"],
+        f"-p{os.environ['MYSQL_PASSWORD']}",
+        "-D",
+        os.environ["MYSQL_DB"],
+        "-S",
+        os.environ["MYSQL_SOCKET"],
+        # For testing locally on dev's machine with active docker-compose db service and
+        #    dotenv run flask --debug --app boxtribute_server.dev_main:app run -p 5005
+        # "-h", "127.0.0.1", "-P", "32000",
+        "-e",
+        f"source {DATABASE_DUMP_FILEPATH}",
+    ]
+    current_app.logger.info("Starting import")
+    p = subprocess.run(command, capture_output=True)
+    if p.returncode == 0:
+        current_app.logger.info("Import completed")
+    else:
+        error_message = p.stderr.decode()
+        current_app.logger.error(p.returncode)
+        current_app.logger.error(error_message)
+        return error_message

--- a/back/boxtribute_server/db.py
+++ b/back/boxtribute_server/db.py
@@ -2,7 +2,7 @@ from flask import request
 from peewee import MySQLDatabase
 from playhouse.flask_utils import FlaskDB  # type: ignore
 
-from .blueprints import API_GRAPHQL_PATH, APP_GRAPHQL_PATH, api_bp, app_bp
+from .blueprints import API_GRAPHQL_PATH, APP_GRAPHQL_PATH, CRON_PATH, api_bp, app_bp
 from .business_logic.statistics import statistics_queries
 from .utils import in_development_environment
 
@@ -33,6 +33,7 @@ class DatabaseManager(FlaskDB):
         if not (
             (request.blueprint == api_bp.name and request.path == API_GRAPHQL_PATH)
             or (request.blueprint == app_bp.name and request.path == APP_GRAPHQL_PATH)
+            or (request.blueprint == app_bp.name and request.path.startswith(CRON_PATH))
             or (
                 request.blueprint == api_bp.name
                 and request.path == "/public"

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -8,7 +8,7 @@ from flask_cors import cross_origin
 
 from .auth import request_jwt, requires_auth
 from .authz import check_beta_feature_access
-from .blueprints import API_GRAPHQL_PATH, APP_GRAPHQL_PATH, api_bp, app_bp
+from .blueprints import API_GRAPHQL_PATH, APP_GRAPHQL_PATH, CRON_PATH, api_bp, app_bp
 from .exceptions import AuthenticationFailed
 from .graph_ql.execution import execute_async
 from .graph_ql.schema import full_api_schema, public_api_schema, query_api_schema
@@ -113,3 +113,34 @@ def graphql_explorer():
 @api_bp.get("/public")
 def public():
     return EXPLORER_HTML, 200
+
+
+@app_bp.get(f"{CRON_PATH}/<job_name>")
+def cron(job_name):
+    authorized = False
+    try:
+        # https://cloud.google.com/appengine/docs/flexible/scheduling-jobs-with-cron-yaml#securing_urls_for_cron
+        authorized = request.headers["X-Appengine-Cron"] == "true"
+    except KeyError:
+        pass
+    if not authorized:
+        from sentry_sdk import capture_message as emit_sentry_message
+
+        emit_sentry_message(
+            "Unauthorized user accessed /cron endpoint", level="warning"
+        )
+        return jsonify({"message": "unauthorized"}), 401
+
+    permitted_databases = ["dropapp_dev", "dropapp_staging"]
+    if (db_name := os.environ["MYSQL_DB"]) not in permitted_databases:
+        return jsonify({"message": f"Reset of '{db_name}' not permitted"}), 400
+
+    if job_name == "reseed-db":
+        from .cron.reseed_db import reseed_db
+
+        response = reseed_db()
+        if response is None:
+            return jsonify({"message": "reseed-db job executed"}), 200
+        return jsonify({"message": response}), 500
+
+    return jsonify({"message": f"unknown job '{job_name}'"}), 400

--- a/back/cron.yaml
+++ b/back/cron.yaml
@@ -1,0 +1,6 @@
+cron:
+# staging
+- description: "db reseed staging"
+  url: /cron/reseed-db
+  target: v2-staging
+  schedule: every day 00:18

--- a/back/test/endpoint_tests/test_cron.py
+++ b/back/test/endpoint_tests/test_cron.py
@@ -1,0 +1,51 @@
+import subprocess
+
+from boxtribute_server.blueprints import CRON_PATH
+
+
+def test_cron_job_endpoint(read_only_client, mocker, monkeypatch):
+    monkeypatch.setenv("MYSQL_USER", "root")
+    monkeypatch.setenv("MYSQL_PASSWORD", "pass")
+    monkeypatch.setenv("MYSQL_DB", "dropapp_dev")
+    monkeypatch.setenv("MYSQL_SOCKET", "/some/socket")
+    reseed_db_path = f"{CRON_PATH}/reseed-db"
+
+    # Permission denied due to missing header
+    response = read_only_client.get(reseed_db_path)
+    assert response.status_code == 401
+    assert response.json == {"message": "unauthorized"}
+
+    # Permission denied due to wrong value in header
+    response = read_only_client.get(
+        reseed_db_path, headers=[("X-AppEngine-Cron", "false")]
+    )
+    assert response.status_code == 401
+    assert response.json == {"message": "unauthorized"}
+
+    headers = [("X-AppEngine-Cron", "true")]
+    # Bad request due to unknown subpath
+    response = read_only_client.get(f"{CRON_PATH}/unknown-job", headers=headers)
+    assert response.status_code == 400
+    assert response.json == {"message": "unknown job 'unknown-job'"}
+
+    # Success because patched command exits with 0
+    mocker.patch("subprocess.run").return_value = subprocess.CompletedProcess(
+        returncode=0, args=[]
+    )
+    response = read_only_client.get(reseed_db_path, headers=headers)
+    assert response.status_code == 200
+    assert response.json == {"message": "reseed-db job executed"}
+
+    # Server error because patched command exits with 1
+    process = subprocess.CompletedProcess(returncode=1, args=[])
+    process.stderr = b"Error"
+    mocker.patch("subprocess.run").return_value = process
+    response = read_only_client.get(reseed_db_path, headers=headers)
+    assert response.status_code == 500
+    assert response.json == {"message": "Error"}
+
+    # Bad request due to wrong environment
+    monkeypatch.setenv("MYSQL_DB", "dropapp_production")
+    response = read_only_client.get(reseed_db_path, headers=headers)
+    assert response.status_code == 400
+    assert response.json == {"message": "Reset of 'dropapp_production' not permitted"}


### PR DESCRIPTION
Some logic taken from
https://github.com/boxwise/dropapp/blob/dc7fa2c608460115519dacd25d41dc051b559525/cron/reseed-db.php

Updated .gcloudignore to insure init.sql is present in the deployed GAE environment.

Also it seems the `reseed-db` PHP cron job does run after all: [cron logs](https://console.cloud.google.com/cloudscheduler?project=dropapp-242214) with [details](https://console.cloud.google.com/logs/query;query=protoPayload.taskName%3D%226729109412488123316%22%20protoPayload.taskQueueName%3D%22__cron%22;cursorTimestamp=2024-04-17T00:18:00.864919Z;aroundTime=2024-04-17T00:36:17.182Z;duration=PT1H?project=dropapp-242214)

### Functional testing

Extend `.env` with

```bash
MYSQL_USER=root
MYSQL_HOST=127.0.0.1
MYSQL_PORT=32000
MYSQL_DB=dropapp_dev
MYSQL_PASSWORD=dropapp_root
```

and apply the following patch

```diff
diff --git a/back/boxtribute_server/cron/reseed_db.py b/back/boxtribute_server/cron/reseed_db.py
index 6fd73591..73ba55bf 100644
--- a/back/boxtribute_server/cron/reseed_db.py
+++ b/back/boxtribute_server/cron/reseed_db.py
@@ -15,11 +15,11 @@ def execute():
         f"-p{os.environ['MYSQL_PASSWORD']}",
         "-D",
         os.environ["MYSQL_DB"],
-        "-S",
-        os.environ["MYSQL_SOCKET"],
+        # "-S", os.environ["MYSQL_SOCKET"],
         # For testing locally on dev's machine with active docker-compose db service and
         #    dotenv run flask --debug --app boxtribute_server.dev_main:app run -p 5005
-        # "-h", "127.0.0.1", "-P", "32000",
+        "-h", "127.0.0.1", "-P", "32000",
         "-e",
         f"source {DATABASE_DUMP_FILEPATH}",
     ]
```

Then run
```bash
docker-compose up -d db
dotenv run flask --debug --app boxtribute_server.dev_main:app run -p 5005

# missing header
curl 'http://localhost:5005/cron/reseed-db'

# unknown url-path
curl 'http://localhost:5005/cron/foo'
```

Now to verify it actually works:
1. go to `http://localhost:5005/graphql` 
2. get the token `./fetch_token -u some.admin@boxtribute.org` for the authorization header
3. create a box and remember the label identifier
```graphql
mutation { createBox(creationInput: {
  productId:1
  sizeId: 1
  locationId: 1
  numberOfItems: 400
}) {
  id
  labelIdentifier
  numberOfItems
}}
```

4. run the cron job `curl 'http://localhost:5005/cron/reseed-db' -H 'x-appengine-cron: true'`
5. verify the box does not exist any more `query { box(labelIdentifier: "XYZ") { id }}`
