### PR TITLE
Avoid pulling pre-2023 data into movedBoxes stat

### DIFF
--- a/back/boxtribute_server/business_logic/statistics/sql.py
+++ b/back/boxtribute_server/business_logic/statistics/sql.py
@@ -35,11 +35,13 @@ BoxHistory AS (
         h.id AS id
     FROM history h
     JOIN ValidBoxes s ON h.record_id = s.id
-    AND ((h.to_int IS NOT null AND h.id >= %s)
-         OR h.changes = "Record created"
-         OR h.changes = "Record deleted"
-         OR h.changes = "Box was undeleted."
+    AND (
+        h.id >= %s
+        AND (
+            h.to_int IS NOT NULL
+            OR h.changes IN ("Record created", "Record deleted", "Box was undeleted.")
         )
+    )
     AND h.tablename = 'stock'
     ORDER BY record_id, changedate DESC, id DESC
 ),


### PR DESCRIPTION
https://trello.com/c/EFSdLs3F

This didn't affect data display because in the FE we filter by a date range (earliest 2023-01-01).
It reduces the querying time and request size (and hence latency) for bases with a considerable amount of pre-2023 boxes.