### PR TITLE
BUG FIX for unassigntags - No tags should get rendered if tagless box is selected

### DIFF
--- a/front/src/views/Boxes/components/RemoveTagsButton.tsx
+++ b/front/src/views/Boxes/components/RemoveTagsButton.tsx
@@ -28,8 +28,10 @@ const RemoveTagsButton: React.FC<RemoveTagsButtonProps> = ({
   const [selectedTagOptions, setSelectedTagOptions] = useState<IDropdownOption[]>([]);
 
   useEffect(() => {
-    if (currentTagOptions.length > 0) {
+    if (currentTagOptions.length >= 1) {
       setSelectedTagOptions(currentTagOptions);
+    } else {
+      setSelectedTagOptions([]);
     }
   }, [currentTagOptions]);
 


### PR DESCRIPTION
As the title describes. Currently if 2 boxes are selected and one of them has tags but the other has 0, when the box with tags gets unchecked, leaving only one box selected, the dropdown doesnt render 0 tags (which is expected behavior). 
This commit fixes that. 

