### PR TITLE
Feat/unassign tags boxes v2

### DIFF
--- a/front/src/hooks/useUnassignTags.ts
+++ b/front/src/hooks/useUnassignTags.ts
@@ -2,15 +2,7 @@ import { useMutation } from "@apollo/client";
 import { graphql } from "../../../graphql/graphql";
 import { useCallback, useState } from "react";
 import { useErrorHandling } from "./useErrorHandling";
-
-export enum IUnassignTagsResultKind {
-  SUCCESS = "success",
-  FAIL = "fail",
-  NETWORK_FAIL = "networkFail",
-  BAD_USER_INPUT = "badUserInput",
-  INVALID_IDENTIFIERS = "invalidIdentifiers",
-  INVALID_TAGS = "invalidaTags",
-}
+import { useNotification } from "./useNotification";
 
 export const UNASSIGN_TAGS_FROM_BOXES = graphql(`
   mutation UnassignTagsFromBoxes($labelIdentifiers: [String!]!, $tagIds: [Int!]!) {
@@ -34,6 +26,7 @@ export const UNASSIGN_TAGS_FROM_BOXES = graphql(`
 
 export const useUnassignTags = () => {
   const { triggerError } = useErrorHandling();
+  const { createToast } = useNotification();
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const [unassignTagsMutation] = useMutation(UNASSIGN_TAGS_FROM_BOXES);
@@ -65,10 +58,9 @@ export const useUnassignTags = () => {
 
           if (invalidBoxLabelIdentifiers && invalidBoxLabelIdentifiers.length > 0) {
             if (showToasts) {
-              invalidBoxLabelIdentifiers.map((identifier) => {
-                triggerError({
-                  message: `Box ${identifier} not affected because it doesn't have the requested tag(s) assigned.`,
-                });
+              createToast({
+                type: "warning",
+                message: `Box(s) ${invalidBoxLabelIdentifiers} not affected because it/they don't have the requested tag(s) assigned.`,
               });
             }
           }
@@ -91,7 +83,7 @@ export const useUnassignTags = () => {
           }
         });
     },
-    [unassignTagsMutation, triggerError],
+    [unassignTagsMutation, triggerError, createToast],
   );
 
   return {

--- a/front/src/hooks/useUnassignTags.ts
+++ b/front/src/hooks/useUnassignTags.ts
@@ -1,0 +1,127 @@
+import { useMutation } from "@apollo/client";
+import { graphql } from "../../../graphql/graphql";
+import { useCallback, useState } from "react";
+import { useErrorHandling } from "./useErrorHandling";
+
+export enum IUnassignTagsResultKind {
+  SUCCESS = "success",
+  FAIL = "fail",
+  NETWORK_FAIL = "networkFail",
+  BAD_USER_INPUT = "badUserInput", // no Boxes were pased to the function
+  INVALID_IDENTIFIERS = "invalidIdentifiers",
+}
+
+export interface IUnassignTagsResult {
+  kind: IUnassignTagsResultKind;
+  requestedLabelIdentifiers: string[];
+  requestedTagIds: number[];
+  // TODO: Might not need
+  // successfulLabelIdentifiers?: string[];
+  // invalidIdentifiers?: string[];
+  error?: any;
+}
+
+/**
+ * 
+ * @returns 
+ * {
+  "data": {
+    "unassignTagsFromBoxes": {
+      "invalidBoxLabelIdentifiers": [
+        "123"
+      ],
+      "tagErrorInfo": [],
+      "updatedBoxes": []
+    }
+  }
+}
+ */
+
+export const UNASSIGN_TAGS_FROM_BOXES = graphql(`
+  mutation UnassignTagsFromBoxes($labelIdentifiers: [String!]!, $tagIds: [Int!]!) {
+    unassignTagsFromBoxes(updateInput: { labelIdentifiers: $labelIdentifiers, tagIds: $tagIds }) {
+      updatedBoxes {
+        labelIdentifier
+      }
+      invalidBoxLabelIdentifiers
+      tagErrorInfo {
+        id
+        error {
+          __typename
+        }
+      }
+    }
+  }
+`);
+
+export const useUnassignTags = () => {
+  const { triggerError } = useErrorHandling();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const [unassignTagsMutation] = useMutation(UNASSIGN_TAGS_FROM_BOXES);
+
+  const unassignTags = useCallback(
+    (labelIdentifiers: string[], tagIds: number[], showToasts: boolean = true) => {
+      setIsLoading(true);
+
+      return unassignTagsMutation({
+        variables: {
+          labelIdentifiers,
+          tagIds,
+        },
+      })
+        .then(({ data, errors }) => {
+          setIsLoading(false);
+
+          if (errors?.length) {
+            if (showToasts) {
+              triggerError({
+                message: "Could not unassign boxes. Try again?",
+              });
+            }
+            return {
+              kind: IUnassignTagsResultKind.FAIL,
+              error: errors[0],
+            } as IUnassignTagsResult;
+          }
+
+          const tagErrorInfoArray = data?.unassignTagsFromBoxes?.tagErrorInfo;
+
+          if (tagErrorInfoArray && tagErrorInfoArray.length > 0) {
+            if (showToasts) {
+              triggerError({
+                message: "Errors in tags unassignment",
+              });
+            }
+            return {
+              kind: IUnassignTagsResultKind.INVALID_IDENTIFIERS,
+            } as IUnassignTagsResult;
+          }
+
+          return {
+            kind: IUnassignTagsResultKind.FAIL,
+          } as IUnassignTagsResult;
+        })
+        .catch((err) => {
+          setIsLoading(false);
+          if (showToasts) {
+            triggerError({
+              message: "Could not unassign boxes. Try again?",
+            });
+          }
+          return {
+            kind: IUnassignTagsResultKind.NETWORK_FAIL,
+            requestedLabelIdentifiers: labelIdentifiers,
+            requestedTagIds: tagIds,
+            error: err,
+          } as IUnassignTagsResult;
+        });
+    },
+    [unassignTagsMutation, triggerError],
+  );
+
+  return {
+    unassignTags,
+    isLoading,
+  };
+};

--- a/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
+++ b/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
@@ -26,6 +26,7 @@ import MakeLabelsButton from "./MakeLabelsButton";
 import AssignTagsButton from "./AssignTagsButton";
 import { IDropdownOption } from "components/Form/SelectField";
 import { useAssignTags } from "hooks/useAssignTags";
+import RemoveTagsButton from "./RemoveTagsButton";
 
 export interface IBoxesActionsAndTableProps {
   tableConfig: IUseTableConfigReturnType;
@@ -64,6 +65,14 @@ function BoxesActionsAndTable({
       ),
     [selectedBoxes],
   );
+
+  // Used for remove tags
+  const getSelectedBoxTags = useMemo(() => {
+    const selectedBoxTags = selectedBoxes.map((box) => box.values.tags);
+    const tagsToFilter = new Set(selectedBoxTags.flat().map((tag) => tag.id));
+    const commonTags = tagOptions.filter((tag) => tagsToFilter.has(tag.value));
+    return commonTags;
+  }, [selectedBoxes, tagOptions]);
 
   // Move Boxes
   const moveBoxesAction = useMoveBoxes();

--- a/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
+++ b/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
@@ -27,6 +27,7 @@ import AssignTagsButton from "./AssignTagsButton";
 import { IDropdownOption } from "components/Form/SelectField";
 import { useAssignTags } from "hooks/useAssignTags";
 import RemoveTagsButton from "./RemoveTagsButton";
+import { useUnassignTags } from "hooks/useUnassignTags";
 
 export interface IBoxesActionsAndTableProps {
   tableConfig: IUseTableConfigReturnType;
@@ -249,12 +250,25 @@ function BoxesActionsAndTable({
     [assignTags, selectedBoxes],
   );
 
+  // Unassign tags from boxes
+  const { unassignTags, isLoading: isUnassignTagsLoading } = useUnassignTags();
+  const onUnassignTags = useCallback(
+    async (tagIds: string[]) => {
+      await unassignTags(
+        selectedBoxes.map((box) => box.values.labelIdentifier),
+        tagIds.map((id) => parseInt(id, 10)),
+      );
+    },
+    [unassignTags, selectedBoxes],
+  );
+
   const actionsAreLoading =
     moveBoxesAction.isLoading ||
     isAssignBoxesToShipmentLoading ||
     isUnassignBoxesFromShipmentsLoading ||
     isDeleteBoxesLoading ||
-    isAssignTagsLoading;
+    isAssignTagsLoading ||
+    isUnassignTagsLoading;
 
   const actionButtons = useMemo(
     () => [
@@ -303,7 +317,7 @@ function BoxesActionsAndTable({
             <RemoveTagsButton
               selectedBoxes={selectedBoxes}
               key="remove-tags"
-              onRemoveTags={onAssignTags}
+              onRemoveTags={onUnassignTags}
               allTagOptions={tagOptions}
               currentTagOptions={getSelectedBoxTags}
             />
@@ -335,6 +349,7 @@ function BoxesActionsAndTable({
       onUnassignBoxesToShipment,
       onAssignTags,
       getSelectedBoxTags,
+      onUnassignTags,
     ],
   );
 

--- a/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
+++ b/front/src/views/Boxes/components/BoxesActionsAndTable.tsx
@@ -299,6 +299,15 @@ function BoxesActionsAndTable({
               allTagOptions={tagOptions}
             />
           </Menu>
+          <Menu>
+            <RemoveTagsButton
+              selectedBoxes={selectedBoxes}
+              key="remove-tags"
+              onRemoveTags={onAssignTags}
+              allTagOptions={tagOptions}
+              currentTagOptions={getSelectedBoxTags}
+            />
+          </Menu>
           <MenuItem as="div">
             <MakeLabelsButton selectedBoxes={selectedBoxes} key="make-labels" />
           </MenuItem>
@@ -325,6 +334,7 @@ function BoxesActionsAndTable({
       tagOptions,
       onUnassignBoxesToShipment,
       onAssignTags,
+      getSelectedBoxTags,
     ],
   );
 

--- a/front/src/views/Boxes/components/RemoveTagsButton.tsx
+++ b/front/src/views/Boxes/components/RemoveTagsButton.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from "react";
+import { Row } from "react-table";
+
+import { BoxRow } from "./types";
+import { useNotification } from "hooks/useNotification";
+import { BiSolidTagX } from "react-icons/bi";
+import { Box, Button, VStack } from "@chakra-ui/react";
+
+import { Select } from "chakra-react-select";
+import { IDropdownOption } from "components/Form/SelectField";
+
+interface RemoveTagsButtonProps {
+  onRemoveTags: (tagIds: string[]) => void;
+  selectedBoxes: Row<BoxRow>[];
+  allTagOptions: IDropdownOption[];
+  currentTagOptions: IDropdownOption[];
+}
+
+const RemoveTagsButton: React.FC<RemoveTagsButtonProps> = ({
+  onRemoveTags,
+  selectedBoxes,
+  allTagOptions,
+  currentTagOptions,
+}) => {
+  const { createToast } = useNotification();
+
+  const [isInputOpen, setIsInputOpen] = useState(false);
+  const [selectedTagOptions, setSelectedTagOptions] =
+    useState<IDropdownOption[]>(currentTagOptions);
+
+  const handleOpenInput = () => {
+    if (selectedBoxes.length === 0) {
+      createToast({
+        type: "warning",
+        message: `Please select a box to remove tags`,
+      });
+    }
+    if (selectedBoxes.length !== 0) {
+      setIsInputOpen(true);
+    }
+  };
+
+  const handleConfirmRemoveTags = () => {
+    onRemoveTags(selectedTagOptions.map((tag) => tag.value));
+    setIsInputOpen(false);
+    setSelectedTagOptions([]);
+  };
+
+  return (
+    <VStack spacing={2}>
+      <Box w="full" alignSelf="start">
+        <Button
+          w="full"
+          justifyContent="flex-start"
+          padding={4}
+          iconSpacing={2}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleOpenInput();
+          }}
+          leftIcon={<BiSolidTagX />}
+          variant="ghost"
+          data-testid="remove-tags-button"
+        >
+          Remove Tags
+        </Button>
+      </Box>
+      {isInputOpen && (
+        <>
+          <Box maxWidth={230}>
+            <Select
+              placeholder="Type to find tags"
+              isSearchable
+              tagVariant="outline"
+              focusBorderColor="blue.500"
+              chakraStyles={{
+                control: (provided) => ({
+                  ...provided,
+                  border: "2px",
+                  borderRadius: "0",
+                }),
+                multiValue: (provided, state) => ({
+                  ...provided,
+                  background: state.data?.color,
+                }),
+              }}
+              isMulti
+              options={allTagOptions}
+              value={selectedTagOptions}
+              onChange={(s: any) => {
+                setSelectedTagOptions(s);
+              }}
+            />
+          </Box>
+          <Box marginRight="10px" alignSelf="end" marginBottom="20px">
+            <Button borderRadius={4} colorScheme="blue" onClick={handleConfirmRemoveTags}>
+              Apply
+            </Button>
+          </Box>
+        </>
+      )}
+    </VStack>
+  );
+};
+
+export default RemoveTagsButton;

--- a/front/src/views/Boxes/components/RemoveTagsButton.tsx
+++ b/front/src/views/Boxes/components/RemoveTagsButton.tsx
@@ -77,6 +77,7 @@ const RemoveTagsButton: React.FC<RemoveTagsButtonProps> = ({
               placeholder="Type to find tags"
               isSearchable
               tagVariant="outline"
+              tagColorScheme="black"
               focusBorderColor="blue.500"
               chakraStyles={{
                 control: (provided) => ({

--- a/front/src/views/Boxes/components/RemoveTagsButton.tsx
+++ b/front/src/views/Boxes/components/RemoveTagsButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Row } from "react-table";
 
 import { BoxRow } from "./types";
@@ -25,8 +25,13 @@ const RemoveTagsButton: React.FC<RemoveTagsButtonProps> = ({
   const { createToast } = useNotification();
 
   const [isInputOpen, setIsInputOpen] = useState(false);
-  const [selectedTagOptions, setSelectedTagOptions] =
-    useState<IDropdownOption[]>(currentTagOptions);
+  const [selectedTagOptions, setSelectedTagOptions] = useState<IDropdownOption[]>([]);
+
+  useEffect(() => {
+    if (currentTagOptions.length > 0) {
+      setSelectedTagOptions(currentTagOptions);
+    }
+  }, [currentTagOptions]);
 
   const handleOpenInput = () => {
     if (selectedBoxes.length === 0) {


### PR DESCRIPTION
Some testing has been done locally but I notice that the updated tags only get reflected in the UI after a refresh of the page. @pylipp Did you know if there is a way to force refresh the boxes after a mutation is executed, or @HaGuesto if you know? 

I noticed that when you unassign tags to boxes, say boxes 1 have tags = A, B, and box 2 has tags = B, C, when A, B, C are all selected, all these tags get unassigned. Is this intended behavior? 

