### PR TITLE
Fix Statviz Filter zIndex

### DIFF
--- a/shared-components/statviz/dashboard/Dashboard.tsx
+++ b/shared-components/statviz/dashboard/Dashboard.tsx
@@ -23,7 +23,7 @@ export default function Dashboard() {
         pos="sticky"
         top="0"
         background="white"
-        zIndex={5}
+        zIndex={2}
       >
         <WrapItem w="350">
           <Center>


### PR DESCRIPTION
This PR implements a minor fix to resolve the issue with the Statviz filter overlay appearing on the menu.