### PR TITLE
Stop logging expected GraphQL errors in test output

### DIFF
--- a/front/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.test.tsx
+++ b/front/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.test.tsx
@@ -6,7 +6,6 @@ import { mockAuthenticatedUser } from "mocks/hooks";
 import { generateMockShipment } from "mocks/shipments";
 import { ShipmentState } from "types/generated/graphql";
 import { organisation1 } from "mocks/organisations";
-import { GraphQLError } from "graphql";
 import { cache, boxReconciliationOverlayVar, IBoxReconciliationOverlayVar } from "queries/cache";
 import { generateMockLocationWithBase } from "mocks/locations";
 import { products } from "mocks/products";
@@ -15,6 +14,7 @@ import { userEvent } from "@testing-library/user-event";
 import { SHIPMENT_BY_ID_WITH_PRODUCTS_AND_LOCATIONS_QUERY } from "queries/queries";
 import { UPDATE_SHIPMENT_WHEN_RECEIVING } from "queries/mutations";
 import { mockedCreateToast, mockedTriggerError } from "tests/setupTests";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 vi.mock("@auth0/auth0-react");
 // @ts-ignore
@@ -57,7 +57,7 @@ const failedQueryShipmentDetailForBoxReconciliation = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 
@@ -115,9 +115,9 @@ const mockUpdateShipmentWhenReceivingMutation = ({
           : {
               updateShipmentWhenReceiving: generateMockShipment({ state: ShipmentState.Receiving }),
             },
-        errors: graphQlError ? [new GraphQLError("Error!")] : undefined,
+        errors: graphQlError ? [new FakeGraphQLError()] : undefined,
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 const noDeliveryTests = [

--- a/front/src/components/QrReaderOverlay/QrReaderOverlay.test.tsx
+++ b/front/src/components/QrReaderOverlay/QrReaderOverlay.test.tsx
@@ -1,5 +1,4 @@
 import { vi, beforeEach, it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
 import { screen, render, act, waitFor } from "tests/test-utils";
 import HeaderMenuContainer from "components/HeaderMenu/HeaderMenuContainer";
@@ -13,6 +12,7 @@ import {
 } from "queries/queries";
 import { generateMockBox } from "mocks/boxes";
 import { mockedTriggerError } from "tests/setupTests";
+import { FakeGraphQLError } from "mocks/functions";
 
 vi.mock("@auth0/auth0-react");
 vi.mock("components/QrReader/components/QrReaderScanner");
@@ -34,7 +34,7 @@ const queryFindNoBoxAssociated = {
     data: {
       box: null,
     },
-    errors: [new GraphQLError("Error!", { extensions: { code: "BAD_USER_INPUT" } })],
+    errors: [new FakeGraphQLError("BAD_USER_INPUT")],
   },
 };
 
@@ -127,7 +127,7 @@ const queryFindBoxFromOtherOrg = {
     data: {
       box: null,
     },
-    errors: [new GraphQLError("Error!", { extensions: { code: "FORBIDDEN" } })],
+    errors: [new FakeGraphQLError("FORBIDDEN")],
   },
 };
 
@@ -254,7 +254,7 @@ const queryBoxFromOtherOrganisation = {
         box: null,
       },
     },
-    errors: [new GraphQLError("Error!", { extensions: { code: "FORBIDDEN" } })],
+    errors: [new FakeGraphQLError("FORBIDDEN")],
   },
 };
 
@@ -325,7 +325,7 @@ const queryHashNotInDb = {
   },
   result: {
     data: null,
-    errors: [new GraphQLError("Error!", { extensions: { code: "BAD_USER_INPUT" } })],
+    errors: [new FakeGraphQLError("BAD_USER_INPUT")],
   },
 };
 
@@ -368,7 +368,7 @@ const queryInternalServerError = {
   },
   result: {
     data: null,
-    errors: [new GraphQLError("Error!", { extensions: { code: "INTERNAL_SERVER_ERROR" } })],
+    errors: [new FakeGraphQLError("INTERNAL_SERVER_ERROR")],
   },
 };
 

--- a/front/src/mocks/functions.ts
+++ b/front/src/mocks/functions.ts
@@ -20,14 +20,28 @@ export function mockMatchMediaQuery(returnBool: Boolean) {
   });
 }
 
-// mock an Apollo GraphQLError
+export class FakeGraphQLError extends GraphQLError {
+  constructor(errorCode?: string, errorDescription?: string) {
+    super(
+      "Fake GraphQL Error",
+      errorCode ? { extensions: { code: errorCode, description: errorDescription } } : undefined,
+    );
+  }
+}
+
+export class FakeGraphQLNetworkError extends Error {
+  constructor() {
+    super("Fake GraphQL Network Error");
+  }
+}
+
 export const mockGraphQLError = (query, variables = {}) => ({
   request: {
     query,
     variables,
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 });
 
@@ -37,5 +51,5 @@ export const mockNetworkError = (query, variables = {}) => ({
     query,
     variables,
   },
-  error: new Error(),
+  error: new FakeGraphQLNetworkError(),
 });

--- a/front/src/views/Box/BoxView.test.tsx
+++ b/front/src/views/Box/BoxView.test.tsx
@@ -1,5 +1,4 @@
 import { vi, beforeEach, it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { screen, render, waitFor } from "tests/test-utils";
 import { userEvent } from "@testing-library/user-event";
 import { cache } from "queries/cache";
@@ -10,7 +9,7 @@ import { product1, product3, products } from "mocks/products";
 import { BOX_BY_LABEL_IDENTIFIER_AND_ALL_PRODUCTS_WITH_BASEID_QUERY } from "views/BoxEdit/BoxEditView";
 import { tags } from "mocks/tags";
 import { textContentMatcher } from "tests/helpers";
-import { mockMatchMediaQuery } from "mocks/functions";
+import { FakeGraphQLError, FakeGraphQLNetworkError, mockMatchMediaQuery } from "mocks/functions";
 import { BOX_BY_LABEL_IDENTIFIER_AND_ALL_SHIPMENTS_QUERY } from "queries/queries";
 import { organisation1 } from "mocks/organisations";
 import { mockedCreateToast, mockedTriggerError } from "tests/setupTests";
@@ -280,7 +279,7 @@ const initialFailedQuery = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 
@@ -323,7 +322,7 @@ const updateNumberOfItemsFailedMutation = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 
@@ -336,7 +335,7 @@ const moveLocationOfBoxFailedMutation = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 
@@ -348,7 +347,7 @@ const moveLocationOfBoxNetworkFailedMutation = {
       newLocationId: 10,
     },
   },
-  error: new Error(),
+  error: new FakeGraphQLNetworkError(),
 };
 
 beforeEach(() => {

--- a/front/src/views/BoxEdit/BoxEditView.test.tsx
+++ b/front/src/views/BoxEdit/BoxEditView.test.tsx
@@ -1,5 +1,4 @@
 import { it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
 import { screen, render, waitFor } from "tests/test-utils";
 import { assertOptionsInSelectField, selectOptionInSelectField } from "tests/helpers";
@@ -13,6 +12,7 @@ import BoxEditView, {
   BOX_BY_LABEL_IDENTIFIER_AND_ALL_PRODUCTS_WITH_BASEID_QUERY,
   UPDATE_CONTENT_OF_BOX_MUTATION,
 } from "./BoxEditView";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 const initialQuery = {
   request: {
@@ -43,7 +43,7 @@ const initialQueryNetworkError = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 
@@ -55,7 +55,7 @@ const initialQueryGraphQLError = {
       labelIdentifier: "123",
     },
   },
-  error: new Error(),
+  error: new FakeGraphQLNetworkError(),
 };
 
 const successfulMutation = {
@@ -107,7 +107,7 @@ const mutationNetworkError = {
       comment: "Test",
     },
   },
-  error: new Error(),
+  error: new FakeGraphQLNetworkError(),
 };
 
 const mutationGraphQLError = {
@@ -124,7 +124,7 @@ const mutationGraphQLError = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 

--- a/front/src/views/Boxes/BoxesView.test.tsx
+++ b/front/src/views/Boxes/BoxesView.test.tsx
@@ -1,5 +1,4 @@
 import { vi, it, describe, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
 import { base2 } from "mocks/bases";
 import { organisation1, organisation2 } from "mocks/organisations";
@@ -11,6 +10,7 @@ import { TableSkeleton } from "components/Skeletons";
 import { Suspense } from "react";
 import { cache } from "queries/cache";
 import Boxes, { ACTION_OPTIONS_FOR_BOXESVIEW_QUERY, BOXES_FOR_BOXESVIEW_QUERY } from "./BoxesView";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 const boxesQuery = {
   request: {
@@ -400,7 +400,7 @@ const initialQueryNetworkError = {
     },
   },
 
-  error: new Error(),
+  error: new FakeGraphQLNetworkError(),
 };
 
 const initialQueryGraphQLError = {
@@ -417,7 +417,7 @@ const initialQueryGraphQLError = {
     data: {
       boxes: null,
     },
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 

--- a/front/src/views/Boxes/BoxesViewActions.test.tsx
+++ b/front/src/views/Boxes/BoxesViewActions.test.tsx
@@ -10,7 +10,6 @@ import { cache, tableConfigsVar } from "queries/cache";
 import { render, screen, waitFor } from "tests/test-utils";
 import { userEvent } from "@testing-library/user-event";
 import { ASSIGN_BOXES_TO_SHIPMENT } from "hooks/useAssignBoxesToShipment";
-import { GraphQLError } from "graphql";
 import { gql } from "@apollo/client";
 import { AlertWithoutAction } from "components/Alerts";
 import { TableSkeleton } from "components/Skeletons";
@@ -18,6 +17,7 @@ import { Suspense } from "react";
 import { ErrorBoundary } from "@sentry/react";
 import { mockedCreateToast } from "tests/setupTests";
 import Boxes, { ACTION_OPTIONS_FOR_BOXESVIEW_QUERY, BOXES_FOR_BOXESVIEW_QUERY } from "./BoxesView";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 const boxesQuery = ({
   state = BoxState.InStock,
@@ -92,9 +92,9 @@ const mutation = ({
     ? undefined
     : {
         data: graphQlError ? null : resultData,
-        errors: graphQlError ? [new GraphQLError("Error!")] : undefined,
+        errors: graphQlError ? [new FakeGraphQLError()] : undefined,
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 vi.mock("@auth0/auth0-react");

--- a/front/src/views/QrReader/QrReaderMultiBox.test.tsx
+++ b/front/src/views/QrReader/QrReaderMultiBox.test.tsx
@@ -1,5 +1,4 @@
 import { vi, beforeEach, it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
 import { screen, render, waitFor, act } from "tests/test-utils";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -16,6 +15,7 @@ import { cache } from "queries/cache";
 import { locations } from "mocks/locations";
 import { mockedCreateToast, mockedTriggerError } from "tests/setupTests";
 import QrReaderView from "./QrReaderView";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 const mockSuccessfulQrQuery = ({
   query = GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE,
@@ -194,9 +194,9 @@ const mockFailedQrQuery = ({
                 },
               }
             : null,
-        errors: [new GraphQLError("Error!", { extensions: { code: errorCode } })],
+        errors: [new FakeGraphQLError(errorCode)],
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 const qrScanningInMultiBoxTabTestsFailing = [

--- a/front/src/views/QrReader/QrReaderMultiBoxAssignTags.test.tsx
+++ b/front/src/views/QrReader/QrReaderMultiBoxAssignTags.test.tsx
@@ -1,5 +1,4 @@
 import { vi, beforeEach, it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
 import { screen, render, waitFor } from "tests/test-utils";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -20,6 +19,7 @@ import { generateAssignTagsRequest } from "queries/dynamic-mutations";
 import { tagsArray } from "mocks/tags";
 import { mockedCreateToast, mockedTriggerError } from "tests/setupTests";
 import QrReaderView from "./QrReaderView";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 const mockSuccessfulQrQuery = ({
   query = GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE,
@@ -62,9 +62,9 @@ const mockTagsQuery = ({
               ],
               base: { locations, tags: tagsArray },
             },
-        errors: graphQlError ? [new GraphQLError("Error!")] : undefined,
+        errors: graphQlError ? [new FakeGraphQLError()] : undefined,
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 const generateAssignTagsResponse = ({ labelIdentifiers, newTagId, failLabelIdentifier }) => {
@@ -107,9 +107,9 @@ const mockAssignTagsMutation = ({
               newTagId,
               failLabelIdentifier,
             }),
-        errors: graphQlError ? [new GraphQLError("Error!")] : undefined,
+        errors: graphQlError ? [new FakeGraphQLError()] : undefined,
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 vi.mock("@auth0/auth0-react");

--- a/front/src/views/QrReader/QrReaderMultiBoxAssignToShipment.test.tsx
+++ b/front/src/views/QrReader/QrReaderMultiBoxAssignToShipment.test.tsx
@@ -1,5 +1,4 @@
 import { vi, beforeEach, it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
 import { screen, render, waitFor } from "tests/test-utils";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -20,6 +19,7 @@ import { tags } from "mocks/tags";
 import { selectOptionInSelectField } from "tests/helpers";
 import { mockedCreateToast, mockedTriggerError } from "tests/setupTests";
 import QrReaderView from "./QrReaderView";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 const mockSuccessfulQrQuery = ({
   query = GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE,
@@ -62,9 +62,9 @@ const mockShipmentsQuery = ({
               shipments: [generateMockShipmentMinimal({ state, iAmSource })],
               base: { locations, tags },
             },
-        errors: graphQlError ? [new GraphQLError("Error!")] : undefined,
+        errors: graphQlError ? [new FakeGraphQLError()] : undefined,
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 const mockAssignToShipmentMutation = ({
@@ -84,11 +84,9 @@ const mockAssignToShipmentMutation = ({
     ? undefined
     : {
         data: graphQlError ? null : { updateShipmentWhenPreparing: generateMockShipment({}) },
-        errors: graphQlError
-          ? [new GraphQLError("Error!", { extensions: { code: errorCode } })]
-          : undefined,
+        errors: graphQlError ? [new FakeGraphQLError(errorCode)] : undefined,
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 vi.mock("@auth0/auth0-react");

--- a/front/src/views/QrReader/QrReaderMultiBoxMoveBox.test.tsx
+++ b/front/src/views/QrReader/QrReaderMultiBoxMoveBox.test.tsx
@@ -1,5 +1,4 @@
 import { vi, beforeEach, it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { userEvent } from "@testing-library/user-event";
 import { screen, render, waitFor } from "tests/test-utils";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -20,6 +19,7 @@ import { generateMoveBoxRequest } from "queries/dynamic-mutations";
 import { tags } from "mocks/tags";
 import { mockedCreateToast, mockedTriggerError } from "tests/setupTests";
 import QrReaderView from "./QrReaderView";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 const mockSuccessfulQrQuery = ({
   query = GET_BOX_LABEL_IDENTIFIER_BY_QR_CODE,
@@ -62,9 +62,9 @@ const mockLocationsQuery = ({
               ],
               base: { locations, tags },
             },
-        errors: graphQlError ? [new GraphQLError("Error!")] : undefined,
+        errors: graphQlError ? [new FakeGraphQLError()] : undefined,
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 const generateMoveBoxesResponse = ({
@@ -113,9 +113,9 @@ const mockMoveBoxesMutation = ({
               newBoxState,
               failLabelIdentifier,
             }),
-        errors: graphQlError ? [new GraphQLError("Error!")] : undefined,
+        errors: graphQlError ? [new FakeGraphQLError()] : undefined,
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 vi.mock("@auth0/auth0-react");

--- a/front/src/views/QrReader/components/ResolveHash.test.tsx
+++ b/front/src/views/QrReader/components/ResolveHash.test.tsx
@@ -1,7 +1,6 @@
 import { vi, beforeEach, it, expect } from "vitest";
 import { useAuth0 } from "@auth0/auth0-react";
 import { QrReaderScanner } from "components/QrReader/components/QrReaderScanner";
-import { GraphQLError } from "graphql";
 import { generateMockBox } from "mocks/boxes";
 import { mockImplementationOfQrReader } from "mocks/components";
 import { mockAuthenticatedUser } from "mocks/hooks";
@@ -11,6 +10,7 @@ import { BoxState } from "types/generated/graphql";
 import { render, screen, waitFor } from "tests/test-utils";
 import { mockedTriggerError } from "tests/setupTests";
 import ResolveHash from "./ResolveHash";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 vi.mock("@auth0/auth0-react");
 vi.mock("components/QrReader/components/QrReaderScanner");
@@ -90,9 +90,9 @@ const mockFailedQrQuery = ({
     ? undefined
     : {
         data: null,
-        errors: [new GraphQLError("Error!", { extensions: { code: errorCode } })],
+        errors: [new FakeGraphQLError(errorCode)],
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 const FailedQrScanningTests = [

--- a/front/src/views/Transfers/CreateShipment/CreateShipmentView.test.tsx
+++ b/front/src/views/Transfers/CreateShipment/CreateShipmentView.test.tsx
@@ -4,7 +4,6 @@ import { organisation1 } from "mocks/organisations";
 import { acceptedTransferAgreement } from "mocks/transferAgreements";
 import { userEvent } from "@testing-library/user-event";
 import { assertOptionsInSelectField, selectOptionInSelectField } from "tests/helpers";
-import { GraphQLError } from "graphql";
 import { base1 } from "mocks/bases";
 import { ShipmentState } from "types/generated/graphql";
 import { generateMockShipment } from "mocks/shipments";
@@ -16,6 +15,7 @@ import CreateShipmentView, {
   CREATE_SHIPMENT_MUTATION,
 } from "./CreateShipmentView";
 import { SHIPMENT_BY_ID_QUERY } from "../ShipmentView/ShipmentView";
+import { FakeGraphQLError } from "mocks/functions";
 
 vi.setConfig({ testTimeout: 12_000 });
 
@@ -88,7 +88,7 @@ const initialQueryNetworkError = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 
@@ -132,7 +132,7 @@ const mutationGraphQLError = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 

--- a/front/src/views/Transfers/CreateTransferAgreement/CreateTransferAgreementView.test.tsx
+++ b/front/src/views/Transfers/CreateTransferAgreement/CreateTransferAgreementView.test.tsx
@@ -1,5 +1,4 @@
 import { vi, it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import { screen, render, cleanup, fireEvent, waitFor } from "tests/test-utils";
 import { userEvent } from "@testing-library/user-event";
 import { organisation1, organisations } from "mocks/organisations";
@@ -12,6 +11,7 @@ import CreateTransferAgreementView, {
   ALL_ORGS_AND_BASES_QUERY,
   CREATE_AGREEMENT_MUTATION,
 } from "./CreateTransferAgreementView";
+import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
 
 const initialQuery = {
   request: {
@@ -31,7 +31,7 @@ const initialQueryNetworkError = {
     variables: {},
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 
@@ -72,7 +72,7 @@ const mutationNetworkError = {
       comment: "",
     },
   },
-  error: new Error(),
+  error: new FakeGraphQLNetworkError(),
 };
 
 const mutationIdenticalAgreementError = {
@@ -91,14 +91,7 @@ const mutationIdenticalAgreementError = {
   },
   result: {
     data: { createTransferAgreement: null },
-    errors: [
-      new GraphQLError("Error!", {
-        extensions: {
-          code: "BAD_USER_INPUT",
-          description: "An identical agreement already exists: ID 1",
-        },
-      }),
-    ],
+    errors: [new FakeGraphQLError("BAD_USER_INPUT", "An identical agreement already exists: ID 1")],
   },
 };
 

--- a/front/src/views/Transfers/ShipmentView/ShipmentView.test.tsx
+++ b/front/src/views/Transfers/ShipmentView/ShipmentView.test.tsx
@@ -1,12 +1,11 @@
 import { vi, beforeEach, it, describe, expect } from "vitest";
 import { screen, render, waitFor } from "tests/test-utils";
 import { organisation1 } from "mocks/organisations";
-import { GraphQLError } from "graphql";
 import { generateMockShipment, generateMockShipmentWithCustomDetails } from "mocks/shipments";
 import { generateMockBox } from "mocks/boxes";
 import { BoxState, ShipmentState } from "types/generated/graphql";
 import { userEvent } from "@testing-library/user-event";
-import { mockMatchMediaQuery } from "mocks/functions";
+import { FakeGraphQLError, mockMatchMediaQuery } from "mocks/functions";
 import { generateMockShipmentDetail } from "mocks/shipmentDetail";
 import ShipmentView, { SHIPMENT_BY_ID_QUERY } from "./ShipmentView";
 
@@ -103,7 +102,7 @@ const initialQueryNetworkError = {
     },
   },
   result: {
-    errors: [new GraphQLError("Error!")],
+    errors: [new FakeGraphQLError()],
   },
 };
 

--- a/shared-components/statviz/components/visualizations/movedBoxes/MovedBoxes.test.tsx
+++ b/shared-components/statviz/components/visualizations/movedBoxes/MovedBoxes.test.tsx
@@ -1,7 +1,22 @@
 import { it, expect } from "vitest";
-import { GraphQLError } from "graphql";
 import MovedBoxesDataContainer, { MOVED_BOXES_QUERY } from "./MovedBoxesDataContainer";
 import { render, screen } from "../../../../tests/testUtils";
+import { GraphQLError } from "graphql";
+
+export class FakeGraphQLError extends GraphQLError {
+  constructor(errorCode?: string, errorDescription?: string) {
+    super(
+      "Fake GraphQL Error",
+      errorCode ? { extensions: { code: errorCode, description: errorDescription } } : undefined,
+    );
+  }
+}
+
+export class FakeGraphQLNetworkError extends Error {
+  constructor() {
+    super("Fake GraphQL Network Error");
+  }
+}
 
 const mockFailedMovedBoxesQuery = ({ baseId = "1", networkError = false }) => ({
   request: {
@@ -12,9 +27,9 @@ const mockFailedMovedBoxesQuery = ({ baseId = "1", networkError = false }) => ({
     ? undefined
     : {
         data: null,
-        errors: [new GraphQLError("Error!")],
+        errors: [new FakeGraphQLError()],
       },
-  error: networkError ? new Error() : undefined,
+  error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
 
 const movedBoxesDataTests = [


### PR DESCRIPTION
The current test set up intercepts GraphQL errors to print them as output. This is useful, as they warn about missing mock data and other errors. However, these messages are mixed up in 'expected' failures that we've set up in the tests themselves. 

This PR switches to separate classes for our fake errors so we can exclude them from the console output.