### PR TITLE
GraphQL implementation update for consistency

### DIFF
--- a/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/agreement/crud.py
@@ -102,7 +102,7 @@ def _validate_unique_transfer_agreement(
             raise DuplicateTransferAgreement(agreement_id=am.id)
 
 
-def _convert_dates_to_utc_datetimes(valid_from, valid_until, timezone):
+def _convert_dates_to_utc_datetimes(valid_from, valid_until, timezone, now):
     """Use given valid_* dates and insert time information such that start/end is at
     midnight. Let valid_from default to current UTC time.
     Return converted datetimes (UTC but without timezone information) as tuple.
@@ -115,7 +115,7 @@ def _convert_dates_to_utc_datetimes(valid_from, valid_until, timezone):
             .replace(tzinfo=None)
         )
     else:
-        valid_from = utcnow().replace(tzinfo=None)
+        valid_from = now.replace(tzinfo=None)
 
     if valid_until is not None:
         valid_until = (
@@ -158,8 +158,9 @@ def create_transfer_agreement(
     if initiating_organisation_id == partner_organisation_id:
         raise InvalidTransferAgreementOrganisation()
 
+    now = utcnow()
     valid_from, valid_until = _convert_dates_to_utc_datetimes(
-        valid_from, valid_until, user.timezone
+        valid_from, valid_until, user.timezone, now
     )
 
     if valid_until and valid_from.date() >= valid_until.date():
@@ -210,6 +211,7 @@ def create_transfer_agreement(
             type=type,
             valid_from=valid_from,
             valid_until=valid_until,
+            requested_on=now,
             requested_by=user.id,
             comment=comment,
         )

--- a/back/boxtribute_server/business_logic/warehouse/box/fields.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/fields.py
@@ -61,12 +61,14 @@ def resolve_box_unit(box_obj, info):
 
 
 @box.field("measureValue")
-def resolve_box_measure_value(box_obj, _):
+async def resolve_box_measure_value(box_obj, info):
     if box_obj.display_unit_id is None:
         # Boxes with size-products (i.e. clothing) don't have any measure value assigned
         return
+
+    display_unit = await info.context["unit_loader"].load(box_obj.display_unit_id)
     # Convert value from base dimension to front-end unit
-    return box_obj.display_unit.conversion_factor * box_obj.measure_value
+    return display_unit.conversion_factor * box_obj.measure_value
 
 
 @box.field("state")

--- a/back/boxtribute_server/business_logic/warehouse/box/queries.py
+++ b/back/boxtribute_server/business_logic/warehouse/box/queries.py
@@ -1,12 +1,10 @@
 from ariadne import QueryType
-from peewee import JOIN
 
 from ....authz import authorize, authorize_for_reading_box
 from ....graph_ql.filtering import derive_box_filter
 from ....graph_ql.pagination import load_into_page
 from ....models.definitions.box import Box
 from ....models.definitions.location import Location
-from ....models.definitions.unit import Unit
 
 query = QueryType()
 
@@ -14,9 +12,8 @@ query = QueryType()
 @query.field("box")
 def resolve_box(*_, label_identifier):
     box = (
-        Box.select(Box, Location, Unit)
-        .join(Location)
-        .join(Unit, JOIN.LEFT_OUTER, src=Box)  # for measureValue resolver
+        Box.select(Box, Location)
+        .join(Location)  # for box.location attribute in authorize_for_reading_box()
         .where(Box.label_identifier == label_identifier)
         .get()
     )
@@ -28,18 +25,13 @@ def resolve_box(*_, label_identifier):
 def resolve_boxes(*_, base_id, pagination_input=None, filter_input=None):
     authorize(permission="stock:read", base_id=base_id)
 
-    selection = (
-        # Omit Unit.id because it confuses .count() in _compute_total_count()
-        Box.select(Box, Unit.conversion_factor, Unit.symbol, Unit.name)
-        .join(
-            Location,
-            on=(
-                (Box.location == Location.id)
-                & (Location.base == base_id)
-                & ((Box.deleted_on == 0) | (Box.deleted_on.is_null()))
-            ),
-        )
-        .join(Unit, JOIN.LEFT_OUTER, src=Box)  # for measureValue resolver
+    selection = Box.select().join(
+        Location,
+        on=(
+            (Box.location == Location.id)
+            & (Location.base == base_id)
+            & ((Box.deleted_on == 0) | (Box.deleted_on.is_null()))
+        ),
     )
     filter_condition, selection = derive_box_filter(filter_input, selection=selection)
 

--- a/back/boxtribute_server/graph_ql/scalars.py
+++ b/back/boxtribute_server/graph_ql/scalars.py
@@ -6,17 +6,21 @@ datetime_scalar = ScalarType("Datetime")
 date_scalar = ScalarType("Date")
 
 
+# Serializing date(time) object in application layer to string for API
 @datetime_scalar.serializer
 def serialize_datetime(value):
+    # Return datetime value as UTC in format YYYY-MM-DDTHH:MM:SS+00:00
     value = value.replace(tzinfo=timezone.utc)
     return value.isoformat()
 
 
 @date_scalar.serializer
 def serialize_date(value):
+    # Return date value in format YYYY-MM-DD
     return value.isoformat()
 
 
+# Parsing string from API into date(time) object in application layer
 @date_scalar.value_parser
 def parse_date(value):
     # Allowed formats: YYYY-MM-DD and YYYYMMDD
@@ -25,6 +29,7 @@ def parse_date(value):
 
 @datetime_scalar.value_parser
 def parse_datetime(value):
-    # Datetime string must be of format '2022-08-30T14:00:00'.
-    # With Python 3.11 more formats will be supported
+    # Allowed formats cf.
+    # https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat
+    # This returns a offset-naive datetime if value without "+XX:XX" suffix
     return datetime.fromisoformat(value)

--- a/back/boxtribute_server/graph_ql/scalars.py
+++ b/back/boxtribute_server/graph_ql/scalars.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from ariadne import ScalarType
 
@@ -19,7 +19,8 @@ def serialize_date(value):
 
 @date_scalar.value_parser
 def parse_date(value):
-    return datetime.strptime(value, "%Y-%m-%d").date()
+    # Allowed formats: YYYY-MM-DD and YYYYMMDD
+    return date.fromisoformat(value)
 
 
 @datetime_scalar.value_parser

--- a/back/boxtribute_server/models/definitions/transfer_agreement.py
+++ b/back/boxtribute_server/models/definitions/transfer_agreement.py
@@ -3,7 +3,6 @@ from peewee import DateTimeField, TextField
 from ...db import db
 from ...enums import TransferAgreementState, TransferAgreementType
 from ..fields import EnumCharField, UIntForeignKeyField
-from ..utils import utcnow
 from .organisation import Organisation
 from .user import User
 
@@ -16,7 +15,7 @@ class TransferAgreement(db.Model):  # type: ignore
         default=TransferAgreementState.UnderReview,
     )
     type = EnumCharField(choices=TransferAgreementType)
-    requested_on = DateTimeField(default=utcnow)
+    requested_on = DateTimeField()
     requested_by = UIntForeignKeyField(
         model=User,
         column_name="requested_by",
@@ -41,7 +40,7 @@ class TransferAgreement(db.Model):  # type: ignore
         on_delete="SET NULL",
         null=True,
     )
-    valid_from = DateTimeField(default=utcnow)
+    valid_from = DateTimeField()
     valid_until = DateTimeField(null=True)
     comment = TextField(null=True)
 

--- a/back/test/data/transfer_agreement.py
+++ b/back/test/data/transfer_agreement.py
@@ -32,6 +32,8 @@ def data():
             "state": TransferAgreementState.Expired,
             "type": TransferAgreementType.Bidirectional,
             "requested_by": default_user_data()["id"],
+            "requested_on": TIME,
+            "valid_from": TIME,
         },
         {
             "id": 3,
@@ -40,6 +42,8 @@ def data():
             "state": TransferAgreementState.UnderReview,
             "type": TransferAgreementType.Bidirectional,
             "requested_by": default_user_data()["id"],
+            "requested_on": TIME,
+            "valid_from": TIME,
         },
         {
             "id": 4,
@@ -48,6 +52,8 @@ def data():
             "state": TransferAgreementState.Accepted,
             "type": TransferAgreementType.SendingTo,
             "requested_by": default_user_data()["id"],
+            "requested_on": TIME,
+            "valid_from": TIME,
         },
         {
             "id": 5,
@@ -56,6 +62,8 @@ def data():
             "state": TransferAgreementState.UnderReview,
             "type": TransferAgreementType.ReceivingFrom,
             "requested_by": default_user_data()["id"],
+            "requested_on": TIME,
+            "valid_from": TIME,
         },
         {
             "id": 6,
@@ -64,6 +72,7 @@ def data():
             "state": TransferAgreementState.Accepted,
             "type": TransferAgreementType.Bidirectional,
             "requested_by": default_user_data()["id"],
+            "requested_on": TIME,
             "valid_from": datetime(2021, 1, 1),
             "valid_until": datetime(2024, 12, 31),
         },
@@ -74,6 +83,8 @@ def data():
             "state": TransferAgreementState.Accepted,
             "type": TransferAgreementType.Bidirectional,
             "requested_by": default_user_data()["id"],
+            "requested_on": TIME,
+            "valid_from": TIME,
         },
     ]
 


### PR DESCRIPTION
- Use simpler date parsing
- Update comments
- Use only one utcnow() call when creating agreement
- Use unit loader instead of relying on join
