### PR TITLE
Fix test warnings about deprecated defaultProps

### DIFF
--- a/front/src/components/AreYouSure.tsx
+++ b/front/src/components/AreYouSure.tsx
@@ -30,9 +30,9 @@ export function AreYouSureDialog({
   title,
   body,
   leftButtonText,
-  leftButtonProps,
+  leftButtonProps = {},
   rightButtonText,
-  rightButtonProps,
+  rightButtonProps = {},
   isLoading,
   isOpen,
   onClose,
@@ -70,8 +70,3 @@ export function AreYouSureDialog({
     </Modal>
   );
 }
-
-AreYouSureDialog.defaultProps = {
-  leftButtonProps: {},
-  rightButtonProps: {},
-};

--- a/front/src/components/Form/SelectField.tsx
+++ b/front/src/components/Form/SelectField.tsx
@@ -32,14 +32,14 @@ function SelectField({
   fieldId,
   fieldLabel,
   placeholder,
-  showLabel,
-  showError,
+  showLabel = true,
+  showError = true,
   options,
   errors,
   control,
-  isMulti,
-  isRequired,
-  onChangeProp,
+  isMulti = false,
+  isRequired = true,
+  onChangeProp = undefined,
 }: ISelectFieldProps) {
   return (
     <FormControl isInvalid={!!errors[fieldId]} id={fieldId}>
@@ -105,13 +105,5 @@ function SelectField({
     </FormControl>
   );
 }
-
-SelectField.defaultProps = {
-  isMulti: false,
-  isRequired: true,
-  showLabel: true,
-  showError: true,
-  onChangeProp: undefined,
-};
 
 export default SelectField;

--- a/front/src/components/QrReader/components/QrReaderScanner.tsx
+++ b/front/src/components/QrReader/components/QrReaderScanner.tsx
@@ -39,10 +39,10 @@ const isMediaDevicesAPIAvailable = () => {
 
 export function QrReaderScanner({
   multiScan,
-  zoom,
-  facingMode,
+  zoom = 1,
+  facingMode = "environment",
   onResult,
-  scanPeriod: delayBetweenScanAttempts,
+  scanPeriod: delayBetweenScanAttempts = 500,
 }: QrReaderScannerProps) {
   // this ref is needed to pass/preview the video stream coming from BrowserQrCodeReader to the the user
   const previewVideoRef: MutableRefObject<HTMLVideoElement | null> = useRef<HTMLVideoElement>(null);
@@ -138,8 +138,3 @@ export function QrReaderScanner({
 }
 
 QrReaderScanner.displayName = "QrReader";
-QrReaderScanner.defaultProps = {
-  facingMode: "environment",
-  zoom: 1,
-  scanPeriod: 500,
-};

--- a/front/src/components/Table/Table.tsx
+++ b/front/src/components/Table/Table.tsx
@@ -45,7 +45,7 @@ interface IBasicTableProps {
   initialState?: IInitialState;
 }
 
-export function FilteringSortingTable({ columns, tableData, initialState }: IBasicTableProps) {
+export function FilteringSortingTable({ columns, tableData, initialState = {} }: IBasicTableProps) {
   // Add custom filter function to filter objects in a column
   // https://react-table-v7.tanstack.com/docs/examples/filtering
   const filterTypes = useMemo(
@@ -90,7 +90,3 @@ export function FilteringSortingTable({ columns, tableData, initialState }: IBas
     </TableContainer>
   );
 }
-
-FilteringSortingTable.defaultProps = {
-  initialState: {},
-};

--- a/front/src/views/Boxes/components/ActionButtons.tsx
+++ b/front/src/views/Boxes/components/ActionButtons.tsx
@@ -23,7 +23,13 @@ interface ISelectButtonProps {
   icon?: ReactElement;
 }
 
-export function SelectButton({ label, options, onSelect, isDisabled, icon }: ISelectButtonProps) {
+export function SelectButton({
+  label,
+  options,
+  onSelect,
+  isDisabled = false,
+  icon = undefined,
+}: ISelectButtonProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [isLargerThan768] = useMediaQuery("(min-width: 768px)");
   return (
@@ -62,8 +68,3 @@ export function SelectButton({ label, options, onSelect, isDisabled, icon }: ISe
     </Menu>
   );
 }
-
-SelectButton.defaultProps = {
-  icon: undefined,
-  isDisabled: false,
-};

--- a/shared-components/form/SelectField.tsx
+++ b/shared-components/form/SelectField.tsx
@@ -33,15 +33,15 @@ function SelectField({
   fieldId,
   fieldLabel,
   placeholder,
-  showLabel,
-  showError,
+  showLabel = true,
+  showError = true,
   options,
   errors,
   control,
-  isMulti,
-  isRequired,
-  defaultValue,
-  onChangeProp,
+  isMulti = false,
+  isRequired = true,
+  defaultValue = undefined,
+  onChangeProp = undefined,
 }: ISelectFieldProps) {
   return (
     <FormControl isInvalid={!!errors[fieldId]} id={fieldId}>
@@ -108,14 +108,5 @@ function SelectField({
     </FormControl>
   );
 }
-
-SelectField.defaultProps = {
-  isMulti: false,
-  isRequired: true,
-  showLabel: true,
-  showError: true,
-  onChangeProp: undefined,
-  defaultValue: undefined,
-};
 
 export default SelectField;

--- a/shared-components/statviz/components/NoDataCard.tsx
+++ b/shared-components/statviz/components/NoDataCard.tsx
@@ -5,7 +5,10 @@ interface INoDataCardProps {
   message?: string;
 }
 
-export default function NoDataCard({ header, message }: INoDataCardProps) {
+export default function NoDataCard({
+  header,
+  message = "No data for the selected time range or selected filters",
+}: INoDataCardProps) {
   return (
     <Card h="200px" w="300px">
       <CardHeader>
@@ -15,7 +18,3 @@ export default function NoDataCard({ header, message }: INoDataCardProps) {
     </Card>
   );
 }
-
-NoDataCard.defaultProps = {
-  message: "No data for the selected time range or selected filters",
-};

--- a/shared-components/statviz/components/VisHeader.tsx
+++ b/shared-components/statviz/components/VisHeader.tsx
@@ -63,7 +63,7 @@ export default function VisHeader({
   defaultWidth,
   defaultHeight,
   chartProps,
-  customIncludes,
+  customIncludes = [],
 }: IVisHeaderProps) {
   const [inputWidth, setInputWidth] = useState(defaultWidth);
   const [inputHeight, setInputHeight] = useState(defaultHeight);
@@ -233,7 +233,3 @@ export default function VisHeader({
     </CardHeader>
   );
 }
-
-VisHeader.defaultProps = {
-  customIncludes: [],
-};

--- a/shared-components/statviz/components/filter/MultiSelectFilter.tsx
+++ b/shared-components/statviz/components/filter/MultiSelectFilter.tsx
@@ -35,11 +35,11 @@ export const ValueFilterSchema = z.object({
 export default function MultiSelectFilter({
   values,
   filterId,
-  placeholder,
+  placeholder = undefined,
   filterValue,
-  fieldLabel,
+  fieldLabel = "display by",
   onFilterChange,
-  defaultFilterValues,
+  defaultFilterValues = undefined,
 }: IValueFilterProps) {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -78,9 +78,3 @@ export default function MultiSelectFilter({
     />
   );
 }
-
-MultiSelectFilter.defaultProps = {
-  defaultFilterValues: undefined,
-  fieldLabel: "display by",
-  placeholder: undefined,
-};

--- a/shared-components/statviz/components/filter/ValueFilter.tsx
+++ b/shared-components/statviz/components/filter/ValueFilter.tsx
@@ -32,9 +32,9 @@ export const ValueFilterSchema = z.object({
 export default function ValueFilter({
   values,
   filterId,
-  placeholder,
+  placeholder = undefined,
   onFilterChange,
-  defaultFilterValue,
+  defaultFilterValue = undefined,
 }: IValueFilterProps) {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -77,8 +77,3 @@ export default function ValueFilter({
     />
   );
 }
-
-ValueFilter.defaultProps = {
-  defaultFilterValue: undefined,
-  placeholder: undefined,
-};


### PR DESCRIPTION
React deprecated defaultProps back in 2019, and we're getting test warnings about it - https://github.com/facebook/react/pull/16210. This switches them to use JS default props instead.