### PR TITLE
Fetch tag options after creating box with new tag

### DIFF
--- a/front/src/views/BoxCreate/BoxCreateView.tsx
+++ b/front/src/views/BoxCreate/BoxCreateView.tsx
@@ -214,6 +214,16 @@ function BoxCreateView() {
         newTagNames,
         qrCode,
       },
+      refetchQueries:
+        // update tag options if new tag(s) created
+        newTagNames.length > 0
+          ? [
+              {
+                query: ALL_PRODUCTS_AND_LOCATIONS_FOR_BASE_QUERY,
+                variables: { baseId },
+              },
+            ]
+          : undefined,
     })
       .then((mutationResult) => {
         if (mutationResult.errors) {


### PR DESCRIPTION
Avoid re-creating tag of same name when running "Save & create another"

https://trello.com/c/MqyXECSQ
