### PR TITLE
re-write ALL_SHIPMENTS query

### DIFF
--- a/front/src/queries/queries.ts
+++ b/front/src/queries/queries.ts
@@ -79,10 +79,31 @@ export const CHECK_IF_QR_EXISTS_IN_DB = gql`
 `;
 
 export const ALL_SHIPMENTS_QUERY = gql`
-  ${SHIPMENT_FIELDS_FRAGMENT}
+  ${BASE_ORG_FIELDS_FRAGMENT}
   query Shipments {
     shipments {
-      ...ShipmentFields
+      id
+      labelIdentifier
+      state
+      details {
+        id
+        box {
+          labelIdentifier
+        }
+        createdOn
+        removedOn
+      }
+      sourceBase {
+        ...BaseOrgFields
+      }
+      targetBase {
+        ...BaseOrgFields
+      }
+      startedOn
+      sentOn
+      receivingStartedOn
+      completedOn
+      canceledOn
     }
   }
 `;

--- a/statviz/types/generated/gql.ts
+++ b/statviz/types/generated/gql.ts
@@ -11,6 +11,7 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * 3. It does not support dead code elimination, so it will add unused operations.
  *
  * Therefore it is highly recommended to use the babel or swc plugin for production.
+ * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
 const documents = {
     "\n  query createdBoxes($baseId: Int!) {\n    createdBoxes(baseId: $baseId) {\n      facts {\n        boxesCount\n        productId\n        categoryId\n        createdOn\n        tagIds\n        gender\n        itemsCount\n      }\n      dimensions {\n        product {\n          id\n          name\n          gender\n        }\n        category {\n          id\n          name\n        }\n        tag {\n          id\n          name\n          color\n        }\n      }\n    }\n  }\n": types.CreatedBoxesDocument,


### PR DESCRIPTION
since the ALL_SHIPMENTS_QUERY was just used in the shipments overview and does not need the recursive query of shipment detail, I only had to separate out the query from the existing fragment.

ALL FE tests passed locally

