### PR TITLE
Add tracking by image download type

### DIFF
--- a/shared-components/statviz/components/VisHeader.tsx
+++ b/shared-components/statviz/components/VisHeader.tsx
@@ -79,6 +79,7 @@ export default function VisHeader({
     isChartExporting(true);
     trackDownloadByGraph({
       graphName: heading,
+      downloadFormat: e.target.value,
     });
 
     const customIncludeProps = customIncludes!

--- a/shared-components/statviz/utils/analytics/heap/types.ts
+++ b/shared-components/statviz/utils/analytics/heap/types.ts
@@ -6,18 +6,9 @@ interface IHeap {
 
 interface IDownloadByGraphEvent extends HeapEvent {
   graphName: string;
-}
-
-interface IDownloadByFormatAndGraphEvent extends IDownloadByGraphEvent {
   downloadFormat: string;
 }
 
 type FilterValue = string | Array<string>;
 
-export type {
-  IDownloadByFormatAndGraphEvent,
-  IDownloadByGraphEvent,
-  IHeap,
-  HeapEvent,
-  FilterValue,
-};
+export type { IDownloadByGraphEvent, IHeap, HeapEvent, FilterValue };


### PR DESCRIPTION
Extended heap tracking event with the image download type. 


Would have liked to add tests in this iteration but couldn't run tests for FE, see thread: https://boxwise.slack.com/archives/CB1UYDGLU/p1724450618067419?thread_ts=1724361187.607409&cid=CB1UYDGLU - will definitely add tests when I can address this. 