### PR TITLE
Remove unnecessary validation for numberOfItems input in BoxEdit

### DIFF
--- a/front/src/views/BoxEdit/components/BoxEdit.tsx
+++ b/front/src/views/BoxEdit/components/BoxEdit.tsx
@@ -76,9 +76,7 @@ export const BoxEditFormDataSchema = z.object({
       invalid_type_error: "Please enter an integer number",
     })
     .int()
-    .nonnegative()
-    .nullable()
-    .transform((num) => num || z.NEVER),
+    .nonnegative(),
   locationId: singleSelectOptionSchema
     .nullable()
     .refine(Boolean, { message: "Please select a location" })


### PR DESCRIPTION
We've been observing errors that a `{"status":"aborted"}` input is
being passed as input into the updateBox mutation from the BoxEdit view
[sentry].
I found an issue in the GH repo of the zod validation library that we
use in the BoxEdit form [github1], [github2], and it hints that
`z.NEVER` should only be used after fatal parsing issues, as a somewhat
unreachable code to satisfy return type requirements.
I decided to remove the `nullable` option (not sure why it's being used
in the first place, since we DON'T want the numberOfItems to be null),
and then also the following `transform` which seemed to serve as a
catcher of null numberOfItems inputs (but I don't understand how they
can be given as input).
Cf. colinhacks/zod#2192

[sentry](https://boxwise.sentry.io/issues/4843084837/events/af3f6c7fe56a498594c0ab4f6547021f/?project=6584301)
[github1](https://github.com/colinhacks/zod/issues/2192#issuecomment-1551114130)
[github2](https://github.com/colinhacks/zod/issues/2192#issuecomment-1812534617)

:warning: Locally all FE tests pass