### PR TITLE
Make pre-commit operate more clearly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+files: back/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 files: back/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: v2.4.0
     hooks:
       - id: trailing-whitespace
+        types: [python]
       - id: end-of-file-fixer
         exclude: statviz/src/types/generated
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
       - id: trailing-whitespace
         types: [python]
       - id: end-of-file-fixer
-        exclude: statviz/src/types/generated
   - repo: local
     hooks:
       - id: black

--- a/back/README.md
+++ b/back/README.md
@@ -375,7 +375,7 @@ If you lack an internet connection to communicate with Auth0, it might be benefi
 
 to simulate a god user with ID 8 (for a regular user, set something like `id=1, organisation_id=1`).
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > To keep the front-end side up-to-date with the GraphQL schema, make sure that the pre-commit command for `*.graphql` files (`id: generate-graphql-ts-types`) is running properly.
 >
 > It should generate both `schema.graphql` (the introspected unified schema) and `graphql-env.d.ts` (the generated types to be ìnferred and consumed in the FE with `gql.tada`) inside `/graphql/generated/`.


### PR DESCRIPTION
To avoid confusion on changes in e.g. readme files:
- Run trailing-whitespace pre-commit linter only on Python files
- Run pre-commit only on file changes in back/
FYI @fhenrich33 
