### PR TITLE
Fix create box if not having visited BoxesView before

### DIFF
--- a/front/src/hooks/hooks.ts
+++ b/front/src/hooks/hooks.ts
@@ -81,7 +81,7 @@ export interface ITableConfig {
 
 interface IUseTableConfigProps {
   tableConfigKey: string;
-  defaultTableConfig?: ITableConfig;
+  defaultTableConfig: ITableConfig;
 }
 
 export interface IUseTableConfigReturnType {
@@ -109,7 +109,7 @@ export const useTableConfig = ({
   const [searchParams] = useSearchParams();
 
   // Intialization
-  if (!tableConfigsState.has(tableConfigKey) && defaultTableConfig) {
+  if (!tableConfigsState.has(tableConfigKey)) {
     const tableConfig: ITableConfig = {
       globalFilter: defaultTableConfig.globalFilter,
       columnFilters: searchParams.get("columnFilters")

--- a/front/src/views/BoxCreate/BoxCreateView.tsx
+++ b/front/src/views/BoxCreate/BoxCreateView.tsx
@@ -163,7 +163,25 @@ function BoxCreateView() {
 
   // Handle Submission
   const tableConfigKey = `bases/${baseId}/boxes`;
-  const tableConfig = useTableConfig({tableConfigKey})
+  const tableConfig = useTableConfig({
+    tableConfigKey,
+    defaultTableConfig: {
+      columnFilters: [{ id: "state", value: ["InStock"] }],
+      sortBy: [{ id: "lastModified", desc: true }],
+      hiddenColumns: [
+        "gender",
+        "size",
+        "shipment",
+        "comment",
+        "age",
+        "lastModified",
+        "lastModifiedBy",
+        "createdBy",
+        "productCategory",
+        "id",
+      ],
+    },
+  });
   const onSubmitBoxCreateForm = (createBoxData: ICreateBoxFormData) => {
     const tagIds = createBoxData?.tags
       ? createBoxData?.tags?.map((tag) => parseInt(tag.value, 10))


### PR DESCRIPTION
- Revert "Make IUseTableConfigProps.defaultTableConfig optional"
- Use defaultTableConfig when refetching boxesview data after creating box
FYI  @HaGuesto @fhenrich33 
Actually a follow-up for an edgecase of #2167 

Sentry: https://boxwise.sentry.io/issues/6623399559/?project=6584301&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0