### PR TITLE
add query execution time to gcloud logging

### DIFF
--- a/back/boxtribute_server/logging.py
+++ b/back/boxtribute_server/logging.py
@@ -10,6 +10,7 @@ from .utils import in_ci_environment, in_development_environment
 # Context names
 API_CONTEXT = "api"
 WEBAPP_CONTEXT = "webapp"
+SHARED_CONTEXT = "shared"
 
 if in_ci_environment() or in_development_environment():
     # Skip logger initialization when running tests in CircleCI, or during local
@@ -28,7 +29,7 @@ else:  # pragma: no cover
     # Store logs in "projects/dropapp-******/logs/api-requests" or ".../webapp-requests"
     request_loggers = {
         context: _logging_client.logger(f"{context}-requests")
-        for context in [API_CONTEXT, WEBAPP_CONTEXT]
+        for context in [API_CONTEXT, WEBAPP_CONTEXT, SHARED_CONTEXT]
     }
 
 

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -23,6 +23,7 @@ from .graph_ql.execution import execute_async
 from .graph_ql.schema import full_api_schema, public_api_schema, query_api_schema
 from .logging import (
     API_CONTEXT,
+    SHARED_CONTEXT,
     WEBAPP_CONTEXT,
     log_profiled_request_to_gcloud,
     log_request_to_gcloud,
@@ -73,7 +74,7 @@ def query_api_server():
     allow_headers="*" if in_development_environment() else CORS_HEADERS,
 )
 def public_api_server():
-    log_request_to_gcloud(context=API_CONTEXT)
+    log_request_to_gcloud(context=SHARED_CONTEXT)
     return execute_async(schema=public_api_schema, introspection=True)
 
 

--- a/back/boxtribute_server/routes.py
+++ b/back/boxtribute_server/routes.py
@@ -53,8 +53,8 @@ def query_api_explorer():
 @api_bp.post(API_GRAPHQL_PATH)
 @requires_auth
 def query_api_server():
-    log_request_to_gcloud(context=API_CONTEXT)
-    return execute_async(schema=query_api_schema, introspection=True)
+    with log_profiled_request_to_gcloud(context=API_CONTEXT):
+        return execute_async(schema=query_api_schema, introspection=True)
 
 
 @shared_bp.post(SHARED_GRAPHQL_PATH)

--- a/back/test/endpoint_tests/test_app.py
+++ b/back/test/endpoint_tests/test_app.py
@@ -480,11 +480,13 @@ def test_gcloud_logging(read_only_client, mocker):
     # Send request to / endpoint of query-API blueprint
     bases = assert_successful_request(read_only_client, query, endpoint="")
 
-    # Expect one call to api logger without execution time
+    # Expect one call to api logger including execution time
     mocked_log_struct = mocked_loggers[API_CONTEXT].log_struct
     mocked_log_struct.assert_called_once()
     assert mocked_log_struct.call_args.kwargs == {"severity": "INFO"}
-    assert mocked_log_struct.call_args.args == ({"query": query},)
+    call_args = mocked_log_struct.call_args.args[0]
+    assert call_args.pop("execution_time") < 10
+    assert call_args == {"query": query}
     assert bases == [{"id": "1"}]
     mocked_loggers[WEBAPP_CONTEXT].log_struct.assert_not_called()
     mocked_loggers[SHARED_CONTEXT].log_struct.assert_not_called()


### PR DESCRIPTION
- Log GraphQL query execution time to GCloud
- Add logging test for requests to query-API
- Use distinct context name for requests to public endpoint
