### PR TITLE
Remove refetching BOXES_FOR_BOXESVIEW_QUERY after creating box

### DIFF
--- a/front/src/views/BoxCreate/BoxCreateView.tsx
+++ b/front/src/views/BoxCreate/BoxCreateView.tsx
@@ -12,9 +12,6 @@ import BoxCreate, { ICreateBoxFormData } from "./components/BoxCreate";
 import { AlertWithoutAction } from "components/Alerts";
 import { selectedBaseAtom, selectedBaseIdAtom } from "stores/globalPreferenceStore";
 import { useAtomValue } from "jotai";
-import { BOXES_FOR_BOXESVIEW_QUERY } from "views/Boxes/BoxesView";
-import { prepareBoxesForBoxesViewQueryVariables } from "views/Boxes/components/transformers";
-import { useTableConfig } from "hooks/hooks";
 
 // TODO: Create fragment or query for ALL_PRODUCTS_AND_LOCATIONS_FOR_BASE_QUERY
 export const ALL_PRODUCTS_AND_LOCATIONS_FOR_BASE_QUERY = graphql(
@@ -162,26 +159,6 @@ function BoxCreateView() {
   }, [triggerError, allFormOptions.loading, allLocations, allProducts]);
 
   // Handle Submission
-  const tableConfigKey = `bases/${baseId}/boxes`;
-  const tableConfig = useTableConfig({
-    tableConfigKey,
-    defaultTableConfig: {
-      columnFilters: [{ id: "state", value: ["InStock"] }],
-      sortBy: [{ id: "lastModified", desc: true }],
-      hiddenColumns: [
-        "gender",
-        "size",
-        "shipment",
-        "comment",
-        "age",
-        "lastModified",
-        "lastModifiedBy",
-        "createdBy",
-        "productCategory",
-        "id",
-      ],
-    },
-  });
   const onSubmitBoxCreateForm = (createBoxData: ICreateBoxFormData) => {
     const tagIds = createBoxData?.tags
       ? createBoxData?.tags?.map((tag) => parseInt(tag.value, 10))
@@ -197,12 +174,6 @@ function BoxCreateView() {
         tagIds,
         qrCode,
       },
-      refetchQueries: [
-        {
-          query: BOXES_FOR_BOXESVIEW_QUERY,
-          variables: prepareBoxesForBoxesViewQueryVariables(baseId, tableConfig.getColumnFilters()),
-        },
-      ],
     })
       .then((mutationResult) => {
         if (mutationResult.errors) {


### PR DESCRIPTION
Revert #2167 and #2176.
The memory load is too large for the GAE instance, we're seeing
gunicorn workers being terminated by GAE.
