### PR TITLE
Avoid redundant history entries when repeatedly adding/removing box to/from shipment

### DIFF
--- a/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
@@ -50,7 +50,7 @@ def _validate_bases_as_part_of_transfer_agreement(
 
     all_base_ids = base_ids["source"] + base_ids["target"]
     for kind in kinds:
-        base_id = locals()[f"{kind}_base_id"]
+        base_id = source_base_id if kind == "source" else target_base_id
         if base_id is None:
             continue
 

--- a/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
+++ b/back/boxtribute_server/business_logic/box_transfer/shipment/crud.py
@@ -337,6 +337,7 @@ def _remove_boxes_from_shipment(
         shipment_id,
         (Box.label_identifier << box_label_identifiers),
         Box.state << old_box_states,
+        ShipmentDetail.removed_on.is_null(),
     ):
         setattr(detail, fields[0].name, now)
         setattr(detail, fields[1].name, user_id)

--- a/back/test/endpoint_tests/test_shipment.py
+++ b/back/test/endpoint_tests/test_shipment.py
@@ -465,7 +465,7 @@ def test_shipment_mutations_on_source_side(
         box_response = assert_successful_request(client, query)
         assert box_response == {"state": BoxState(box["state"]).name}
 
-    # Add one box again
+    # Add one box again, remove it, and add it again
     box_label_identifier = default_box["label_identifier"]
     update_input = f"""{{ id: {shipment_id},
                 preparedBoxLabelIdentifiers: ["{box_label_identifier}"] }}"""
@@ -473,6 +473,22 @@ def test_shipment_mutations_on_source_side(
                 updateInput: {update_input}) {{
                     details {{ id box {{ state }} }} }} }}"""
     shipment = assert_successful_request(client, mutation)
+    temp_shipment_detail_id = str(shipment["details"][-1].pop("id"))
+
+    update_input = f"""{{ id: {shipment_id},
+                removedBoxLabelIdentifiers: ["{box_label_identifier}"] }}"""
+    mutation = f"""mutation {{ updateShipmentWhenPreparing(
+                updateInput: {update_input}) {{
+                    details {{ id box {{ state }} }} }} }}"""
+    assert_successful_request(client, mutation)
+
+    update_input = f"""{{ id: {shipment_id},
+                preparedBoxLabelIdentifiers: ["{box_label_identifier}"] }}"""
+    mutation = f"""mutation {{ updateShipmentWhenPreparing(
+                updateInput: {update_input}) {{
+                    details {{ id box {{ state }} }} }} }}"""
+    shipment = assert_successful_request(client, mutation)
+
     newest_shipment_detail_id = str(shipment["details"][-1].pop("id"))
     assert shipment == {
         "details": [
@@ -482,6 +498,11 @@ def test_shipment_mutations_on_source_side(
             },
             {
                 "id": shipment_detail_id,
+                # this points to the box that has been marked for shipment again
+                "box": {"state": BoxState.MarkedForShipment.name},
+            },
+            {
+                "id": temp_shipment_detail_id,
                 # this points to the box that has been marked for shipment again
                 "box": {"state": BoxState.MarkedForShipment.name},
             },
@@ -511,6 +532,23 @@ def test_shipment_mutations_on_source_side(
     assert shipment["details"][0]["box"].pop("lastModifiedOn").startswith(today)
     assert shipment["details"][1]["box"].pop("lastModifiedOn").startswith(today)
     assert shipment["details"][2]["box"].pop("lastModifiedOn").startswith(today)
+    assert shipment["details"][3]["box"].pop("lastModifiedOn").startswith(today)
+    common_box_info = {
+        "state": BoxState.InTransit.name,
+        "lastModifiedBy": {"id": source_base_user_id},
+        "history": [
+            {"changes": f"{change_prefix} MarkedForShipment to InTransit"},
+            {"changes": f"{change_prefix} InStock to MarkedForShipment"},
+            {"changes": f"{change_prefix} MarkedForShipment to InStock"},
+            {"changes": f"{change_prefix} InStock to MarkedForShipment"},
+            {"changes": f"{change_prefix} MarkedForShipment to InStock"},
+            {"changes": f"{change_prefix} InStock to MarkedForShipment"},
+            {"changes": "assigned tag 'pallet1' to box"},
+            {"changes": "removed tag 'pallet1' from box"},
+            {"changes": "assigned tag 'pallet1' to box"},
+            {"changes": "created record"},
+        ],
+    }
     assert shipment == {
         "id": shipment_id,
         "state": ShipmentState.Sent.name,
@@ -531,37 +569,15 @@ def test_shipment_mutations_on_source_side(
             },
             {
                 "id": shipment_detail_id,
-                "box": {
-                    "state": BoxState.InTransit.name,
-                    "lastModifiedBy": {"id": source_base_user_id},
-                    "history": [
-                        {"changes": f"{change_prefix} MarkedForShipment to InTransit"},
-                        {"changes": f"{change_prefix} InStock to MarkedForShipment"},
-                        {"changes": f"{change_prefix} MarkedForShipment to InStock"},
-                        {"changes": f"{change_prefix} InStock to MarkedForShipment"},
-                        {"changes": "assigned tag 'pallet1' to box"},
-                        {"changes": "removed tag 'pallet1' from box"},
-                        {"changes": "assigned tag 'pallet1' to box"},
-                        {"changes": "created record"},
-                    ],
-                },
+                "box": common_box_info,
+            },
+            {
+                "id": temp_shipment_detail_id,
+                "box": common_box_info,
             },
             {
                 "id": newest_shipment_detail_id,
-                "box": {
-                    "state": BoxState.InTransit.name,
-                    "lastModifiedBy": {"id": source_base_user_id},
-                    "history": [
-                        {"changes": f"{change_prefix} MarkedForShipment to InTransit"},
-                        {"changes": f"{change_prefix} InStock to MarkedForShipment"},
-                        {"changes": f"{change_prefix} MarkedForShipment to InStock"},
-                        {"changes": f"{change_prefix} InStock to MarkedForShipment"},
-                        {"changes": "assigned tag 'pallet1' to box"},
-                        {"changes": "removed tag 'pallet1' from box"},
-                        {"changes": "assigned tag 'pallet1' to box"},
-                        {"changes": "created record"},
-                    ],
-                },
+                "box": common_box_info,
             },
         ],
     }


### PR DESCRIPTION
https://trello.com/c/uUaagOoO/1807-20-bug-multiple-history-entries-when-repeatedly-adding-removing-box-to-from-shipment