### PR TITLE
Include full apollo error messages when running tests

### DIFF
--- a/front/src/tests/setupTests.ts
+++ b/front/src/tests/setupTests.ts
@@ -9,9 +9,16 @@ import "regenerator-runtime/runtime";
 import { useErrorHandling } from "hooks/useErrorHandling";
 import { useNotification } from "hooks/useNotification";
 
+import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
+
 // -------- Apollo cache
 // extracting a cacheObject to reset the cache correctly later
 const emptyCache = cache.extract();
+// Adds full apollo error messages in a dev environment
+// so we get meaningful error messages rather than encoded
+// url - https://www.apollographql.com/docs/react/errors/
+loadDevMessages();
+loadErrorMessages();
 
 // -------- Mocking Toasts
 // Toasts are persisting throughout the tests since they are rendered in the wrapper and not in the render-function.
@@ -32,9 +39,12 @@ mockedUseNotification.mockReturnValue({ createToast: mockedCreateToast });
 
 // This is needed to mock the `navigator.mediaDevices.getUserMedia` function,
 // used to ask users for camera permissions in order to scan QR codes.
-const mockGetUserMedia = vi.fn(async () => new Promise<void>(resolve => {
-  resolve()
-}))
+const mockGetUserMedia = vi.fn(
+  async () =>
+    new Promise<void>((resolve) => {
+      resolve();
+    }),
+);
 
 Object.defineProperty(navigator, "mediaDevices", {
   value: {
@@ -46,7 +56,7 @@ Object.defineProperty(navigator, "mediaDevices", {
 // Mock the `navigator.userAgent` property to check for iOS browsers.
 Object.defineProperty(navigator, "userAgent", {
   get() {
-    return "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
+    return "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0";
   },
   // configurable: true
 });


### PR DESCRIPTION
So we get meaningful errors in test console output like this:

`Missing field 'requestedOn' while writing result { "__typename": "TransferAgreement", "comment": "", "id": "1", "requestedBy": { "__typename": "User", "id": "1", "name": "some admin" }, "shipments": [], "targetBases": [ { "__typename": "Base", "id": "2", "name": "Thessaloniki" }, { "__typename": "Base", "id": "3", "name": "Samos" }, { "__typename": "Base", "id": "4", "name": "Athens" } ], "targetOrganisation": { "__typename": "Organisation", "id": "2", "name": "BoxCare" }, "state": "Accepted", "sourceBases": [ { "__typename": "Base", "id": "1", "name": "Lesvos" } ], "sourceOrganisation": { "__typename": "Organisation", "id": "1", "name": "BoxAid" }, "type": "SendingTo", "validFrom": "2023-01-26T00:00:00+00:00", "validUntil": null }`

as opposed to 

`https://www.apollographql.com/docs/react/errors#%7B%22version%22%3A%223.11.8%22%2C%22message%22%3A12%2C%22args%22%3A%5B%22requestedOn%22%2C%22%7B%5Cn%20%20%5C%22__typename%5C%22%3A%20%5C%22TransferAgreement%5C%22%2C%5Cn%20%20%5C%22comment%5C%22%3A%20%5C%22%5C%22%2C%5Cn%20%20%5C%22id%5C%22%3A%20%5C%221%5C%22%2C%5Cn%20%20%5C%22requestedBy%5C%22%3A%20%7B%5Cn%20%20%20%20%5C%22__typename%5C%22%3A%20%5C%22User%5C%22%2C%5Cn%20%20%20%20%5C%22id%5C%22%3A%20%5C%221%5C%22%2C%5Cn%20%20%20%20%5C%22name%5C%22%3A%20%5C%22some%20admin%5C%22%5Cn%20%20%7D%2C%5Cn%20%20%5C%22shipments%5C%22%3A%20%5B%5D%2C%5Cn%20%20%5C%22targetBases%5C%22%3A%20%5B%5Cn%20%20%20%20%7B%5Cn%20%20%20%20%20%20%5C%22__typename%5C%22%3A%20%5C%22Base%5C%22%2C%5Cn%20%20%20%20%20%20%5C%22id%5C%22%3A%20%5C%222%5C%22%2C%5Cn%20%20%20%20%20%20%5C%22name%5C%22%3A%20%5C%22Thessaloniki%5C%22%5Cn%20%20%20%20%7D%2C%5Cn%20%20%20%20%7B%5Cn%20%20%20%20%20%20%5C%22__typename%5C%22%3A%20%5C%22Base%5C%22%2C%5Cn%20%20%20%20%20%20%5C%22id%5C%22%3A%20%5C%223%5C%22%2C%5Cn%20%20%20%20%20%20%5C%22name%5C%22%3A%20%5C%22Samos%5C%22%5Cn%20%20%20%20%7D%2C%5Cn%20%20%20%20%7B%5Cn%20%20%20%20%20%20%5C%22__typename%5C%22%3A%20%5C%22Base%5C%22%2C%5Cn%20%20%20%20%20%20%5C%22id%5C%22%3A%20%5C%224%5C%22%2C%5Cn%20%20%20%20%20%20%5C%22name%5C%22%3A%20%5C%22Athens%5C%22%5Cn%20%20%20%20%7D%5Cn%20%20%5D%2C%5Cn%20%20%5C%22targetOrganisation%5C%22%3A%20%7B%5Cn%20%20%20%20%5C%22__typename%5C%22%3A%20%5C%22Organisation%5C%22%2C%5Cn%20%20%20%20%5C%22id%5C%22%3A%20%5C%222%5C%22%2C%5Cn%20%20%20%20%5C%22name%5C%22%3A%20%5C%22BoxCare%5C%22%5Cn%20%20%7D%2C%5Cn%20%20%5C%22state%5C%22%3A%20%5C%22Accepted%5C%22%2C%5Cn%20%20%5C%22sourceBases%5C%22%3A%20%5B%5Cn%20%20%20%20%7B%5Cn%20%20%20%20%20%20%5C%22__typename%5C%22%3A%20%5C%22Base%5C%22%2C%5Cn%20%20%20%20%20%20%5C%22id%5C%22%3A%20%5C%221%5C%22%2C%5Cn%20%20%20%20%20%20%5C%22name%5C%22%3A%20%5C%22Lesvos%5C%22%5Cn%20%20%20%20%7D%5Cn%20%20%5D%2C%5Cn%20%20%5C%22sourceOrganisation%5C%22%3A%20%7B%5Cn%20%20%20%20%5C%22__typename%5C%22%3A%20%5C%22Organisation%5C%22%2C%5Cn%20%20%20%20%5C%22id%5C%22%3A%20%5C%221%5C%22%2C%5Cn%20%20%20%20%5C%22name%5C%22%3A%20%5C%22BoxAid%5C%22%5Cn%20%20%7D%2C%5Cn%20%20%5C%22type%5C%22%3A%20%5C%22SendingTo%5C%22%2C%5Cn%20%20%5C%22validFrom%5C%22%3A%20%5C%222023-01-26T00%3A00%3A00%2B00%3A00%5C%22%2C%5Cn%20%20%5C%22validUntil%5C%22%3A%20null%5Cn%7D%22%5D%7D`