### PR TITLE
Make base-name skeletons load for god user

### DIFF
--- a/front/src/hooks/useLoadAndSetGlobalPreferences.ts
+++ b/front/src/hooks/useLoadAndSetGlobalPreferences.ts
@@ -58,11 +58,12 @@ export const useLoadAndSetGlobalPreferences = () => {
       // - the selected base ID is part of the available base IDs from Auth0 or
       // - that the user is a Boxtribute God
       if (urlBaseId) {
-        if (isGod || user[JWT_AVAILABLE_BASES].map(String).includes(urlBaseId)) {
-          if (selectedBaseId !== urlBaseId) {
+        if (isGod) {
+          setSelectedBase({ id: urlBaseId });
+        }
+        else if (user[JWT_AVAILABLE_BASES].map(String).includes(urlBaseId) && (selectedBaseId !== urlBaseId)) {
             // only overwrite the selected base ID if the id is different from the existing one.
             setSelectedBase({ id: urlBaseId });
-          }
         } else {
           setError("The requested base is not available to you.");
         }

--- a/front/src/views/Products/ProductsView.tsx
+++ b/front/src/views/Products/ProductsView.tsx
@@ -373,12 +373,6 @@ function Products() {
     return <TableSkeleton />;
   }
 
-  console.log("standardProductsRawData", standardProductsRawData);
-  console.log(
-    "transformedData",
-    standardProductsRawDataToTableDataTransformer(standardProductsRawData),
-  );
-
   return (
     <>
       <BreadcrumbNavigation


### PR DESCRIPTION
God user does not have base_ids set in their JWT, hence selectedBaseIdAtom keeps returning "0" which does not match the urlBaseId.

As a result, the skeletons that use selectedBaseAtom load forever (e.g. in EnableStandardProductForm).
