### PR TITLE
Fix console warning in browser re key usage

### DIFF
--- a/front/src/components/Table/Table.tsx
+++ b/front/src/components/Table/Table.tsx
@@ -15,19 +15,25 @@ interface ITableRowProps {
 
 function TableRow({ row, children }: ITableRowProps) {
   const navigate = useNavigate();
+  const { key, ...props } = row.getRowProps();
   if (typeof row.original.href === "string" && row.original.href.length > 0) {
     return (
       <Tr
         onClick={() => navigate(row.original.href)}
         _hover={{ bg: "brandYellow.100" }}
         cursor="pointer"
-        {...row.getRowProps()}
+        key={key}
+        {...props}
       >
         {children}
       </Tr>
     );
   }
-  return <Tr {...row.getRowProps()}>{children}</Tr>;
+  return (
+    <Tr key={key} {...props}>
+      {children}
+    </Tr>
+  );
 }
 
 interface IInitialStateFilters {


### PR DESCRIPTION
Key prop needs to be explicit, not exposed via a spread. These were causing errors in the console of the browser:

<img width="854" alt="Screenshot 2024-09-13 at 19 07 05" src="https://github.com/user-attachments/assets/0ccc322b-3823-4468-8cd3-0667e2485df9">

when accessing http://localhost:3000/bases/1/transfers/shipments