### PR TITLE
Handle undefined value in SelectColumnFilter

### DIFF
--- a/front/src/components/Table/Filter.tsx
+++ b/front/src/components/Table/Filter.tsx
@@ -104,7 +104,7 @@ export function SelectColumnFilter({
         const objectToString = ObjectToString(value);
         groupedOptionLabels.add(objectToString);
         optionValues[objectToString] = value;
-      } else {
+      } else if (value !== undefined) {
         groupedOptionLabels.add(value);
         optionValues[value] = value;
       }


### PR DESCRIPTION
E.g. if a box has no size (but measure value + unit instead)
