### PR TITLE
Remove cron.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,6 @@ jobs:
           name: Deploy to GAE
           command: |
             gcloud app deploy app-<< parameters.serviceName >>.yaml
-            gcloud app deploy cron.yaml
       - slack/notify-on-failure:
           only_for_branches: master,production
 

--- a/back/cron.yaml
+++ b/back/cron.yaml
@@ -1,6 +1,0 @@
-cron:
-# staging
-- description: "db reseed staging"
-  url: /cron/reseed-db
-  target: v2-staging
-  schedule: every day 00:18


### PR DESCRIPTION
Moved to system-management repo to deploy single file for dropapp and v2
cron jobs (otherwise deploying in either app overrides settings deployed
by other app)

Cf. boxwise/dropapp#588
