### PR TITLE
Generate GraphQL Typescript definitions via pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
           command: |
             pnpm lint:fix:all
             pnpm format:write:all
+            pnpm generate-graphql-ts-types
       - run:
           name: Build front
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,9 @@ jobs:
             source $(pyenv root)/versions/3.12.2/envs/env/bin/activate
             # https://pre-commit.com/#pre-commit-run
             git ls-files . | xargs pre-commit run --files
+          environment:
+            # Skip hook that requires docker-compose
+            SKIP: generate-graphql-ts-types
       - save_cache:
           key: webapp-deps-{{ checksum "requirements.txt" }}-{{ checksum "requirements-deploy.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "../.pre-commit-config.yaml" }}
           paths:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,11 @@ repos:
         language: system
         require_serial: true
         args: ["--filter-files"]
+      - id: generate-graphql-ts-types
+        name: Generate GraphQL Typescript definitions
+        entry: docker-compose
+        types: [graphql]
+        language: system
+        require_serial: true
+        pass_filenames: false
+        args: ["run", "--rm", "front", "pnpm", "generate-graphql-ts-types"]


### PR DESCRIPTION
Previously achieved via a script (invoke_yarn) which seems unnecessary
in hindsight.
Follow-up for #1444.
