### PR TITLE
Introduce dependabot groups for BE dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/back/"
     schedule:
       interval: "weekly"
+    groups:
+      back-dev-deps:
+        dependency-type: development
+      back-prod-patch-update-deps:
+        applies-to: version-updates
+        dependency-type: production
+        update-types:
+        - "patch"
     assignees:
       - "pylipp"
   - package-ecosystem: "npm"


### PR DESCRIPTION
- group all dev updates, regardless of version bump
- group all prod updates with "patch" version bumps
- all other updates receive individual PRs
