### PR TITLE
fix default timerange filter in statviz

### DIFF
--- a/shared-components/statviz/components/filter/TimeRangeSelect.tsx
+++ b/shared-components/statviz/components/filter/TimeRangeSelect.tsx
@@ -43,15 +43,16 @@ export default function TimeRangeSelect() {
 
   useEffect(() => {
     const currentQuery = searchParams.toString();
+    const newSearchParams = searchParams;
 
     if (!searchParams.get("from")) {
-      searchParams.append("from", date2String(subMonths(new Date(), 3)));
+      newSearchParams.append("from", date2String(subMonths(new Date(), 3)));
     }
     if (!searchParams.get("to")) {
-      searchParams.append("to", date2String(new Date()));
+      newSearchParams.append("to", date2String(new Date()));
     }
-    const from = searchParams.get("from")!;
-    const to = searchParams.get("to")!;
+    const from = newSearchParams.get("from")!;
+    const to = newSearchParams.get("to")!;
 
     if (toFormValue === undefined) {
       setValue("to", to);
@@ -62,16 +63,16 @@ export default function TimeRangeSelect() {
     }
 
     if (toFormValue && date2String(new Date(toFormValue)) !== to) {
-      searchParams.delete("to");
       const newToDate = date2String(new Date(toFormValue));
-      searchParams.append("to", newToDate);
+      newSearchParams.delete("to");
+      newSearchParams.append("to", newToDate);
       trackFilter({ filterId: "timeRange", newToDate, from });
     }
 
     if (fromFormValue && date2String(new Date(fromFormValue)) !== from) {
       const newFromDate = date2String(new Date(fromFormValue));
-      searchParams.delete("from");
-      searchParams.append("from", newFromDate);
+      newSearchParams.delete("from");
+      newSearchParams.append("from", newFromDate);
       trackFilter({
         filterId: "timeRange",
         from: newFromDate,
@@ -79,8 +80,8 @@ export default function TimeRangeSelect() {
       });
     }
 
-    if (searchParams.toString() !== currentQuery) {
-      setSearchParams(searchParams);
+    if (newSearchParams.toString() !== currentQuery) {
+      setSearchParams(newSearchParams);
     }
   }, [searchParams, setValue, setSearchParams, fromFormValue, toFormValue]);
 

--- a/statviz/types/generated/gql.ts
+++ b/statviz/types/generated/gql.ts
@@ -11,7 +11,6 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * 3. It does not support dead code elimination, so it will add unused operations.
  *
  * Therefore it is highly recommended to use the babel or swc plugin for production.
- * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
 const documents = {
     "\n  query createdBoxes($baseId: Int!) {\n    createdBoxes(baseId: $baseId) {\n      facts {\n        boxesCount\n        productId\n        categoryId\n        createdOn\n        tagIds\n        gender\n        itemsCount\n      }\n      dimensions {\n        product {\n          id\n          name\n          gender\n        }\n        category {\n          id\n          name\n        }\n        tag {\n          id\n          name\n          color\n        }\n      }\n    }\n  }\n": types.CreatedBoxesDocument,


### PR DESCRIPTION
This is a fix for the bug mentioned [here](https://trello.com/c/XUrjWcSI).

Reason for the error: The state was used and edited before passing the state to the state update function. This is not best practice and did somehow not work on the initial load.

@pylipp you wanted to create a bug ticket for it, could you assign this PR to it?