### PR TITLE
Implement tracking of filter values

### DIFF
--- a/shared-components/statviz/components/filter/TimeRangeSelect.tsx
+++ b/shared-components/statviz/components/filter/TimeRangeSelect.tsx
@@ -64,9 +64,9 @@ export default function TimeRangeSelect() {
     if (toFormValue && new Date(toFormValue) !== to) {
       searchParams.delete("to");
       const newToDate = date2String(new Date(toFormValue));
-      const stringifiedForm = date2String(from);
+      const stringifiedFrom = date2String(from);
       searchParams.append("to", newToDate);
-      trackFilter({ filterId: "timeRange", newToDate, stringifiedForm });
+      trackFilter({ filterId: "timeRange", newToDate, stringifiedFrom });
     }
 
     if (fromFormValue && new Date(fromFormValue) !== from) {

--- a/shared-components/statviz/components/filter/TimeRangeSelect.tsx
+++ b/shared-components/statviz/components/filter/TimeRangeSelect.tsx
@@ -50,33 +50,32 @@ export default function TimeRangeSelect() {
     if (!searchParams.get("to")) {
       searchParams.append("to", date2String(new Date()));
     }
-    const from = new Date(searchParams.get("from")!);
-    const to = new Date(searchParams.get("to")!);
+    const from = searchParams.get("from")!;
+    const to = searchParams.get("to")!;
 
     if (toFormValue === undefined) {
-      setValue("to", date2String(to));
+      setValue("to", to);
     }
 
     if (fromFormValue === undefined) {
-      setValue("from", date2String(from));
+      setValue("from", from);
     }
 
-    if (toFormValue && new Date(toFormValue) !== to) {
+    if (toFormValue && date2String(new Date(toFormValue)) !== to) {
       searchParams.delete("to");
       const newToDate = date2String(new Date(toFormValue));
-      const stringifiedFrom = date2String(from);
       searchParams.append("to", newToDate);
-      trackFilter({ filterId: "timeRange", newToDate, stringifiedFrom });
+      trackFilter({ filterId: "timeRange", newToDate, from });
     }
 
-    if (fromFormValue && new Date(fromFormValue) !== from) {
+    if (fromFormValue && date2String(new Date(fromFormValue)) !== from) {
+      const newFromDate = date2String(new Date(fromFormValue));
       searchParams.delete("from");
-      searchParams.append("from", date2String(new Date(fromFormValue)));
-      const stringifiedTo = date2String(to);
+      searchParams.append("from", newFromDate);
       trackFilter({
-        filterId: "timerange",
-        from: date2String(new Date(fromFormValue)),
-        stringifiedTo,
+        filterId: "timeRange",
+        from: newFromDate,
+        to,
       });
     }
 

--- a/shared-components/statviz/components/filter/TimeRangeSelect.tsx
+++ b/shared-components/statviz/components/filter/TimeRangeSelect.tsx
@@ -7,6 +7,7 @@ import { useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import { DateField } from "../../..";
 import { date2String } from "../../../utils/helpers";
+import { trackFilter } from "../../utils/analytics/heap";
 
 export const FilterCreatedOnFormScheme = z.object({
   from: z
@@ -62,12 +63,21 @@ export default function TimeRangeSelect() {
 
     if (toFormValue && new Date(toFormValue) !== to) {
       searchParams.delete("to");
-      searchParams.append("to", date2String(new Date(toFormValue)));
+      const newToDate = date2String(new Date(toFormValue));
+      const stringifiedForm = date2String(from);
+      searchParams.append("to", newToDate);
+      trackFilter({ filterId: "timeRange", newToDate, stringifiedForm });
     }
 
     if (fromFormValue && new Date(fromFormValue) !== from) {
       searchParams.delete("from");
       searchParams.append("from", date2String(new Date(fromFormValue)));
+      const stringifiedTo = date2String(to);
+      trackFilter({
+        filterId: "timerange",
+        from: date2String(new Date(fromFormValue)),
+        stringifiedTo,
+      });
     }
 
     if (searchParams.toString() !== currentQuery) {

--- a/shared-components/statviz/hooks/useMultiSelectFilter.ts
+++ b/shared-components/statviz/hooks/useMultiSelectFilter.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { IFilterValue } from "../components/filter/ValueFilter";
+import { trackFilter } from "../utils/analytics/heap";
 
 export const urlFilterValuesEncode = <T>(array: (IFilterValue & T)[]): string =>
   array.map((e) => encodeURIComponent(e.urlId)).join(",");
@@ -39,6 +40,7 @@ export default function useMultiSelectFilter<T>(
     }
     if (selected.length > 0) {
       searchParams.append(filterId, urlFilterValuesEncode(selected));
+      trackFilter({ filterId, value: selected[selected.length - 1].label });
     }
     setSearchParams(searchParams);
   };

--- a/shared-components/statviz/hooks/useValueFilter.ts
+++ b/shared-components/statviz/hooks/useValueFilter.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { IFilterValue } from "../components/filter/ValueFilter";
+import { trackFilter } from "../utils/analytics/heap";
 
 export default function useValueFilter<T>(
   values: (IFilterValue & T)[],
@@ -25,6 +26,7 @@ export default function useValueFilter<T>(
     searchParams.append(filterId, selected.urlId);
 
     setSearchParams(searchParams);
+    trackFilter({ filterId, value: selected.label });
   };
 
   return { onFilterChange, filterValue };

--- a/shared-components/statviz/utils/analytics/heap/index.ts
+++ b/shared-components/statviz/utils/analytics/heap/index.ts
@@ -16,6 +16,34 @@ export const getHeap = (): IHeap => {
   };
 };
 
+// Filter related utility functions
+
+type HeapEvent = Record<string, string | number>;
+
+export interface IFilterEvent extends HeapEvent {
+  filterId: string;
+}
+
+const filterIdHeapLabelMap = {
+  gf: "products-gender-filter",
+  pf: "products-filter",
+  boi: "boxes-items-filter",
+  stg: "stock-overview-level1-filter",
+  loc: "outgoing-items-hide-locations-filter",
+  cbg: "new-items-display-by",
+};
+
+const getFilterLabel = (filterId: string): string => {
+  if (typeof filterIdHeapLabelMap[filterId] !== "undefined") {
+    return filterIdHeapLabelMap[filterId];
+  }
+  return filterId;
+};
+
 export const trackDownloadByGraph = (event: IDownloadByGraphEvent) => {
   getHeap().track("StatViz Download By Graph", event);
+};
+
+export const trackFilter = (event: IFilterEvent) => {
+  getHeap().track("StatViz Filter: ", { ...event, label: getFilterLabel(event.filterId) });
 };


### PR DESCRIPTION
Implemented filter tracking courtesy of Maik's draft implementation in https://github.com/boxwise/boxtribute/pull/1364/files#diff-ef01c5e03077013a4f49a11bf62dba2f8d1a35268b3f6438aa8bb1b1b5346461. 

As I couldn't test it locally due to errors in running the frontend, could @fhenrich33 take a peek at running this branch locally and see if the console logs log the correct filter values? 

Note: There is a slight deviation between Maik's changes in `shared-components/statviz/components/filter/TimeRangeSelect.tsx` and mine, see original version here- https://github.com/boxwise/boxtribute/pull/1364/files#diff-ef01c5e03077013a4f49a11bf62dba2f8d1a35268b3f6438aa8bb1b1b5346461L7. 