### PR TITLE
Fix error when creating shipments based on multiple agreements with same org

### DIFF
--- a/front/src/views/Transfers/CreateShipment/CreateShipmentView.tsx
+++ b/front/src/views/Transfers/CreateShipment/CreateShipmentView.tsx
@@ -183,11 +183,12 @@ function CreateShipmentView() {
       // Merge options. If there are multiple transfer agreements this step is necessary
       const existingOrganisation = accumulator.find((org) => org.id === currentOrg.id);
       if (existingOrganisation) {
-        existingOrganisation.bases.push(
+        existingOrganisation.bases = [
+          ...existingOrganisation.bases,
           ...currentOrg.bases.filter(
             (base) => !existingOrganisation.bases.some((b) => b.id === base.id),
           ),
-        );
+        ];
       } else {
         accumulator.push(currentOrg);
       }


### PR DESCRIPTION
Use spread-operator and avoid error
    can't define array index property past the end of an array with non-writable length
cf. https://boxwise.sentry.io/issues/7080935471

https://trello.com/c/cGSXXlMy
