### PR TITLE
Fix isInitialMount for BoxesTable

### DIFF
--- a/front/src/hooks/useTableConfig.ts
+++ b/front/src/hooks/useTableConfig.ts
@@ -202,8 +202,8 @@ export const useTableConfig = ({
       setIsInitialMount(false);
     }
     // Intentionally disable exhaustive-deps: this effect is meant to run only once on initial mount.
-    // The values it uses (updateUrl, urlFilters, initialColumnFilters) are stable/memoized by design.
-    // Adding all inferred deps would cause unwanted re-runs; update dependencies intentionally if behavior changes.
+    // The dependencies intentionally included are: syncFiltersAndUrlParams, searchParams, tableConfigKey, tableConfigsState, updateUrl, defaultTableConfig, urlFilters, initialColumnFilters.
+    // These values are stable/memoized by design. Adding all inferred deps would cause unwanted re-runs; update dependencies intentionally if behavior changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     syncFiltersAndUrlParams,


### PR DESCRIPTION
https://trello.com/c/Fmd4vmMN

### Issue

When going from BoxesView to BoxView and back to BoxesView, the skeletons in the top two rows of the table never stop loading. It turns out that `isInitialMount` keeps being true when useTableConfig is called again.

### Solution

Use useState instead of useRef for the initial mount state.