### PR TITLE
Update EnableStandardProduct back navigation

### DIFF
--- a/front/src/views/EnableStandardProduct/EnableStandardProductView.tsx
+++ b/front/src/views/EnableStandardProduct/EnableStandardProductView.tsx
@@ -171,9 +171,12 @@ function EnableStandardProductFormContainer() {
 }
 
 function EnableStandardProductView() {
+  const baseId = useAtomValue(selectedBaseIdAtom);
   return (
     <>
-      <MobileBreadcrumbButton label="Back to Manage Products" linkPath=".." />
+    {/* If a standard product is selected, the view path becomes /products/enable/X, if none is
+    selected yet, the view path is /products/enable. In both cases return to ProductsView */}
+      <MobileBreadcrumbButton label="Back to Manage Products" linkPath={`/bases/${baseId}/products`} />
       <Center>
         {/* <form action=""> */}
         <Box w={["100%", "100%", "60%", "40%"]}>

--- a/front/src/views/EnableStandardProduct/components/EnableStandardProductForm.tsx
+++ b/front/src/views/EnableStandardProduct/components/EnableStandardProductForm.tsx
@@ -230,7 +230,7 @@ function EnableStandardProductForm({
             type="button"
             w="full"
             variant="cancel"
-            onClick={() => navigate("../../")}
+            onClick={() => navigate(`${selectedStandardProduct ? "../.." : ".."}`)}
           >
             Nevermind
           </Button>


### PR DESCRIPTION
- Make breadcrumb navigation on EnableStandardProductView use absolute path (partially broken by myself in #2174)
- Fix cancel button navigation in EnableStandardProductForm
FYI @HaGuesto @fhenrich33 