### PR TITLE
Feat/update action icons v2

### DIFF
--- a/front/src/views/Boxes/BoxesView.tsx
+++ b/front/src/views/Boxes/BoxesView.tsx
@@ -32,6 +32,7 @@ export const BOXES_FOR_BOXESVIEW_QUERY = graphql(
           hasNextPage
         }
         elements {
+          id
           labelIdentifier
           product {
             ...ProductBasicFields
@@ -127,6 +128,7 @@ function Boxes() {
         "lastModifiedBy",
         "createdBy",
         "productCategory",
+        "id",
       ],
     },
   });
@@ -251,6 +253,13 @@ function Boxes() {
         id: "createdBy",
         Filter: SelectColumnFilter,
         filter: "includesOneOfMultipleStrings",
+      },
+      {
+        Header: "ID",
+        accessor: "id",
+        id: "id",
+        Filter: SelectColumnFilter,
+        disableFilters: true,
       },
     ],
     [],

--- a/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
+++ b/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
@@ -2,13 +2,12 @@ import { Column, Row } from "react-table";
 import { useMoveBoxes } from "hooks/useMoveBoxes";
 import { useNavigate } from "react-router-dom";
 
-import { FaWarehouse } from "react-icons/fa"; // Add Trash Icon for delete action
+import { FaDollyFlatbed } from "react-icons/fa";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAssignBoxesToShipment } from "hooks/useAssignBoxesToShipment";
 import { useDeleteBoxes } from "hooks/useDeleteBoxes";
 import { IBoxBasicFields } from "types/graphql-local-only";
-import { Button } from "@chakra-ui/react";
-import { ShipmentIcon } from "components/Icon/Transfer/ShipmentIcon";
+import { Button, Menu, MenuButton, MenuList, MenuItem } from "@chakra-ui/react";
 import { useUnassignBoxesFromShipments } from "hooks/useUnassignBoxesFromShipments";
 import { useNotification } from "hooks/useNotification";
 import { QueryRef } from "@apollo/client";
@@ -20,6 +19,8 @@ import { useBaseIdParam } from "hooks/useBaseIdParam";
 import RemoveBoxesButton from "./RemoveBoxesButton";
 import { BoxesForBoxesViewVariables, BoxesForBoxesViewQuery } from "queries/types";
 import ExportToCsvButton from "./ExportToCsvButton";
+import { FaTruckArrowRight } from "react-icons/fa6";
+import { BsBox2HeartFill } from "react-icons/bs";
 
 export interface IBoxesActionsAndTableProps {
   tableConfig: IUseTableConfigReturnType;
@@ -228,18 +229,11 @@ function BoxesActionsAndTable({
 
   const actionButtons = useMemo(
     () => [
-      <RemoveBoxesButton
-        onDeleteBoxes={onDeleteBoxes}
-        actionsAreLoading={actionsAreLoading}
-        selectedBoxes={selectedBoxes}
-        key="remove-boxes"
-      />,
-      <ExportToCsvButton selectedBoxes={selectedBoxes} key="export-csv" />,
       <SelectButton
         label="Move to ..."
         options={locationOptions}
         onSelect={onMoveBoxes}
-        icon={<FaWarehouse />}
+        icon={<FaDollyFlatbed />}
         isDisabled={actionsAreLoading || locationOptions.length === 0}
         key="move-to"
       />,
@@ -247,10 +241,33 @@ function BoxesActionsAndTable({
         label="Assign to Shipment"
         options={shipmentOptions}
         onSelect={onAssignBoxesToShipment}
-        icon={<ShipmentIcon />}
+        icon={<FaTruckArrowRight />}
         isDisabled={actionsAreLoading || shipmentOptions.length === 0}
         key="assign-to-shipment"
       />,
+      <Menu key="box-actions">
+        <MenuButton as={Button}>
+          <BsBox2HeartFill />
+        </MenuButton>
+        <MenuList>
+          <MenuItem>Create a Box</MenuItem>
+          <MenuItem>
+            <RemoveBoxesButton
+              labelIdentifier="Delete Boxes"
+              onDeleteBoxes={onDeleteBoxes}
+              actionsAreLoading={actionsAreLoading}
+              selectedBoxes={selectedBoxes}
+              key="remove-boxes"
+            />
+          </MenuItem>
+          <MenuItem>
+            <ExportToCsvButton selectedBoxes={selectedBoxes} key="export-csv" />
+          </MenuItem>
+          <MenuItem>Add/Remove Tags</MenuItem>
+          <MenuItem>Make QR Labels</MenuItem>
+        </MenuList>
+      </Menu>,
+
       <div key="unassign-from-shipment">
         {thereIsABoxMarkedForShipmentSelected && (
           <Button onClick={() => onUnassignBoxesToShipment()} isDisabled={actionsAreLoading}>

--- a/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
+++ b/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
@@ -250,7 +250,6 @@ function BoxesActionsAndTable({
           <BsBox2HeartFill />
         </MenuButton>
         <MenuList>
-          <MenuItem>Create a Box</MenuItem>
           <MenuItem>
             <RemoveBoxesButton
               labelIdentifier="Delete Boxes"
@@ -263,8 +262,6 @@ function BoxesActionsAndTable({
           <MenuItem>
             <ExportToCsvButton selectedBoxes={selectedBoxes} key="export-csv" />
           </MenuItem>
-          <MenuItem>Add/Remove Tags</MenuItem>
-          <MenuItem>Make QR Labels</MenuItem>
         </MenuList>
       </Menu>,
 

--- a/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
+++ b/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
@@ -21,6 +21,7 @@ import { BoxesForBoxesViewVariables, BoxesForBoxesViewQuery } from "queries/type
 import ExportToCsvButton from "./ExportToCsvButton";
 import { FaTruckArrowRight } from "react-icons/fa6";
 import { BsBox2HeartFill } from "react-icons/bs";
+import MakeLabelsButton from "./MakeLabelsButton";
 
 export interface IBoxesActionsAndTableProps {
   tableConfig: IUseTableConfigReturnType;
@@ -261,6 +262,9 @@ function BoxesActionsAndTable({
           </MenuItem>
           <MenuItem>
             <ExportToCsvButton selectedBoxes={selectedBoxes} key="export-csv" />
+          </MenuItem>
+          <MenuItem>
+            <MakeLabelsButton selectedBoxes={selectedBoxes} key="make-labels" />
           </MenuItem>
         </MenuList>
       </Menu>,

--- a/front/src/views/Boxes/components/ExportToCsvButton.tsx
+++ b/front/src/views/Boxes/components/ExportToCsvButton.tsx
@@ -5,6 +5,7 @@ import { Row } from "react-table";
 
 import { BoxRow } from "./types";
 import { useNotification } from "hooks/useNotification";
+import { RiFileDownloadLine } from "react-icons/ri";
 
 interface ExportToCsvButtonProps {
   selectedBoxes: Row<BoxRow>[];
@@ -30,11 +31,10 @@ const ExportToCsvButton: React.FC<ExportToCsvButtonProps> = ({ selectedBoxes }) 
       <Button
         key="export"
         data-testid="export-button"
-        height="48px"
-        width="200px"
-        border="0px"
-        bgColor="white"
-        borderColor="white"
+        variant="ghost"
+        leftIcon={<RiFileDownloadLine />}
+        iconSpacing={2}
+        padding={1}
       >
         <CSVLink
           onClick={checkForSelectedBoxes}

--- a/front/src/views/Boxes/components/ExportToCsvButton.tsx
+++ b/front/src/views/Boxes/components/ExportToCsvButton.tsx
@@ -27,7 +27,15 @@ const ExportToCsvButton: React.FC<ExportToCsvButtonProps> = ({ selectedBoxes }) 
   const filename = `Stock_${new Date().toJSON().slice(0, 10)}_${new Date().valueOf()}`;
   return (
     <>
-      <Button key="export" data-testid="export-button">
+      <Button
+        key="export"
+        data-testid="export-button"
+        height="48px"
+        width="200px"
+        border="0px"
+        bgColor="white"
+        borderColor="white"
+      >
         <CSVLink
           onClick={checkForSelectedBoxes}
           data={selectedBoxes.map((box) => {

--- a/front/src/views/Boxes/components/MakeLabelsButton.tsx
+++ b/front/src/views/Boxes/components/MakeLabelsButton.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { Button, MenuItem } from "@chakra-ui/react";
+import { Button } from "@chakra-ui/react";
 import { Row } from "react-table";
 
 import { BoxRow } from "./types";
 import { useNotification } from "hooks/useNotification";
 import { RiQrCodeLine } from "react-icons/ri";
-import { NavLink, redirect, useNavigate } from "react-router-dom";
 
 interface MakeLabelsButtonProps {
   selectedBoxes: Row<BoxRow>[];

--- a/front/src/views/Boxes/components/MakeLabelsButton.tsx
+++ b/front/src/views/Boxes/components/MakeLabelsButton.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Button, MenuItem } from "@chakra-ui/react";
+import { Row } from "react-table";
+
+import { BoxRow } from "./types";
+import { useNotification } from "hooks/useNotification";
+import { RiQrCodeLine } from "react-icons/ri";
+import { NavLink, redirect, useNavigate } from "react-router-dom";
+
+interface MakeLabelsButtonProps {
+  selectedBoxes: Row<BoxRow>[];
+}
+
+const MakeLabelsButton: React.FC<MakeLabelsButtonProps> = ({ selectedBoxes }) => {
+  const { createToast } = useNotification();
+
+  const MAKE_LABELS_URL = `${import.meta.env.FRONT_OLD_APP_BASE_URL}/pdf/qr.php?label=`;
+  const selectedBoxIds = selectedBoxes.map((box) => box.values.id).join();
+  const makeLabels = () => {
+    if (selectedBoxes.length === 0) {
+      createToast({
+        type: "warning",
+        message: `Please select a box for making labels`,
+      });
+      return false;
+    }
+    window.location.href = MAKE_LABELS_URL + selectedBoxIds;
+    return true;
+  };
+
+  return (
+    <>
+      <Button
+        key="make-labels"
+        variant="ghost"
+        data-testid="make-labels-button"
+        leftIcon={<RiQrCodeLine />}
+        iconSpacing={2}
+        padding={1}
+        onClick={makeLabels}
+      >
+        Make Labels
+      </Button>
+    </>
+  );
+};
+
+export default MakeLabelsButton;

--- a/front/src/views/Boxes/components/RemoveBoxesButton.tsx
+++ b/front/src/views/Boxes/components/RemoveBoxesButton.tsx
@@ -2,10 +2,10 @@ import React, { useState } from "react";
 import { Row } from "react-table";
 
 import { Button } from "@chakra-ui/react";
-import { FaTrashAlt } from "react-icons/fa";
 import RemoveBoxesOverlay from "./RemoveBoxesOverlay";
 import { BoxRow } from "./types";
 import { useNotification } from "hooks/useNotification";
+import { BiTrash } from "react-icons/bi";
 
 interface RemoveBoxesButtonProps {
   onDeleteBoxes: () => void;
@@ -45,10 +45,11 @@ const RemoveBoxesButton: React.FC<RemoveBoxesButtonProps> = ({
   return (
     <>
       <Button
-        variant="link"
+        padding={1}
+        variant="ghost"
         onClick={handleOpenDialog}
-        leftIcon={<FaTrashAlt />}
-        iconSpacing={0}
+        leftIcon={<BiTrash />}
+        iconSpacing={2}
         isDisabled={actionsAreLoading}
         data-testid="delete-boxes-button"
       >

--- a/front/src/views/Boxes/components/RemoveBoxesButton.tsx
+++ b/front/src/views/Boxes/components/RemoveBoxesButton.tsx
@@ -11,12 +11,14 @@ interface RemoveBoxesButtonProps {
   onDeleteBoxes: () => void;
   actionsAreLoading: boolean;
   selectedBoxes: Row<BoxRow>[];
+  labelIdentifier: string;
 }
 
 const RemoveBoxesButton: React.FC<RemoveBoxesButtonProps> = ({
   onDeleteBoxes,
   actionsAreLoading,
   selectedBoxes,
+  labelIdentifier,
 }) => {
   const { createToast } = useNotification();
 
@@ -43,12 +45,15 @@ const RemoveBoxesButton: React.FC<RemoveBoxesButtonProps> = ({
   return (
     <>
       <Button
+        variant="link"
         onClick={handleOpenDialog}
         leftIcon={<FaTrashAlt />}
         iconSpacing={0}
         isDisabled={actionsAreLoading}
         data-testid="delete-boxes-button"
-      />
+      >
+        {labelIdentifier}
+      </Button>
       <RemoveBoxesOverlay
         isLoading={actionsAreLoading}
         isOpen={isDialogOpen}

--- a/front/src/views/Boxes/components/transformers.ts
+++ b/front/src/views/Boxes/components/transformers.ts
@@ -9,6 +9,7 @@ export const boxesRawDataToTableDataTransformer = (boxesQueryResult: BoxesForBox
     .map(
       (element) =>
         ({
+          id: element.id,
           labelIdentifier: element.labelIdentifier,
           product: element.product!.name,
           productCategory: element.product!.category.name,

--- a/front/src/views/Boxes/components/types.ts
+++ b/front/src/views/Boxes/components/types.ts
@@ -18,4 +18,5 @@ export type BoxRow = {
   lastModified: Date | null;
   createdBy: string | null;
   lastModifiedBy: string | null;
+  id: string;
 };


### PR DESCRIPTION
Desktop:
<img width="1304" alt="Screenshot 2025-01-09 at 01 06 58" src="https://github.com/user-attachments/assets/04e17293-dc95-410f-ac74-2849f8297d2b" />


Mobile:
![image](https://github.com/user-attachments/assets/9ed50de0-cbff-47f4-8c38-9690983556a8)

Removed the action buttons which were still pending discussion on behavior/dependencies.

