### PR TITLE
Correctly show box sizes grouped by product in ShipmentView

### DIFF
--- a/front/src/mocks/products.ts
+++ b/front/src/mocks/products.ts
@@ -25,6 +25,7 @@ export const productBasic1 = {
   },
   gender: "Boy",
   type: "Custom",
+  sizeRange: sizeRange1,
   deletedOn: null,
   __typename: "Product",
 };

--- a/front/src/mocks/shipmentDetail.ts
+++ b/front/src/mocks/shipmentDetail.ts
@@ -77,5 +77,6 @@ export const generateMockShipmentDetail = ({
   lostBy: null,
   receivedOn: null,
   receivedBy: null,
+  autoMatchingTargetProduct: null,
   __typename: "ShipmentDetail",
 });

--- a/front/src/views/Transfers/ShipmentView/ShipmentView.test.tsx
+++ b/front/src/views/Transfers/ShipmentView/ShipmentView.test.tsx
@@ -269,6 +269,9 @@ describe("4.5 Test Cases", () => {
       name: /10/i,
     });
 
+    // check for shipment content grouped by product
+    expect(screen.getByText(/mixed women long sleeves/i)).toBeInTheDocument();
+    expect(screen.getByText(/s women long sleeves/i)).toBeInTheDocument();
     expect(screen.getByText(/30x/i)).toBeInTheDocument();
   }, 10000);
 

--- a/front/src/views/Transfers/ShipmentView/ShipmentView.test.tsx
+++ b/front/src/views/Transfers/ShipmentView/ShipmentView.test.tsx
@@ -2,6 +2,8 @@ import { beforeEach, it, describe, expect, vi } from "vitest";
 import { screen, render, waitFor } from "tests/test-utils";
 import { generateMockShipment, generateMockShipmentWithCustomDetails } from "mocks/shipments";
 import { generateMockBox } from "mocks/boxes";
+import { product1 } from "mocks/products";
+import { size1, size2 } from "mocks/sizeRanges";
 import { userEvent } from "@testing-library/user-event";
 import { FakeGraphQLError, mockMatchMediaQuery } from "mocks/functions";
 import { generateMockShipmentDetail } from "mocks/shipmentDetail";
@@ -32,6 +34,8 @@ const initialQuery = {
   },
 };
 
+const mockBox1 = generateMockBox({ labelIdentifier: "123", product: product1, size: size2, numberOfItems: 10 });
+const mockBox2 = generateMockBox({ labelIdentifier: "124", product: product1, size: size1, numberOfItems: 20 });
 const initialWithGroupedItemQuery = {
   request: {
     query: SHIPMENT_BY_ID_QUERY,
@@ -44,11 +48,19 @@ const initialWithGroupedItemQuery = {
       shipment: generateMockShipmentWithCustomDetails({
         state: "Preparing",
         details: [
-          generateMockShipmentDetail({ id: "1", box: generateMockBox({ labelIdentifier: "123" }) }),
+          generateMockShipmentDetail({
+            id: "1",
+            box: mockBox1,
+            sourceProduct: mockBox1.product,
+            sourceSize: mockBox1.size,
+            sourceQuantity: mockBox1.numberOfItems,
+          }),
           generateMockShipmentDetail({
             id: "2",
-            box: generateMockBox({ labelIdentifier: "124", numberOfItems: 20 }),
-            sourceQuantity: 20,
+            box: mockBox2,
+            sourceProduct: mockBox2.product,
+            sourceSize: mockBox2.size,
+            sourceQuantity: mockBox2.numberOfItems,
           }),
         ],
       }),

--- a/front/src/views/Transfers/ShipmentView/ShipmentView.tsx
+++ b/front/src/views/Transfers/ShipmentView/ShipmentView.tsx
@@ -530,7 +530,7 @@ function ShipmentView() {
     shipmentTab = (
       <ShipmentTabs
         shipmentState={shipmentState}
-        detail={shipmentContents}
+        details={shipmentContents}
         histories={sortedGroupedHistoryEntries}
         isLoadingMutation={isLoadingFromMutation}
         onRemoveBox={onRemoveBox}

--- a/front/src/views/Transfers/ShipmentView/components/ShipmentTabs.tsx
+++ b/front/src/views/Transfers/ShipmentView/components/ShipmentTabs.tsx
@@ -59,7 +59,7 @@ function ShipmentTabs({
           (detail) =>
             ({
               ...detail.box,
-              size: group[0]?.sourceSize,
+              size: detail.sourceSize,
               numberOfItems: detail.sourceQuantity,
               product: group[0]?.sourceProduct,
             }) as Box,

--- a/front/src/views/Transfers/ShipmentView/components/ShipmentTabs.tsx
+++ b/front/src/views/Transfers/ShipmentView/components/ShipmentTabs.tsx
@@ -31,7 +31,7 @@ export interface IGroupedHistoryEntry {
 
 export interface IShipmentTabsProps {
   shipmentState: ShipmentState | undefined;
-  detail: ShipmentDetail[];
+  details: ShipmentDetail[];
   histories: IGroupedRecordEntry[];
   isLoadingMutation: boolean | undefined;
   showRemoveIcon: Boolean;
@@ -40,7 +40,7 @@ export interface IShipmentTabsProps {
 }
 function ShipmentTabs({
   showRemoveIcon,
-  detail,
+  details,
   histories,
   isLoadingMutation,
   onRemoveBox,
@@ -48,19 +48,19 @@ function ShipmentTabs({
   shipmentState,
 }: IShipmentTabsProps) {
   const boxGroupedByProductGender = _.values(
-    _(detail)
-      .groupBy((shipment) => `${shipment?.sourceProduct?.name}_${shipment?.sourceProduct?.gender}`)
+    _(details)
+      .groupBy((detail) => `${detail?.sourceProduct?.name}_${detail?.sourceProduct?.gender}`)
       .mapValues((group) => ({
         product: group[0]?.sourceProduct,
-        totalItems: _.sumBy(group, (shipment) => shipment?.sourceQuantity || 0),
+        totalItems: _.sumBy(group, (detail) => detail?.sourceQuantity || 0),
         totalBoxes: group.length,
-        totalLosts: group.filter((shipment) => shipment?.lostOn !== null).length,
+        totalLosts: group.filter((detail) => detail?.lostOn !== null).length,
         boxes: group.map(
-          (shipment) =>
+          (detail) =>
             ({
-              ...shipment.box,
+              ...detail.box,
               size: group[0]?.sourceSize,
-              numberOfItems: shipment.sourceQuantity,
+              numberOfItems: detail.sourceQuantity,
               product: group[0]?.sourceProduct,
             }) as Box,
         ),
@@ -81,7 +81,7 @@ function ShipmentTabs({
       </TabList>
       <TabPanels>
         <TabPanel p={0}>
-          {(detail?.length || 0) === 0 && (
+          {(details?.length || 0) === 0 && (
             <Center p={8}>No boxes have been assigned to this shipment yet!</Center>
           )}
           <ShipmentContent


### PR DESCRIPTION

![2025-06-12-152953_931x575_scrot](https://github.com/user-attachments/assets/76e8b445-8c09-438f-9473-91ed9cb6f478)


- Update confusing naming
- Correctly set up shipment detail test data
- Show correct box sizes when grouping by product in ShipmentView
- Remove 'Missing field' warning when creating mock data
