### PR TITLE
Remove unnecessary use of act()

### DIFF
--- a/front/src/components/QrReaderOverlay/QrReaderOverlay.test.tsx
+++ b/front/src/components/QrReaderOverlay/QrReaderOverlay.test.tsx
@@ -1,7 +1,7 @@
 import { vi, beforeEach, it, expect } from "vitest";
 import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
-import { screen, render, act, waitFor } from "tests/test-utils";
+import { screen, render, waitFor } from "tests/test-utils";
 import HeaderMenuContainer from "components/HeaderMenu/HeaderMenuContainer";
 import { useAuth0 } from "@auth0/auth0-react";
 import { QrReaderScanner } from "components/QrReader/components/QrReaderScanner";
@@ -51,18 +51,12 @@ it("3.4.1.2 - Mobile: Enter invalid box identifier and click on Find button", as
 
   // 3.4.1.1 - Open QROverlay
   const qrButton = await screen.findByTestId("qr-code-button");
-  await act(async () => {
-    await user.click(qrButton);
-  });
+  await user.click(qrButton);
 
   // Find Box
   const findBoxButton = await screen.findByRole("button", { name: /find/i });
-  await act(async () => {
-    await user.type(screen.getByRole("textbox"), "123456");
-  });
-  await act(async () => {
-    await user.click(findBoxButton);
-  });
+  await user.type(screen.getByRole("textbox"), "123456");
+  await user.click(findBoxButton);
 
   // error message appears
   await waitFor(() =>
@@ -103,9 +97,7 @@ it("3.4.1.3 - Mobile: Enter valid box identifier and click on Find button", asyn
 
   // 3.4.1.1 - Open QROverlay
   const qrButton = await screen.findByTestId("qr-code-button");
-  await act(async () => {
-    await user.click(qrButton);
-  });
+  await user.click(qrButton);
 
   // Find Box
   const findBoxButton = await screen.findByRole("button", { name: /find/i });

--- a/front/src/tests/helpers.ts
+++ b/front/src/tests/helpers.ts
@@ -1,5 +1,5 @@
 import { expect } from "vitest";
-import { act, screen, waitFor } from "tests/test-utils";
+import { screen, waitFor } from "tests/test-utils";
 import { userEvent } from "@testing-library/user-event";
 
 type UserEvent = ReturnType<typeof userEvent.setup>;
@@ -18,18 +18,14 @@ export async function assertOptionsInSelectField(
   subHeadings.forEach((subHeading) => {
     expect(screen.queryByText(subHeading)).not.toBeInTheDocument();
   });
-  await act(async () => {
-    await user.click(fieldControlInput);
-  });
+  await user.click(fieldControlInput);
   options.forEach(async (option) => {
     expect(await screen.findByRole("option", { name: option })).toBeInTheDocument();
   });
   subHeadings.forEach((subHeading) => {
     expect(screen.getByText(subHeading)).toBeInTheDocument();
   });
-  await act(async () => {
-    await user.click(elementOutside);
-  });
+  await user.click(elementOutside);
   options.forEach(async (option) => {
     await waitFor(() => {
       expect(screen.queryByText(option)).not.toBeInTheDocument();

--- a/front/src/views/QrReader/QrReaderMultiBox.test.tsx
+++ b/front/src/views/QrReader/QrReaderMultiBox.test.tsx
@@ -1,7 +1,7 @@
 import { vi, beforeEach, it, expect } from "vitest";
 import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
-import { screen, render, waitFor, act } from "tests/test-utils";
+import { screen, render, waitFor } from "tests/test-utils";
 import { useAuth0 } from "@auth0/auth0-react";
 import { QrReaderScanner } from "components/QrReader/components/QrReaderScanner";
 import { mockAuthenticatedUser } from "mocks/hooks";
@@ -108,9 +108,7 @@ qrScanningInMultiBoxTabTests.forEach(({ name, hash, mocks, boxCount, toasts }) =
     // go to the MultiBox Tab
     const multiBoxTab = await screen.findByRole("tab", { name: /multi box/i });
     expect(multiBoxTab).toBeInTheDocument();
-    await act(async () => {
-      await user.click(multiBoxTab);
-    });
+    await user.click(multiBoxTab);
 
     // 3.4.3.1 - no QR-codes were successfully scanned yet.
     const boxesSelectedStatus = await screen.findByText(/boxes selected: 0/i);
@@ -122,9 +120,7 @@ qrScanningInMultiBoxTabTests.forEach(({ name, hash, mocks, boxCount, toasts }) =
 
     // Click a button to trigger the event of scanning a QR-Code in mockImplementationOfQrReader
     const scanButton = await screen.findByTestId("ReturnScannedQr");
-    await act(async () => {
-      await user.click(scanButton);
-    });
+    await user.click(scanButton);
 
     // toast shown
     await waitFor(() =>
@@ -137,9 +133,7 @@ qrScanningInMultiBoxTabTests.forEach(({ name, hash, mocks, boxCount, toasts }) =
 
     // second scan?
     if (toasts.length === 2) {
-      await act(async () => {
-        await user.click(scanButton);
-      });
+      await user.click(scanButton);
       // toast shown
       await waitFor(() =>
         expect(toasts[1].isError ? mockedTriggerError : mockedCreateToast).toHaveBeenCalledWith(
@@ -162,9 +156,7 @@ qrScanningInMultiBoxTabTests.forEach(({ name, hash, mocks, boxCount, toasts }) =
       expect(deleteScannedBoxesButton).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /undo last scan/i })).toBeInTheDocument();
       // 3.4.4.1 - Pressing the delete button
-      await act(async () => {
-        await user.click(deleteScannedBoxesButton);
-      });
+      await user.click(deleteScannedBoxesButton);
       expect(await screen.findByText(/boxes selected: 0/i)).toBeInTheDocument();
     }
   });
@@ -275,9 +267,7 @@ qrScanningInMultiBoxTabTestsFailing.forEach(({ name, hash, isBoxtributeQr, mocks
     // go to the MultiBox Tab
     const multiBoxTab = await screen.findByRole("tab", { name: /multi box/i });
     expect(multiBoxTab).toBeInTheDocument();
-    await act(async () => {
-      await user.click(multiBoxTab);
-    });
+    await user.click(multiBoxTab);
 
     // 3.4.3.1 - no QR-codes were successfully scanned yet.
     const boxesSelectedStatus = await screen.findByText(/boxes selected: 0/i);
@@ -289,9 +279,7 @@ qrScanningInMultiBoxTabTestsFailing.forEach(({ name, hash, isBoxtributeQr, mocks
 
     // Click a button to trigger the event of scanning a QR-Code in mockImplementationOfQrReader
     const scanButton = await screen.findByTestId("ReturnScannedQr");
-    await act(async () => {
-      await user.click(scanButton);
-    });
+    await user.click(scanButton);
 
     // toast shown
     await waitFor(() =>


### PR DESCRIPTION
These were causing `Warning: The current testing environment is not configured to support act(...)` errors in the test console output. The react testing library handles act() automatically and so these are not necessary.