### PR TITLE
Update GraphQL schema documentation

### DIFF
--- a/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
@@ -140,9 +140,10 @@ def create_transfer_agreement(
 ):
     """Insert information for a new TransferAgreement in the database. Update
     TransferAgreementDetail model with given source/target base information. By default,
-    the agreement is established between all bases of both organisations (indicated by
-    NULL for the Detail.source/target_base field). As a result, any base that added to
-    an organisation in the future would be part of such an agreement.
+    the agreement is established with all non-deleted bases of the partner organisation.
+    As a result, any base added to the partner organisation afterwards will NOT be part
+    of the agreement. A new agreement needs to be created then to transfer goods with
+    the new base.
     Convert optional local dates into UTC datetimes using user timezone information.
     Raise an InvalidTransferAgreementOrganisation exception if the current user's
     organisation is identical to the target organisation.

--- a/back/boxtribute_server/business_logic/user/fields.py
+++ b/back/boxtribute_server/business_logic/user/fields.py
@@ -8,7 +8,18 @@ user = ObjectType("User")
 
 
 @user.field("bases")
-def resolve_bases(*_):
+def resolve_bases(user_obj, _):
+    if user_obj.id != g.user.id:
+        # If the queried user is different from the current user, we don't have a way
+        # yet to fetch secure information about that user's bases; it would require
+        # accessing Auth0 to find out if the current user has sufficient permission.
+        # For now, null is returned
+        return
+
+    if g.user.is_god:
+        # God user have access to all bases
+        return Base.select()
+
     return Base.select().where(authorized_bases_filter())
 
 

--- a/back/boxtribute_server/graph_ql/definitions/protected/inputs.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/inputs.graphql
@@ -1,6 +1,4 @@
-"""
-GraphQL input types for mutations **only**.
-"""
+# GraphQL input types for mutations **only**.
 input BoxCreationInput {
   productId: Int!
   sizeId: Int!
@@ -111,7 +109,7 @@ input TransferAgreementCreationInput {
   initiatingOrganisationId: Int!
   partnerOrganisationId: Int!
   type: TransferAgreementType!
-  # pass local date
+  " Validity dates must be in local time "
   validFrom: Date
   validUntil: Date
   initiatingOrganisationBaseIds: [Int!]!

--- a/back/boxtribute_server/graph_ql/definitions/protected/mutations.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/mutations.graphql
@@ -1,11 +1,11 @@
-"""
-Naming convention:
-- input argument: creationInput/updateInput
-- input type: <Resource>CreationInput/UpdateInput
-"""
+# Naming convention:
+# - input argument: creationInput/updateInput
+# - input type: <Resource>CreationInput/UpdateInput
 type Mutation {
   createQrCode(boxLabelIdentifier: String): QrCode
+  " Create a new box in a location, containing items of certain product and size. Optionally pass tags to assign to the box. "
   createBox(creationInput: BoxCreationInput): Box
+  " Update one or more properties of a box with specified label identifier. "
   updateBox(updateInput: BoxUpdateInput): Box
   " Any boxes that are non-existing, already deleted, and/or in a base that the user must not access are returned in the `BoxResult.invalidBoxLabelIdentifiers` list. "
   deleteBoxes(labelIdentifiers: [String!]!): DeleteBoxesResult
@@ -16,37 +16,63 @@ type Mutation {
   " Any boxes that are non-existing, don't have the requested tag assigned, and/or in a base that the user must not access are returned in the `BoxResult.invalidBoxLabelIdentifiers` list. "
   unassignTagFromBoxes(updateInput: BoxAssignTagInput): UnassignTagFromBoxesResult
 
+  " Create a new beneficiary in a base, using first/last name, date of birth, and group identifier. Optionally pass tags to assign to the beneficiary. "
   createBeneficiary(creationInput: BeneficiaryCreationInput): Beneficiary
+  " Update one or more properties of a beneficiary with specified ID. "
   updateBeneficiary(updateInput: BeneficiaryUpdateInput): Beneficiary
+  " Deactivate beneficiary with specified ID. "
   deactivateBeneficiary(id: ID!): Beneficiary
 
+  " Create a new tag for a base, described by name, color and type. "
   createTag(creationInput: TagCreationInput): Tag
+  " Update one or more properties of a tag with specified ID. "
   updateTag(updateInput: TagUpdateInput): Tag
+  " Soft-delete tag with specified ID. "
   deleteTag(id: ID!): Tag
   assignTag(assignmentInput: TagOperationInput): TaggableResource
   unassignTag(unassignmentInput: TagOperationInput): TaggableResource
 
+  " Create new transfer agreement with with a partner organisation (the client's organisation is the initiating organisation). By default, the agreement is established with non-deleted bases of the partner organisation, and is infinitely valid. As a result, any base added to that organisation afterwards will NOT be part of the agreement; instead a new agreement needs to be established. If an accepted agreement with the same set of organisations and bases already exists, an error is returned. The client must be member of all bases of the initiating organisation.  "
   createTransferAgreement(creationInput: TransferAgreementCreationInput): TransferAgreement
+  " Change state of specified transfer agreement to `Accepted`. Only valid for agreements in `UnderReview` state. The client must be member of all agreement target bases. "
   acceptTransferAgreement(id: ID!): TransferAgreement
+  " Change state of specified transfer agreement to `Rejected`. Only valid for agreements in `UnderReview` state. The client must be member of all agreement target bases. "
   rejectTransferAgreement(id: ID!): TransferAgreement
+  " Change state of specified transfer agreement to `Canceled`. Only valid for agreements in `UnderReview` or `Accepted` state. The client must be member of either all agreement target bases or all agreement source bases. "
   cancelTransferAgreement(id: ID!): TransferAgreement
 
+  " Create a new shipment between two bases. The specified transfer agreement must be in `Accepted` state. The client must be member of the specified source base. "
   createShipment(creationInput: ShipmentCreationInput): Shipment
+  " Add boxes to or remove boxes from the shipment during preparation on the source side. Only valid if shipment is in `Preparing` state. The client must be member of the shipment source base. "
   updateShipmentWhenPreparing(updateInput: ShipmentWhenPreparingUpdateInput): Shipment
+  " Reconcile boxes or mark them as lost during shipment receival on the target side. Only valid if shipment is in `Receiving` state. If all boxes are reconciled, the state automatically updates to `Completed`. The client must be member of the shipment target base. "
   updateShipmentWhenReceiving(updateInput: ShipmentWhenReceivingUpdateInput): Shipment
+  " Change state of specified shipment to `Canceled`. Only valid for shipments in `Preparing` state. Any boxes marked for shipment are moved back into stock. The client must be member of either source or target base of the shipment. "
   cancelShipment(id: ID!): Shipment
+  " Change state of specified shipment to `Sent`, and state of all contained `MarkedForShipment` boxes to `InTransit`. Only valid for shipments in `Preparing` state. The client must be member of the shipment source base. "
   sendShipment(id: ID!): Shipment
+  " Change state of specified shipment to `Receiving`, and state of all contained `InTransit` boxes to `Receiving`. Only valid for shipments in `Sent` state. The client must be member of the shipment target base. "
   startReceivingShipment(id: ID!): Shipment
+  " Change state of specified shipment to `Lost`, and state of all contained `InTransit` boxes to `NotDelivered`. Only valid for shipments in `Sent` state. The client must be member of either source or target base of the shipment. "
   markShipmentAsLost(id: ID!): Shipment
+  " Change state of boxes that were accidentally marked as `NotDelivered` back to `InStock`. "
   moveNotDeliveredBoxesInStock(boxIds: [String!]!): Shipment
 
+  " Create a new custom product in a base, specifying properties like name, gender, size range, and price. Return errors in case of invalid input. The client must be member of the specified base. "
   createCustomProduct(creationInput: CustomProductCreationInput): CreateCustomProductResult
+  " Edit properties of the custom product with specified ID. Return errors in case of invalid input. The client must be member of the base that the product is registered in. "
   editCustomProduct(editInput: CustomProductEditInput): EditCustomProductResult
+  " Soft-delete the custom product with specified ID. Return errors if the product is still assigned to any boxes. The client must be member of the base that the product is registered in. "
   deleteProduct(id: ID!): DeleteProductResult
+  " Enable a standard product for a base, specifying properties like size range, and price. This creates a so-called standard product instantiation that can be treated like any [`Product`]({{Types.Product}}). Return errors in case of invalid input (especially if the standard product has already been enabled for the base). The client must be member of the specified base. "
   enableStandardProduct(enableInput: StandardProductEnableInput): EnableStandardProductResult
+  " Edit properties of the standard product instantiation with specified ID. Return errors in case of invalid input. The client must be member of the base that the product is registered in. "
   editStandardProductInstantiation(editInput: StandardProductInstantiationEditInput): EditStandardProductInstantiationResult
+  " Disable the standard product instantiation with specified ID. Return errors if the product is still assigned to any boxes. The client must be member of the base that the product is registered in. "
   disableStandardProduct(instantiationId: ID!): DisableStandardProductResult
 
+
+  # Undocumented mutations of the mobile-distribution feature
   createDistributionSpot(creationInput: DistributionSpotCreationInput): DistributionSpot
   createDistributionEvent(creationInput: DistributionEventCreationInput): DistributionEvent
 
@@ -79,11 +105,6 @@ type Mutation {
     id: ID!
     numberOfItems: Int!
   ): UnboxedItemsCollection
-  # moveItemsFromUnboxedItemsCollectionToBox(
-  #   unboxedItemsCollectionId: ID!
-  #   boxLabelIdentifier: ID!
-  #   numberOfItems: Int!
-  # ): Box
 
   startDistributionEventsTrackingGroup(
     distributionEventIds: [ID!]!,

--- a/back/boxtribute_server/graph_ql/definitions/protected/queries.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/queries.graphql
@@ -1,43 +1,48 @@
 type Query {
-  " Return all [`Bases`]({{Types.Base}}) that the client is authorized to view. "
+  " Return all non-deleted [`Bases`]({{Types.Base}}) that the client is authorized to view. "
   bases(filterInput: FilterBaseInput): [Base!]!
+  " Return [`Base`]({{Types.Base}})  with specified ID. Accessible for clients who are members of this base. "
   base(id: ID!): Base
-  " Return all [`DistributionSpots`]({{Types.DistributionSpot}}) that the client is authorized to view. "
-  distributionSpots: [DistributionSpot!]!
-  distributionSpot(id: ID!): DistributionSpot
-  distributionEvent(id: ID!): DistributionEvent
-  packingListEntry(id: ID!): PackingListEntry
-  distributionEventsTrackingGroup(id: ID!): DistributionEventsTrackingGroup
+  " Return [`Organisation`]({{Types.Organisation}}) with specified ID. "
   organisation(id: ID!): Organisation
-  " Return all [`Organisations`]({{Types.Organisation}}) that the client is authorized to view. "
+  " Return all [`Organisations`]({{Types.Organisation}}). "
   organisations: [Organisation!]!
+  " Return [`User`]({{Types.User}}) with specified ID. Some fields might be restricted. "
   user(id: ID): User
-  " Return all [`Users`]({{Types.User}}) that the client is authorized to view. "
+  " Return all [`Users`]({{Types.User}}). Accessible for god users only "
   users: [User!]!
+  " Return [`Box`]({{Types.Box}}) with specified label identifier. For a box in InTransit, Receiving, or NotDelivered state, clients of both source and target base of the underlying shipment are allowed to view it. Otherwise the client must be permitted to access the base of the box location "
   box(labelIdentifier: String!): Box
+  " Return page of non-deleted [`Boxes`]({{Types.Box}}) in base with specified ID. Optionally pass filters "
   boxes(baseId: ID!, paginationInput: PaginationInput, filterInput: FilterBoxInput): BoxPage!
+  " Return [`QrCode`]({{Types.QrCode}}) with specified code (an MD5 hash in hex format of length 32) "
   qrCode(qrCode: String!): QrCode
   qrExists(qrCode: String): Boolean
+  " Return [`ClassicLocation`]({{Types.ClassicLocation}}) with specified ID. Accessible for clients who are members of the location's base "
   location(id: ID!): ClassicLocation
   " Return all [`ClassicLocations`]({{Types.ClassicLocation}}) that the client is authorized to view. "
   locations: [ClassicLocation!]!
+  " Return [`Product`]({{Types.Product}}) with specified ID. Accessible for clients who are members of the product's base "
   product(id: ID!): Product
-  " Return all [`Products`]({{Types.Product}}) that the client is authorized to view. "
+  " Return all [`Products`]({{Types.Product}}) (incl. deleted) that the client is authorized to view. "
   products(paginationInput: PaginationInput): ProductPage!
+  " Return [`StandardProduct`]({{Types.StandardProduct}}) with specified ID, or an error in case of insufficient permission or missing resource. "
   standardProduct(id: ID!): StandardProductResult
   " Return standard products of latest version. Optionally include all standard products enabled for specified base. "
   standardProducts(baseId: ID): StandardProductsResult
+  " Return [`ProductCategory`]({{Types.ProductCategory}}) with specified ID. "
   productCategory(id: ID!): ProductCategory
-  " Return all [`ProductCategories`]({{Types.ProductCategory}}) that the client is authorized to view. "
+  " Return all [`ProductCategories`]({{Types.ProductCategory}}). "
   productCategories: [ProductCategory!]!
+  " Return [`Beneficiary`]({{Types.Beneficiary}}) with specified ID. Accessible for clients who are members of the beneficiary's base "
   beneficiary(id: ID!): Beneficiary
-  " Return all [`Beneficiaries`]({{Types.Beneficiary}}) that the client is authorized to view. "
+  " Return all [`Beneficiaries`]({{Types.Beneficiary}}) that the client is authorized to view. Optionally pass filter. "
   beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage!
-  """
-  Return all [`Tags`]({{Types.Tag}}) that the client is authorized to view. Optionally filter for tags of certain type.
-  """
+  " Return all non-deleted [`Tags`]({{Types.Tag}}) that the client is authorized to view. Optionally filter for tags of certain type. "
   tags(tagType: TagType): [Tag!]!
+  " Return [`Tag`]({{Types.Tag}}) with specified ID. Accessible for clients who are members of the tag's base "
   tag(id: ID!): Tag
+  " Return [`TransferAgreement`]({{Types.TransferAgreement}}) with specified ID. Clients are authorized to view an agreement if they're member of at least one of the agreement's source or target bases "
   transferAgreement(id: ID!): TransferAgreement
   """
   Return all [`TransferAgreements`]({{Types.TransferAgreement}}) that the client is authorized to view.
@@ -45,6 +50,7 @@ type Query {
   regardless of agreement state. Optionally filter for agreements of certain state(s).
   """
   transferAgreements(states: [TransferAgreementState!]): [TransferAgreement!]!
+  " Return [`Shipment`]({{Types.Shipment}}) with specified ID. Clients are authorized to view a shipment if they're member of either the source or the target base "
   shipment(id: ID!): Shipment
   " Return all [`Shipments`]({{Types.Shipment}}) that the client is authorized to view. "
   shipments: [Shipment!]!
@@ -60,4 +66,11 @@ type Query {
   topProductsDonated(baseId: Int!): TopProductsDonatedData
   movedBoxes(baseId: Int!): MovedBoxesData
   stockOverview(baseId: Int!): StockOverviewData
+
+  # Undocumented queries of the mobile-distribution feature
+  distributionSpots: [DistributionSpot!]!
+  distributionSpot(id: ID!): DistributionSpot
+  distributionEvent(id: ID!): DistributionEvent
+  packingListEntry(id: ID!): PackingListEntry
+  distributionEventsTrackingGroup(id: ID!): DistributionEventsTrackingGroup
 }

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -124,7 +124,6 @@ type ProductCategory {
   name: String!
   " List of all products registered in bases the client is authorized to view. "
   products(paginationInput: PaginationInput): ProductPage
-  sizeRanges: [SizeRange]
   " Non-clothing categories don't have a product gender. "
   hasGender: Boolean!
 }
@@ -178,7 +177,6 @@ type SizeRange {
   id: ID!
   label: String!
   sizes: [Size!]!
-  productCategory: [ProductCategory!]
 }
 
 """
@@ -240,12 +238,9 @@ type Base {
   distributionSpots: [DistributionSpot!]!
   distributionEvents(states: [DistributionEventState!]): [DistributionEvent!]!
 
-  # TODO: rethink this query once the prototype testing is over
+  # TODO: rethink these queries once the prototype testing is over
   # probably better to have filter parameters and only one query operation
   distributionEventsBeforeReturnedFromDistributionState: [DistributionEvent!]!
-
-  # TODO: rethink this query once the prototype testing is over (same as above)
-  # probably better to have filter parameters and only one query operation
   distributionEventsInReturnedFromDistributionState: [DistributionEvent!]!
 
   distributionEventsTrackingGroups(states: [DistributionEventsTrackingGroupState!]): [DistributionEventsTrackingGroup!]!
@@ -278,9 +273,6 @@ type Organisation {
   bases(filterInput: FilterBaseInput): [Base!]
 }
 
-"""
-TODO: Add description here once specs are final/confirmed
-"""
 type DistributionEvent {
   id: ID!
   distributionSpot: DistributionSpot
@@ -299,9 +291,6 @@ type DistributionEvent {
   distributionEventsTrackingGroup: DistributionEventsTrackingGroup
 }
 
-"""
-TODO: Add description here once specs are final/confirmed
-"""
 type DistributionEventsTrackingEntry {
   id: ID!
   product: Product!
@@ -312,9 +301,6 @@ type DistributionEventsTrackingEntry {
   flowDirection: DistributionEventTrackingFlowDirection!
 }
 
-"""
-TODO: Add description here once specs are final/confirmed
-"""
 type DistributionEventsTrackingGroup {
   id: ID!
   state: DistributionEventsTrackingGroupState!
@@ -323,9 +309,6 @@ type DistributionEventsTrackingGroup {
   createdOn: Datetime!
 }
 
-"""
-TODO: Add description here once specs are final/confirmed
-"""
 type PackingListEntry {
   id: ID!
   product: Product
@@ -335,13 +318,11 @@ type PackingListEntry {
   state: PackingListEntryState!
 }
 
-"""
-TODO: Add description here once specs are final/confirmed
-"""
 type DistributionSpot implements Location {
   id: ID!
   name: String
   base: Base
+  " Not implemented, only for compatibility with Location interface "
   boxes(paginationInput: PaginationInput, filterInput: FilterBoxInput): BoxPage
   comment: String!
   latitude: Float

--- a/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
+++ b/back/boxtribute_server/graph_ql/definitions/protected/types.graphql
@@ -1,7 +1,5 @@
 # GraphQL basic types as returned by queries and mutations, and input types for queries.
 
-
-
 interface ItemsCollection {
   id: ID!
   product: Product
@@ -20,7 +18,6 @@ type UnboxedItemsCollection implements ItemsCollection {
   location: Location
   distributionEvent: DistributionEvent
 }
-
 
 """
 Representation of a box storing items of a [`Product`]({{Types.Product}}) in a [`Location`]({{Types.Location}})
@@ -158,12 +155,13 @@ type Tag {
   description: String
   color: String
   type: TagType!
+  " List of boxes and/or beneficiaries that have this tag assigned "
   taggedResources: [TaggableResource!]
   base: Base!
 }
 
 """
-Representation of product size.
+Representation of product size (e.g. clothing size "XL", shoe size 39).
 """
 type Size {
   id: ID!
@@ -171,11 +169,12 @@ type Size {
 }
 
 """
-Representation of group of sizes.
+Representation of group of sizes (e.g. clothing sizes "S, M, L, XL").
 """
 type SizeRange {
   id: ID!
   label: String!
+  " List of sizes belonging to the group "
   sizes: [Size!]!
 }
 
@@ -187,10 +186,11 @@ type ClassicLocation implements Location {
   id: ID!
   base: Base
   name: String
+  " Used for ordering purposes "
   seq: Int
   isShop: Boolean!
   isStockroom: Boolean!
-  " List of all the [`Boxes`]({{Types.Box}}) in this classic location "
+  " List of all [`Boxes`]({{Types.Box}}) (incl. deleted) in this classic location "
   boxes(paginationInput: PaginationInput, filterInput: FilterBoxInput): BoxPage
   " Default state for boxes in this classic location"
   defaultBoxState: BoxState
@@ -226,14 +226,14 @@ type Base {
   name: String!
   organisation: Organisation!
   deletedOn: Datetime
-  " List of all [`Beneficiaries`]({{Types.Beneficiary}}) registered in this base "
+  " List of all [`Beneficiaries`]({{Types.Beneficiary}}) registered in this base. Optionally pass filters "
   beneficiaries(paginationInput: PaginationInput, filterInput: FilterBeneficiaryInput): BeneficiaryPage
   currencyName: String
-  " List of all undeleted [`ClassicLocations`]({{Types.ClassicLocation}}) present in this base "
+  " List of all non-deleted [`ClassicLocations`]({{Types.ClassicLocation}}) present in this base "
   locations: [ClassicLocation!]!
-  " List of all undeleted [`Products`]({{Types.Product}}) registered in this base "
+  " List of all non-deleted [`Products`]({{Types.Product}}) registered in this base "
   products(filterInput: FilterProductInput): [Product!]!
-  " List of all [`Tags`]({{Types.Tag}}) registered in this base. Optionally filter for a [`resource type`]({{Types.TaggableResourceType}}) "
+  " List of all non-deleted [`Tags`]({{Types.Tag}}) registered in this base. Optionally filter for a [`resource type`]({{Types.TaggableResourceType}}) "
   tags(resourceType: TaggableResourceType): [Tag!]
   distributionSpots: [DistributionSpot!]!
   distributionEvents(states: [DistributionEventState!]): [DistributionEvent!]!
@@ -245,6 +245,16 @@ type Base {
 
   distributionEventsTrackingGroups(states: [DistributionEventsTrackingGroupState!]): [DistributionEventsTrackingGroup!]!
   distributionEventsStatistics: [DistributionEventsStatistics!]!
+}
+
+"""
+Representation of an organisation.
+"""
+type Organisation {
+  id: ID!
+  name: String!
+  " List of all non-deleted [`Bases`]({{Types.Base}}) managed by this organisation. Accessible for any authenticated user "
+  bases(filterInput: FilterBaseInput): [Base!]
 }
 
 type DistributionEventsStatistics {
@@ -261,16 +271,6 @@ type DistributionEventsStatistics {
   distroEventTrackingGroupId: String!
   productId: String!
   sizeId: String!
-}
-
-"""
-Representation of an organisation.
-"""
-type Organisation {
-  id: ID!
-  name: String!
-  " List of all [`Bases`]({{Types.Base}}) managed by this organisation "
-  bases(filterInput: FilterBaseInput): [Base!]
 }
 
 type DistributionEvent {
@@ -331,17 +331,19 @@ type DistributionSpot implements Location {
 }
 
 """
-Representation of a user signed up for the web application.
-The user is a member of a specific [`Organisation`]({{Types.Organisation}}).
+Representation of a boxtribute user.
 """
 type User {
   id: ID!
+  " The [`Organisation`]({{Types.Organisation}}) the user is a member of. Meaningful only if the currently authenticated user queries themselves "
   organisation: Organisation
+  " First and last name. Accessible to any authenticated user "
   name: String
+  " Available only if the currently authenticated user queries themselves "
   email: String
   validFirstDay: Date
   validLastDay: Date
-  " List of all [`Bases`]({{Types.Base}}) this user can access "
+  " List of all [`Bases`]({{Types.Base}}) this user can access. Meaningful only if the currently authenticated user queries themselves "
   bases: [Base]
   lastLogin: Datetime
   lastAction: Datetime
@@ -492,6 +494,9 @@ input PaginationInput {
   last: Int
 }
 
+"""
+Representation of an agreement between two organisations prior to start mutual shipments.
+"""
 type TransferAgreement {
   id: ID!
   sourceOrganisation: Organisation!
@@ -514,8 +519,12 @@ type TransferAgreement {
   shipments: [Shipment!]!
 }
 
+"""
+Representation of a shipment of boxes between two bases of two distinct organisations. The content is tracked via [`ShipmentDetails`]({{Types.ShipmentDetail}})
+"""
 type Shipment {
   id: ID!
+  " Unique identifier of the shipment, constructed from ID, start date, source and target base names. E.g. `S042-230815-THxLE` "
   labelIdentifier: String!
   sourceBase: Base!
   targetBase: Base!
@@ -534,6 +543,9 @@ type Shipment {
   details: [ShipmentDetail!]!
 }
 
+"""
+Representation of a box in a shipment. Boxes might be added or removed on the source side, and received or marked as lost on the target side. All properties (product, location, size, quantity) at source and target side are tracked here
+"""
 type ShipmentDetail {
   id: ID!
   sourceProduct: Product

--- a/back/test/endpoint_tests/test_product_categories.py
+++ b/back/test/endpoint_tests/test_product_categories.py
@@ -7,14 +7,12 @@ def test_product_category_query(read_only_client, default_product_category):
     query = f"""query {{ productCategory(id: {category_id}) {{
                 id
                 name
-                sizeRanges {{ id }}
                 hasGender
             }} }}"""
     category = assert_successful_request(read_only_client, query)
     assert category == {
         "id": category_id,
         "name": default_product_category["name"],
-        "sizeRanges": None,
         "hasGender": True,
     }
 
@@ -27,7 +25,6 @@ def test_product_categories_query(read_only_client):
                     products {
                         elements { id }
                     }
-                    sizeRanges { id }
                     hasGender
                 }
             }"""


### PR DESCRIPTION
I built the schema documentation that we host e.g. on api-staging.boxtribute.org/docs ([instructions](https://github.com/boxwise/boxtribute/blob/master/docs/graphql-api/README.md#usage)), and zipped it:
[docs.zip](https://github.com/user-attachments/files/16713998/docs.zip)

Extract and view `public/index.html`.