### PR TITLE
QR Overlay Updates

### DIFF
--- a/front/src/components/QrReader/components/QrReader.tsx
+++ b/front/src/components/QrReader/components/QrReader.tsx
@@ -106,7 +106,7 @@ function QrReader({
                   onChange={(e) => onBoxLabelInputChange(e.currentTarget.value)}
                   isDisabled={findBoxByLabelIsLoading}
                   value={boxLabelInputValue}
-                  placeholder={"12345678"}
+                  placeholder="12345678"
                   borderRadius={0}
                 />
                 <InputRightElement>

--- a/front/src/components/QrReaderOverlay/QrReaderOverlay.tsx
+++ b/front/src/components/QrReaderOverlay/QrReaderOverlay.tsx
@@ -20,17 +20,15 @@ function QrReaderOverlay({ isOpen, onClose }: IQrReaderOverlayProps) {
     <Modal isOpen={isOpen} closeOnOverlayClick={false} closeOnEsc onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <div className="flex flex-row justify-end">
-          <ModalHeader>Boxtribute QR Scanner</ModalHeader>
-          <ModalCloseButton />
-        </div>
+        <ModalHeader display="flex" justifyContent="space-between" alignItems="center">
+          Boxtribute QR Scanner
+          <ModalCloseButton position="static" />
+        </ModalHeader>
         <ModalBody>
           <QrReaderContainer onSuccess={onClose} />
         </ModalBody>
         <ModalFooter>
-          <Button mr={3} onClick={onClose}>
-            Close QR Scanner
-          </Button>
+          <Button onClick={onClose}>Close QR Scanner</Button>
         </ModalFooter>
       </ModalContent>
     </Modal>


### PR DESCRIPTION
Related to this [task](https://trello.com/c/ZnUZ1ij8/1467-20-qr-overlay-add-x-on-the-top-right-to-close-the-modal-make-it-uncloseable-otherwise).

Some general questions regarding the qr scanner

- I was unable to get open the qr scanner modal unless i was in mobile view (smaller width) and got the burger menu instead of the sidebar. Is this intentional, or am I just unable to find the QR Scanner button in PC mode?
- When testing the QR Reader on a previous task, I began by manually navigating to /bases/1/qrreader. Is there a way to get to this url normally, or should this url not be accessible technically?

