### PR TITLE
Make all mutations available via beta-levels

### DIFF
--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -344,7 +344,17 @@ ALL_ALLOWED_MUTATIONS[6] = ALL_ALLOWED_MUTATIONS[5] + (
     "updateTag",
     "deleteTag",
 )
-ALL_ALLOWED_MUTATIONS[99] = ALL_ALLOWED_MUTATIONS[6] + (
+ALL_ALLOWED_MUTATIONS[98] = ALL_ALLOWED_MUTATIONS[6] + (
+    # !!!
+    # Any new mutation should be added here
+    # !!!
+    "createBeneficiary",
+    "updateBeneficiary",
+    "deactivateBeneficiary",
+    "assignTag",
+    "unassignTag",
+)
+ALL_ALLOWED_MUTATIONS[99] = ALL_ALLOWED_MUTATIONS[98] + (
     # + mutations for mobile distribution pages
     "createDistributionSpot",
     "createDistributionEvent",

--- a/back/boxtribute_server/authz.py
+++ b/back/boxtribute_server/authz.py
@@ -16,11 +16,7 @@ from .models.definitions.shipment import Shipment
 from .models.definitions.shipment_detail import ShipmentDetail
 from .models.definitions.transfer_agreement import TransferAgreement
 from .models.definitions.transfer_agreement_detail import TransferAgreementDetail
-from .utils import (
-    convert_pascal_to_snake_case,
-    in_ci_environment,
-    in_development_environment,
-)
+from .utils import convert_pascal_to_snake_case
 
 BASE_AGNOSTIC_RESOURCES = (
     "box_state",
@@ -383,10 +379,6 @@ def check_beta_feature_access(
     Fall back to default beta-feature scope if the one assigned to the user is not
     registered.
     """
-    if in_ci_environment() or in_development_environment():
-        # Skip check when running tests in CircleCI, or during local development
-        return True
-
     current_user = current_user or g.user
     if current_user.is_god:
         return True

--- a/back/test/auth.py
+++ b/back/test/auth.py
@@ -71,6 +71,7 @@ def _create_jwt_payload(
     user_id=8,
     is_god=False,
     permissions=None,
+    beta_feature_scope=99,
     timezone="Europe/London",
 ):
     """Create payload containing arbitrary authorization information of a user.
@@ -92,6 +93,7 @@ def _create_jwt_payload(
         f"{JWT_CLAIM_PREFIX}/email": email,
         f"{JWT_CLAIM_PREFIX}/organisation_id": organisation_id,
         f"{JWT_CLAIM_PREFIX}/base_ids": list(base_ids),
+        f"{JWT_CLAIM_PREFIX}/beta_user": beta_feature_scope,
         f"{JWT_CLAIM_PREFIX}/timezone": timezone,
         f"{JWT_CLAIM_PREFIX}/roles": (
             [GOD_ROLE] if is_god else [f"base_{base_ids[0]}_coordinator"]

--- a/back/test/auth0_integration_tests/test_operations.py
+++ b/back/test/auth0_integration_tests/test_operations.py
@@ -67,7 +67,12 @@ def test_queries(auth0_client, endpoint):
     assert response["totalCount"] == 155
 
 
-def test_mutations(auth0_client):
+def test_mutations(auth0_client, mocker):
+    # Pretend that the users have a sufficient beta-level to run the beneficiary
+    # migrations
+    mocker.patch("boxtribute_server.routes.check_beta_feature_access").return_value = (
+        True
+    )
     auth0_client.environ_base["HTTP_AUTHORIZATION"] = get_authorization_header(
         "coordinator@coordinator.co"
     )

--- a/back/test/auth0_integration_tests/test_permissions.py
+++ b/back/test/auth0_integration_tests/test_permissions.py
@@ -121,7 +121,13 @@ def test_usergroup_cross_organisation_permissions(
     expected_accessible_base_ids,
     expected_forbidden_base_ids,
     forbidden_beneficiary_id,
+    mocker,
 ):
+    # Pretend that the users have a sufficient beta-level to run the beneficiary
+    # migrations
+    mocker.patch("boxtribute_server.routes.check_beta_feature_access").return_value = (
+        True
+    )
     dropapp_dev_client.environ_base["HTTP_AUTHORIZATION"] = get_authorization_header(
         username
     )
@@ -227,12 +233,6 @@ def test_god_user(dropapp_dev_client):
 
 
 def test_check_beta_feature_access(dropapp_dev_client, mocker):
-    # Enable testing of check_beta_feature_access() function
-    env_variables = os.environ.copy()
-    env_variables["CI"] = "false"
-    del env_variables["ENVIRONMENT"]
-    mocker.patch("os.environ", env_variables)
-
     dropapp_dev_client.environ_base["HTTP_AUTHORIZATION"] = get_authorization_header(
         "dev_coordinator@boxaid.org"
     )

--- a/back/test/auth0_integration_tests/test_permissions.py
+++ b/back/test/auth0_integration_tests/test_permissions.py
@@ -8,7 +8,11 @@ from auth import (
     get_authorization_header,
 )
 from boxtribute_server.auth import CurrentUser, decode_jwt, get_public_key
-from utils import assert_forbidden_request, assert_successful_request
+from utils import (
+    assert_forbidden_request,
+    assert_successful_request,
+    assert_unauthorized,
+)
 
 # Test user data in dropapp_dev database:
 # users: Volunteer - Coordinator - Head of Operations
@@ -237,9 +241,7 @@ def test_check_beta_feature_access(dropapp_dev_client, mocker):
     assert_successful_request(dropapp_dev_client, mutation)
 
     mutation = "mutation { deleteTag(id: 1) { id } }"
-    data = {"query": mutation}
-    response = dropapp_dev_client.post("/graphql", json=data)
-    assert response.status_code == 401
+    response = assert_unauthorized(dropapp_dev_client, mutation)
     assert response.json["error"] == "No permission to access beta feature"
 
 
@@ -250,7 +252,5 @@ def test_check_public_api_access(dropapp_dev_client, mocker):
     mocker.patch("os.environ", env_variables)
 
     query = "query { beneficiaryDemographics(baseId: 1) { count } }"
-    data = {"query": query}
-    response = dropapp_dev_client.post("/public", json=data)
-    assert response.status_code == 401
+    response = assert_unauthorized(dropapp_dev_client, query, endpoint="public")
     assert response.json["error"] == "No permission to access public API"

--- a/back/test/unit_tests/test_authz.py
+++ b/back/test/unit_tests/test_authz.py
@@ -395,6 +395,21 @@ def test_check_beta_feature_access(mocker):
         "query { base(id: 1) { name } }", current_user=current_user
     )
 
+    # User with scope 6 can additionally run tag mutations
+    current_user._beta_feature_scope = 6
+    for mutation in ["createBeneficiary"]:
+        payload = f"mutation {{ {mutation} }}"
+        assert not check_beta_feature_access(payload, current_user=current_user)
+    for mutation in ALL_ALLOWED_MUTATIONS[beta_feature_scope]:
+        payload = f"mutation {{ {mutation} }}"
+        assert check_beta_feature_access(payload, current_user=current_user)
+    for query in statistics_queries():
+        payload = f"query {{ {query} }}"
+        assert check_beta_feature_access(payload, current_user=current_user)
+    assert check_beta_feature_access(
+        "query { base(id: 1) { name } }", current_user=current_user
+    )
+
     current_user = CurrentUser(id=0, organisation_id=0, is_god=True)
     assert check_beta_feature_access({}, current_user=current_user)
 

--- a/back/test/unit_tests/test_authz.py
+++ b/back/test/unit_tests/test_authz.py
@@ -285,6 +285,7 @@ def test_check_beta_feature_access(mocker):
         "deleteProduct",
         "deleteBoxes",
         "createTag",
+        "createBeneficiary",
     ]:
         payload = f"mutation {{ {mutation} }}"
         assert not check_beta_feature_access(payload, current_user=current_user)
@@ -300,7 +301,13 @@ def test_check_beta_feature_access(mocker):
 
     # User with scope 1 can additionally access BoxCreate/ScanBox pages
     current_user._beta_feature_scope = 1
-    for mutation in ["createShipment", "deleteProduct", "deleteBoxes", "createTag"]:
+    for mutation in [
+        "createShipment",
+        "deleteProduct",
+        "deleteBoxes",
+        "createTag",
+        "createBeneficiary",
+    ]:
         payload = f"mutation {{ {mutation} }}"
         assert not check_beta_feature_access(payload, current_user=current_user)
     for mutation in ALL_ALLOWED_MUTATIONS[beta_feature_scope]:
@@ -315,7 +322,7 @@ def test_check_beta_feature_access(mocker):
 
     # User with scope 2 can additionally access Transfers pages
     current_user._beta_feature_scope = 2
-    for mutation in ["deleteBoxes", "deleteProduct", "createTag"]:
+    for mutation in ["deleteBoxes", "deleteProduct", "createTag", "createBeneficiary"]:
         payload = f"mutation {{ {mutation} }}"
         assert not check_beta_feature_access(payload, current_user=current_user)
     for mutation in ALL_ALLOWED_MUTATIONS[beta_feature_scope]:
@@ -330,7 +337,7 @@ def test_check_beta_feature_access(mocker):
 
     # Scope 3 is the default, hence users with unknown scope have the same permissions
     current_user._beta_feature_scope = 50
-    for mutation in ["deleteProduct", "createTag"]:
+    for mutation in ["deleteProduct", "createTag", "createBeneficiary"]:
         payload = f"mutation {{ {mutation} }}"
         assert not check_beta_feature_access(payload, current_user=current_user)
     for mutation in ALL_ALLOWED_MUTATIONS[DEFAULT_BETA_FEATURE_SCOPE]:
@@ -345,7 +352,7 @@ def test_check_beta_feature_access(mocker):
 
     # User with scope 3 can additionally access statviz data
     current_user._beta_feature_scope = 3
-    for mutation in ["deleteProduct", "createTag"]:
+    for mutation in ["deleteProduct", "createTag", "createBeneficiary"]:
         payload = f"mutation {{ {mutation} }}"
         assert not check_beta_feature_access(payload, current_user=current_user)
     for mutation in ALL_ALLOWED_MUTATIONS[beta_feature_scope]:
@@ -360,7 +367,7 @@ def test_check_beta_feature_access(mocker):
 
     # User with scope 4 can additionally execute Box bulk actions
     current_user._beta_feature_scope = 4
-    for mutation in ["deleteProduct", "createTag"]:
+    for mutation in ["deleteProduct", "createTag", "createBeneficiary"]:
         payload = f"mutation {{ {mutation} }}"
         assert not check_beta_feature_access(payload, current_user=current_user)
     for mutation in ALL_ALLOWED_MUTATIONS[beta_feature_scope]:
@@ -375,7 +382,7 @@ def test_check_beta_feature_access(mocker):
 
     # User with scope 5 can additionally access Product pages
     current_user._beta_feature_scope = 5
-    for mutation in ["createTag"]:
+    for mutation in ["createTag", "createBeneficiary"]:
         payload = f"mutation {{ {mutation} }}"
         assert not check_beta_feature_access(payload, current_user=current_user)
     for mutation in ALL_ALLOWED_MUTATIONS[beta_feature_scope]:

--- a/back/test/unit_tests/test_authz.py
+++ b/back/test/unit_tests/test_authz.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from boxtribute_server.auth import (
     GOD_ROLE,
@@ -267,12 +265,6 @@ def test_non_duplicated_base_ids_when_read_and_write_permissions_given():
 
 
 def test_check_beta_feature_access(mocker):
-    # Enable testing of check_beta_feature_access() function
-    env_variables = os.environ.copy()
-    env_variables["CI"] = "false"
-    del env_variables["ENVIRONMENT"]
-    mocker.patch("os.environ", env_variables)
-
     # User with scope 0 can only access BoxView/BoxEdit pages, and queries
     beta_feature_scope = 0
     current_user = CurrentUser(

--- a/back/test/utils.py
+++ b/back/test/utils.py
@@ -75,15 +75,27 @@ def assert_internal_server_error(client, query, **kwargs):
     )
 
 
-def assert_successful_request(client, query, field=None, endpoint="graphql"):
+def assert_unauthorized(client, query, **kwargs):
+    """Send GraphQL request with query using given client.
+    Assert that a 401 response is returned.
+    """
+    return _assert_web_request(client, query, http_code=401, **kwargs)
+
+
+def assert_successful_request(client, query, field=None, **kwargs):
     """Send GraphQL request with query using given client.
     Assert response HTTP code 200, and return main response JSON data field.
     """
-    data = {"query": query}
-    response = client.post(f"/{endpoint}", json=data)
-    assert response.status_code == 200
-
-    assert "errors" not in response.json
-
+    response = _assert_web_request(client, query, field=field, **kwargs)
     field = field or _extract_field(query)
     return response.json["data"][field]
+
+
+def _assert_web_request(
+    client, query, *, http_code=200, field=None, endpoint="graphql"
+):
+    data = {"query": query}
+    response = client.post(f"/{endpoint}", json=data)
+    assert response.status_code == http_code
+    assert "errors" not in response.json
+    return response


### PR DESCRIPTION
- all mutations can be controlled via beta-levels
- when a new mutation is added to the BE, it must be added to one beta-level
- when in development, the FE requests a new mutation using a test user, the mutation needs to moved to a smaller beta-level
