### PR TITLE
Show onboarding path 2 to combined warehouse+freeshop volunteers

### DIFF
--- a/front/src/components/Walkthrough/desktop/useVisiblePaths.ts
+++ b/front/src/components/Walkthrough/desktop/useVisiblePaths.ts
@@ -4,14 +4,15 @@ import { WalkthroughPath } from "./paths/types";
 import path1 from "./paths/path1";
 import path2 from "./paths/path2";
 import path3 from "./paths/path3";
-import { isCoordinatorOrAbove, isWarehouseVolunteer } from "../roles";
+import { isCoordinatorOrAbove, isFreeShopVolunteer } from "../roles";
 
 /** Returns the walkthrough paths visible to the current user based on their roles. */
 export function useVisiblePaths(): WalkthroughPath[] {
   const { user } = useAuth0();
   const roles: string | string[] = user?.[JWT_ROLE] ?? [];
 
-  const showPath2 = !isWarehouseVolunteer(roles);
+  // Don't show path 2 if user has only the WarehouseVolunteer role
+  const showPath2 = isCoordinatorOrAbove(roles) || isFreeShopVolunteer(roles);
   const showPath3 = isCoordinatorOrAbove(roles);
 
   return [path1, ...(showPath2 ? [path2] : []), ...(showPath3 ? [path3] : [])];


### PR DESCRIPTION
Several users have both warehouse+freeshop volunteer roles. Previously
they would not see path 2 (beneficiary management) even though they
should.

https://trello.com/c/3v9fM4sY

