### PR TITLE
Check only for not allowed or found MediaStream errors

### DIFF
--- a/front/src/components/QrReader/QrReaderContainer.tsx
+++ b/front/src/components/QrReader/QrReaderContainer.tsx
@@ -55,7 +55,9 @@ function QrReaderContainer({ onSuccess }: IQrReaderContainerProps) {
       .catch((error) => {
         if (error.name === "NotAllowedError") {
           setIsCameraNotPermited(true);
-        } else {
+        }
+
+        if (error.name === "NotFoundError") {
           triggerError({
             userMessage: "No camera is available on your device.",
             message: `getUserMedia error: ${error.name}`,


### PR DESCRIPTION
Chrome (mobile only) was catching the [MediaStream.NotReadableError](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#notreadableerror) because the camera wasn't loaded yet when the permission was evaluated. Thus showing an error toast.