### PR TITLE
Only return tagged boxes if tag filter applied in public StockOverview

### DIFF
--- a/back/boxtribute_server/business_logic/statistics/crud.py
+++ b/back/boxtribute_server/business_logic/statistics/crud.py
@@ -432,12 +432,13 @@ def compute_moved_boxes(base_id):
     return DataCube(facts=facts, dimensions=dimensions, type="MovedBoxesData")
 
 
-def compute_stock_overview(base_id):
+def compute_stock_overview(base_id, *, tag_ids=None):
     """Compute stock overview (number of boxes and number of contained items) for the
     given base. The result can be filtered by size, location, box state, product
     category, product name, and product gender.
     """
     _validate_existing_base(base_id)
+    tag_filter = (TagsRelation.tag << tag_ids) if tag_ids else True
 
     # Subquery to select distinct boxes with associated tags
     boxes = (
@@ -465,7 +466,7 @@ def compute_stock_overview(base_id):
                 & (TagsRelation.deleted_on.is_null())
             ),
         )
-        .where((~Box.deleted_on) | (Box.deleted_on.is_null()))
+        .where((~Box.deleted_on) | (Box.deleted_on.is_null()), tag_filter)
         .group_by(Box.id)
     )
     facts = (

--- a/back/boxtribute_server/business_logic/statistics/fields.py
+++ b/back/boxtribute_server/business_logic/statistics/fields.py
@@ -1,3 +1,5 @@
+import urllib.parse as up
+
 from ariadne import ObjectType
 
 from ...enums import ShareableView
@@ -24,7 +26,14 @@ def resolve_resolved_link_data(resolved_link_obj, _):
         ]
 
     elif resolved_link_obj.view == ShareableView.StockOverview:
-        return [compute_stock_overview(resolved_link_obj.base_id)]
+        tag_ids = None
+        if resolved_link_obj.url_parameters is not None:
+            # Skip leading '?' in URL parameters
+            raw_tag_ids = up.parse_qs(resolved_link_obj.url_parameters[1:]).get("tags")
+            if raw_tag_ids:
+                # parse_qs returns a list with one element; decode the IDs
+                tag_ids = [int(i) for i in raw_tag_ids[0].split(",")]
+        return [compute_stock_overview(resolved_link_obj.base_id, tag_ids=tag_ids)]
 
     else:  # pragma: no cover
         raise ValueError("Invalid value for ShareableView")

--- a/back/test/data/__init__.py
+++ b/back/test/data/__init__.py
@@ -74,7 +74,12 @@ from .qr_code import (
     qr_code_for_not_delivered_box,
     qr_code_without_box,
 )
-from .shareable_link import expired_link, shareable_link, stock_overview_link
+from .shareable_link import (
+    expired_link,
+    shareable_link,
+    stock_overview_link,
+    tagged_stock_overview_link,
+)
 from .shipment import (
     another_shipment,
     canceled_shipment,
@@ -216,6 +221,7 @@ __all__ = [
     "standard_products",
     "stock_overview_link",
     "superceding_measure_standard_product",
+    "tagged_stock_overview_link",
     "tags",
     "transfer_agreements",
     "unidirectional_transfer_agreement",

--- a/back/test/data/shareable_link.py
+++ b/back/test/data/shareable_link.py
@@ -44,6 +44,16 @@ def data():
             "created_on": now,
             "created_by": default_user_data()["id"],
         },
+        {
+            "id": 4,
+            "code": hashlib.sha256(b"4").hexdigest(),
+            "valid_until": one_week_from_now,
+            "view": ShareableView.StockOverview,
+            "base_id": 1,
+            "url_parameters": "?tags=2%2C3",
+            "created_on": now,
+            "created_by": default_user_data()["id"],
+        },
     ]
 
 
@@ -60,6 +70,11 @@ def expired_link():
 @pytest.fixture
 def stock_overview_link():
     return data()[2]
+
+
+@pytest.fixture
+def tagged_stock_overview_link():
+    return data()[3]
 
 
 def create():

--- a/back/test/endpoint_tests/test_shareable_link.py
+++ b/back/test/endpoint_tests/test_shareable_link.py
@@ -80,6 +80,7 @@ def test_shareable_link_queries(
     read_only_client,
     shareable_link,
     stock_overview_link,
+    tagged_stock_overview_link,
     expired_link,
     default_base,
     default_organisation,
@@ -162,3 +163,20 @@ def test_shareable_link_queries(
                 }} }}"""
     response = assert_successful_request(read_only_client, query, endpoint="public")
     assert response == {"code": code}
+
+    code = tagged_stock_overview_link["code"]
+    query = f"""query {{ resolveLink(code: "{code}") {{
+                ...on ResolvedLink {{
+                    data {{
+                        ...on StockOverviewData {{
+                            stockOverviewFacts: facts {{ tagIds }}
+                        }}
+                    }}
+                }} }} }}"""
+    response = assert_successful_request(read_only_client, query, endpoint="public")
+    data = response.pop("data")
+    assert data[0]["stockOverviewFacts"] == [
+        {"tagIds": [2, 3]},
+        {"tagIds": [3]},
+        {"tagIds": [3]},
+    ]


### PR DESCRIPTION
Test with `docker compose up` and

1. go to Statviz Dashboard
1. apply a tags filter
1. create a shareable link for StockOverview
1. open the link
1. only the tagged boxes are included
1. when manually modifying the tags URL parameter, the data selection does not change
