### PR TITLE
Enable filter for deleted bases

### DIFF
--- a/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
@@ -21,16 +21,19 @@ from ....models.utils import convert_ids, utcnow
 
 
 def _base_ids_of_organisation(organisation_id):
-    """Return IDs of that bases that belong to the organisation with given ID."""
+    """Return IDs of non-deleted bases that belong to the organisation with given ID."""
     return [
         b.id
-        for b in Base.select(Base.id).where(Base.organisation_id == organisation_id)
+        for b in Base.select(Base.id).where(
+            Base.organisation_id == organisation_id,
+            Base.deleted_on.is_null(),
+        )
     ]
 
 
 def _validate_bases_as_part_of_organisation(*, base_ids, organisation_id):
     """Raise InvalidTransferAgreementBase exception if any of the given bases is not run
-    by the given organisation.
+    by the given organisation, or deleted.
     """
     organisation_base_ids = _base_ids_of_organisation(organisation_id)
     invalid_base_ids = [i for i in base_ids if i not in organisation_base_ids]

--- a/back/boxtribute_server/business_logic/core/base/queries.py
+++ b/back/boxtribute_server/business_logic/core/base/queries.py
@@ -1,14 +1,16 @@
 from ariadne import QueryType
 
 from ....authz import authorize, authorized_bases_filter
+from ....graph_ql.filtering import derive_base_filter
 from ....models.definitions.base import Base
 
 query = QueryType()
 
 
 @query.field("bases")
-def resolve_bases(*_):
-    return Base.select().where(authorized_bases_filter())
+def resolve_bases(*_, filter_input=None):
+    conditions = derive_base_filter(filter_input)
+    return Base.select().where(authorized_bases_filter(), *conditions)
 
 
 @query.field("base")

--- a/back/boxtribute_server/business_logic/core/organisation/fields.py
+++ b/back/boxtribute_server/business_logic/core/organisation/fields.py
@@ -1,12 +1,14 @@
 from ariadne import ObjectType
 
 from ....authz import authorize_for_organisation_bases
+from ....graph_ql.filtering import derive_base_filter
 from ....models.definitions.base import Base
 
 organisation = ObjectType("Organisation")
 
 
 @organisation.field("bases")
-def resolve_organisation_bases(organisation_obj, _):
+def resolve_organisation_bases(organisation_obj, _, filter_input=None):
     authorize_for_organisation_bases()
-    return Base.select().where(Base.organisation_id == organisation_obj.id)
+    conditions = derive_base_filter(filter_input)
+    return Base.select().where(Base.organisation_id == organisation_obj.id, *conditions)

--- a/back/boxtribute_server/graph_ql/definitions/protected/queries.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/queries.graphql
@@ -1,6 +1,6 @@
 type Query {
   " Return all [`Bases`]({{Types.Base}}) that the client is authorized to view. "
-  bases: [Base!]!
+  bases(filterInput: FilterBaseInput): [Base!]!
   base(id: ID!): Base
   " Return all [`DistributionSpots`]({{Types.DistributionSpot}}) that the client is authorized to view. "
   distributionSpots: [DistributionSpot!]!

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -489,7 +489,7 @@ input FilterProductInput {
 }
 
 input FilterBaseInput {
-  includeDeleted: Boolean = true
+  includeDeleted: Boolean = false
 }
 
 """

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -274,7 +274,7 @@ type Organisation {
   id: ID!
   name: String!
   " List of all [`Bases`]({{Types.Base}}) managed by this organisation "
-  bases: [Base!]
+  bases(filterInput: FilterBaseInput): [Base!]
 }
 
 """
@@ -485,6 +485,10 @@ input FilterBoxInput {
 input FilterProductInput {
   includeDeleted: Boolean = false
   type: ProductTypeFilter = Custom
+}
+
+input FilterBaseInput {
+  includeDeleted: Boolean = true
 }
 
 """

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -227,6 +227,7 @@ type Base {
   id: ID!
   name: String!
   organisation: Organisation!
+  deletedOn: Datetime
   " List of all [`Beneficiaries`]({{Types.Beneficiary}}) registered in this base "
   beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage
   currencyName: String

--- a/back/boxtribute_server/graph_ql/filtering.py
+++ b/back/boxtribute_server/graph_ql/filtering.py
@@ -1,4 +1,5 @@
 from ..enums import ProductTypeFilter, TaggableObjectType
+from ..models.definitions.base import Base
 from ..models.definitions.beneficiary import Beneficiary
 from ..models.definitions.box import Box
 from ..models.definitions.product import Product
@@ -115,7 +116,7 @@ def derive_box_filter(filter_input, selection=None):
 
 def derive_product_filter(filter_input):
     """Derive filter condition for select-query from given filter parameters. If no
-    parameters given, return True (i.e. no filtering applied).
+    parameters given, return empty conditions (i.e. no filtering applied).
     """
     include_deleted = False
     type_filter = ProductTypeFilter.Custom
@@ -135,5 +136,24 @@ def derive_product_filter(filter_input):
         conditions.append(Product.standard_product.is_null())
     elif type_filter == ProductTypeFilter.StandardInstantiation:
         conditions.append(Product.standard_product.is_null(False))
+
+    return conditions
+
+
+def derive_base_filter(filter_input):
+    """Derive filter condition for select-query from given filter parameters. If no
+    parameters given, return empty conditions (i.e. no filtering applied).
+    """
+    include_deleted = True
+    if filter_input:
+        include_deleted = filter_input.get("include_deleted")
+
+    conditions = []
+
+    if include_deleted is not True:
+        conditions.append(
+            # work-around for 0000-00-00 00:00:00 datetime fields in database
+            (Base.deleted_on.is_null() | (Base.deleted_on == 0)),
+        )
 
     return conditions

--- a/back/boxtribute_server/graph_ql/filtering.py
+++ b/back/boxtribute_server/graph_ql/filtering.py
@@ -144,7 +144,7 @@ def derive_base_filter(filter_input):
     """Derive filter condition for select-query from given filter parameters. If no
     parameters given, return empty conditions (i.e. no filtering applied).
     """
-    include_deleted = True
+    include_deleted = False
     if filter_input:
         include_deleted = filter_input.get("include_deleted")
 

--- a/back/boxtribute_server/models/definitions/base.py
+++ b/back/boxtribute_server/models/definitions/base.py
@@ -30,7 +30,7 @@ class Base(db.Model):  # type: ignore
         null=True,
     )
     delete_inactive_users = IntegerField(constraints=[SQL("DEFAULT 30")])
-    deleted = DateTimeField(null=True, default=None)
+    deleted_on = DateTimeField(null=True, column_name="deleted", default=None)
     dropcap_adult = IntegerField(
         column_name="dropcapadult", constraints=[SQL("DEFAULT 99999")]
     )

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -47,7 +47,12 @@ from .location import (
     yet_another_location,
 )
 from .log import default_log
-from .organisation import another_organisation, default_organisation, organisations
+from .organisation import (
+    another_organisation,
+    default_organisation,
+    inactive_organisation,
+    organisations,
+)
 from .packing_list_entry import packing_list_entry
 from .product import (
     another_product,
@@ -162,6 +167,7 @@ __all__ = [
     "expired_transfer_agreement",
     "god_user",
     "in_transit_box",
+    "inactive_organisation",
     "lost_box",
     "marked_for_shipment_box",
     "newest_standard_product",

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -4,7 +4,7 @@ import pathlib
 
 from boxtribute_server.db import db
 
-from .base import another_base, default_base, default_bases
+from .base import another_base, default_base, default_bases, deleted_base
 from .beneficiary import (
     another_beneficiary,
     another_relative_beneficiary,
@@ -159,6 +159,7 @@ __all__ = [
     "default_transfer_agreement",
     "default_user",
     "default_users",
+    "deleted_base",
     "deleted_location",
     "distribution_spot",
     "distro_spot5_distribution_events",

--- a/back/test/data/base.py
+++ b/back/test/data/base.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from boxtribute_server.models.definitions.base import Base
 
@@ -12,6 +14,7 @@ def data():
             "currency_name": "dingo dollars",
             "seq": 1,
             "organisation": organisation_data()[0]["id"],
+            "deleted_on": None,
         },
         {
             "id": 2,
@@ -19,6 +22,7 @@ def data():
             "currency_name": "monster munch",
             "seq": 1,
             "organisation": organisation_data()[0]["id"],
+            "deleted_on": None,
         },
         {
             "id": 3,
@@ -26,6 +30,7 @@ def data():
             "currency_name": "mustard",
             "seq": 1,
             "organisation": organisation_data()[1]["id"],
+            "deleted_on": None,
         },
         {
             "id": 4,
@@ -33,6 +38,15 @@ def data():
             "currency_name": "pounds",
             "seq": 1,
             "organisation": organisation_data()[1]["id"],
+            "deleted_on": None,
+        },
+        {
+            "id": 5,
+            "name": "third base",
+            "currency_name": "euro",
+            "seq": 1,
+            "organisation": organisation_data()[2]["id"],
+            "deleted_on": datetime(2023, 1, 1),
         },
     ]
 

--- a/back/test/data/base.py
+++ b/back/test/data/base.py
@@ -62,6 +62,11 @@ def another_base():
 
 
 @pytest.fixture
+def deleted_base():
+    return data()[4]
+
+
+@pytest.fixture
 def default_bases():
     return data()
 

--- a/back/test/data/organisation.py
+++ b/back/test/data/organisation.py
@@ -12,6 +12,10 @@ def data():
             "id": 2,
             "name": "Helpers",
         },
+        {
+            "id": 3,
+            "name": "Inactives",
+        },
     ]
 
 
@@ -28,6 +32,11 @@ def default_organisation():
 @pytest.fixture
 def another_organisation():
     return data()[1]
+
+
+@pytest.fixture
+def inactive_organisation():
+    return data()[2]
 
 
 def create():

--- a/back/test/endpoint_tests/test_base.py
+++ b/back/test/endpoint_tests/test_base.py
@@ -11,6 +11,7 @@ def test_bases_query(
                     id
                     name
                     currencyName
+                    deletedOn
                     beneficiaries { elements { id } }
                 }
             }"""
@@ -22,6 +23,7 @@ def test_bases_query(
             "id": str(default_base["id"]),
             "name": default_base["name"],
             "currencyName": default_base["currency_name"],
+            "deletedOn": None,
             "beneficiaries": {},
         }
     ]
@@ -31,9 +33,14 @@ def test_bases_query(
     response = assert_successful_request(read_only_client, query)
     assert response == []
 
-    query = """query { bases(filterInput: {includeDeleted: true}) { id } }"""
+    query = """query { bases(filterInput: {includeDeleted: true}) { id deletedOn } }"""
     response = assert_successful_request(read_only_client, query)
-    assert response == [{"id": str(deleted_base["id"])}]
+    assert response == [
+        {
+            "id": str(deleted_base["id"]),
+            "deletedOn": deleted_base["deleted_on"].isoformat() + "+00:00",
+        }
+    ]
 
 
 def test_base_query(

--- a/back/test/endpoint_tests/test_base.py
+++ b/back/test/endpoint_tests/test_base.py
@@ -28,8 +28,13 @@ def test_bases_query(
         }
     ]
 
+    # Test case 99.1.1a
     mock_user_for_request(mocker, base_ids=[deleted_base["id"]])
     query = """query { bases(filterInput: {includeDeleted: false}) { id } }"""
+    response = assert_successful_request(read_only_client, query)
+    assert response == []
+
+    query = """query { bases { id } }"""
     response = assert_successful_request(read_only_client, query)
     assert response == []
 

--- a/back/test/endpoint_tests/test_base.py
+++ b/back/test/endpoint_tests/test_base.py
@@ -1,7 +1,10 @@
+from auth import mock_user_for_request
 from utils import assert_successful_request
 
 
-def test_bases_query(read_only_client, default_base, default_beneficiaries):
+def test_bases_query(
+    read_only_client, default_base, deleted_base, default_beneficiaries, mocker
+):
     # Test case 99.1.1
     query = """query {
                 bases {
@@ -22,6 +25,15 @@ def test_bases_query(read_only_client, default_base, default_beneficiaries):
             "beneficiaries": {},
         }
     ]
+
+    mock_user_for_request(mocker, base_ids=[deleted_base["id"]])
+    query = """query { bases(filterInput: {includeDeleted: false}) { id } }"""
+    response = assert_successful_request(read_only_client, query)
+    assert response == []
+
+    query = """query { bases(filterInput: {includeDeleted: true}) { id } }"""
+    response = assert_successful_request(read_only_client, query)
+    assert response == [{"id": str(deleted_base["id"])}]
 
 
 def test_base_query(

--- a/back/test/endpoint_tests/test_organisation.py
+++ b/back/test/endpoint_tests/test_organisation.py
@@ -7,7 +7,17 @@ def test_organisation_query(
     default_organisation,
     default_beneficiaries,
     another_organisation,
+    inactive_organisation,
 ):
+    organisation_id = str(inactive_organisation["id"])
+    query = f"""query {{
+                organisation(id: "{organisation_id}") {{
+                    bases(filterInput: {{ includeDeleted: false }}) {{ id }}
+                }}
+            }}"""
+    response = assert_successful_request(read_only_client, query)
+    assert response == {"bases": []}
+
     # Test case 99.1.8
     # The user is a member of base 1 for default_organisation. They can read name and ID
     # of the organisation's bases but the beneficiary data of base 1 ONLY

--- a/back/test/endpoint_tests/test_organisation.py
+++ b/back/test/endpoint_tests/test_organisation.py
@@ -9,16 +9,20 @@ def test_organisation_query(
     another_organisation,
     inactive_organisation,
 ):
+    # Test case 99.1.8
     organisation_id = str(inactive_organisation["id"])
-    query = f"""query {{
-                organisation(id: "{organisation_id}") {{
-                    bases(filterInput: {{ includeDeleted: false }}) {{ id }}
-                }}
-            }}"""
+    query = f"""query {{ organisation(id: {organisation_id}) {{ bases {{ id }} }} }}"""
     response = assert_successful_request(read_only_client, query)
     assert response == {"bases": []}
 
-    # Test case 99.1.8
+    query = f"""query {{
+                organisation(id: "{organisation_id}") {{
+                    bases(filterInput: {{ includeDeleted: true }}) {{ id }}
+                }}
+            }}"""
+    response = assert_successful_request(read_only_client, query)
+    assert response == {"bases": [{"id": str(default_bases[4]["id"])}]}
+
     # The user is a member of base 1 for default_organisation. They can read name and ID
     # of the organisation's bases but the beneficiary data of base 1 ONLY
     organisation_id = str(default_organisation["id"])

--- a/back/test/endpoint_tests/test_statistics.py
+++ b/back/test/endpoint_tests/test_statistics.py
@@ -478,11 +478,11 @@ def test_authorization(read_only_client, mocker):
 
 def test_public_query_validation(read_only_client):
     for query in [
-        "query { beneficiaryDemographics(baseId: 5) { facts { age } } }",
-        "query { createdBoxes(baseId: 5) { facts { productId } } }",
-        "query { topProductsCheckedOut(baseId: 5) { facts { productId } } }",
-        "query { topProductsDonated(baseId: 5) { facts { productId } } }",
-        "query { movedBoxes(baseId: 5) { facts { categoryId } } }",
-        "query { stockOverview(baseId: 5) { facts { categoryId } } }",
+        "query { beneficiaryDemographics(baseId: 99) { facts { age } } }",
+        "query { createdBoxes(baseId: 99) { facts { productId } } }",
+        "query { topProductsCheckedOut(baseId: 99) { facts { productId } } }",
+        "query { topProductsDonated(baseId: 99) { facts { productId } } }",
+        "query { movedBoxes(baseId: 99) { facts { categoryId } } }",
+        "query { stockOverview(baseId: 99) { facts { categoryId } } }",
     ]:
         assert_bad_user_input(read_only_client, query, endpoint="public")

--- a/back/test/integration_tests/test_cli.py
+++ b/back/test/integration_tests/test_cli.py
@@ -265,7 +265,7 @@ def test_remove_base_access(patched_input, mysql_data, auth0_management_api_clie
     time.sleep(WAIT)
 
     base = Base.get_by_id(int(base_id))
-    assert base.deleted.date() == date.today()
+    assert base.deleted_on.date() == date.today()
 
     # Verify that no users have base ID 8 in their app_metadata any more
     users = auth0_management_api_client.get_users_of_base(base_id)
@@ -319,7 +319,7 @@ def test_remove_base_access(patched_input, mysql_data, auth0_management_api_clie
     assert len(role_ids) == 1
 
     base = Base.get_by_id(int(base_id))
-    assert base.deleted is None
+    assert base.deleted_on is None
 
     # Verify that User._usergroup field is set to NULL and User data is anonymized
     fields = {
@@ -480,7 +480,7 @@ WHERE cms_usergroups_id BETWEEN 99999990 AND 99999994;"""
     assert len(role_ids) == 0
 
     base = Base.get_by_id(int(base_id))
-    assert base.deleted.date() == date.today()
+    assert base.deleted_on.date() == date.today()
 
     cursor = db.database.execute_sql(
         """\

--- a/back/test/model_tests/test_cli.py
+++ b/back/test/model_tests/test_cli.py
@@ -483,7 +483,7 @@ def test_remove_base_access(usergroup_data):
     remove_base_access(base_id=base_id, service=service, force=True)
 
     base = Base.get_by_id(base_id)
-    assert base.deleted.date() == date.today()
+    assert base.deleted_on.date() == date.today()
 
     # Verify that User._usergroup field is set to NULL and User data is anonymized
     assert User.select(User.id, User._usergroup, User.name, User.email).dicts() == [

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -25,6 +25,7 @@ export type Base = {
   /**  List of all [`Beneficiaries`]({{Types.Beneficiary}}) registered in this base  */
   beneficiaries?: Maybe<BeneficiaryPage>;
   currencyName?: Maybe<Scalars['String']>;
+  deletedOn?: Maybe<Scalars['Datetime']>;
   distributionEvents: Array<DistributionEvent>;
   distributionEventsBeforeReturnedFromDistributionState: Array<DistributionEvent>;
   distributionEventsInReturnedFromDistributionState: Array<DistributionEvent>;

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -515,6 +515,10 @@ export type EmptyNameError = {
 
 export type EnableStandardProductResult = InsufficientPermissionError | InvalidPriceError | Product | ResourceDoesNotExistError | StandardProductAlreadyEnabledForBaseError | UnauthorizedForBaseError;
 
+export type FilterBaseInput = {
+  includeDeleted?: InputMaybe<Scalars['Boolean']>;
+};
+
 /**
  * Optional filter values when retrieving [`Beneficiaries`]({{Types.Beneficiary}}).
  * If several fields are defined (not null), they are combined into a filter expression using logical AND (i.e. the filter returns only elements for which *all* fields are true).
@@ -1266,6 +1270,12 @@ export type Organisation = {
   bases?: Maybe<Array<Base>>;
   id: Scalars['ID'];
   name: Scalars['String'];
+};
+
+
+/** Representation of an organisation. */
+export type OrganisationBasesArgs = {
+  filterInput?: InputMaybe<FilterBaseInput>;
 };
 
 /** TODO: Add description here once specs are final/confirmed */

--- a/front/src/types/generated/graphql.ts
+++ b/front/src/types/generated/graphql.ts
@@ -1495,6 +1495,11 @@ export type QueryBaseArgs = {
 };
 
 
+export type QueryBasesArgs = {
+  filterInput?: InputMaybe<FilterBaseInput>;
+};
+
+
 export type QueryBeneficiariesArgs = {
   filterInput?: InputMaybe<FilterBeneficiaryInput>;
   paginationInput?: InputMaybe<PaginationInput>;

--- a/front/src/views/Transfers/CreateTransferAgreement/CreateTransferAgreementView.tsx
+++ b/front/src/views/Transfers/CreateTransferAgreement/CreateTransferAgreementView.tsx
@@ -26,7 +26,7 @@ export const ALL_ORGS_AND_BASES_QUERY = gql`
     organisations {
       id
       name
-      bases {
+      bases(filterInput: {includeDeleted: false}) {
         id
         name
       }

--- a/front/src/views/Transfers/CreateTransferAgreement/CreateTransferAgreementView.tsx
+++ b/front/src/views/Transfers/CreateTransferAgreement/CreateTransferAgreementView.tsx
@@ -26,7 +26,7 @@ export const ALL_ORGS_AND_BASES_QUERY = gql`
     organisations {
       id
       name
-      bases(filterInput: {includeDeleted: false}) {
+      bases {
         id
         name
       }


### PR DESCRIPTION
Filtering is now possible with these two queries:
```graphql
organisations { bases(filterInput: {includeDeleted: false}) { id }}
bases(filterInput: {includeDeleted: false}) { id }
```
Default for the filter parameter is to _include_ deleted bases. I did it this way because I didn't want a `bases` query to have breaking-change behavior. There might be API users who rely on the `bases` query returning deleted bases, too; and there is our own FE that might issue the `bases` query in different places, and I didn't want to break it.

I adjusted the FE already.

Furthermore the `Base.deletedOn` field was added.