### PR TITLE
Fix package installation in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             pnpm config set store-dir .pnpm-store
       - run:
           name: Install node packages for all front-ends
-          command: pnpm install --frozen-lockfile
+          command: corepack use pnpm@`pnpm -v` && pnpm i
       - save_cache:
           key: dependency-cache-{{ checksum "pnpm-lock.yaml" }}
           paths:


### PR DESCRIPTION
@jamescrowley  Trying to fix the problem bellow when dependabot open PRs:

![Screenshot 2024-11-14 at 23-20-35 install-node-packages (33710) - boxwise_boxtribute](https://github.com/user-attachments/assets/6adb0da8-def1-435e-a1ab-477604ab4678)

Trying this suggested fix https://github.com/pnpm/pnpm/issues/7934#issuecomment-2117539381