### PR TITLE
Collapse dashboard accordion by default

### DIFF
--- a/shared-components/statviz/dashboard/Dashboard.tsx
+++ b/shared-components/statviz/dashboard/Dashboard.tsx
@@ -37,7 +37,7 @@ export default function Dashboard({ roles = [] }: DashboardProps) {
   const movedBoxesIdx = showMovedBoxes ? idx++ : -1;
   const beneficiaryIdx = showBeneficiary ? idx++ : -1;
 
-  const [everOpened, setEverOpened] = useState<Set<number>>(new Set([0]));
+  const [everOpened, setEverOpened] = useState<Set<number>>(new Set());
 
   const handleAccordionChange = (indices: number | number[]) => {
     const next = Array.isArray(indices) ? indices : [indices];
@@ -114,7 +114,7 @@ export default function Dashboard({ roles = [] }: DashboardProps) {
       <InfoText />
 
       <Accordion
-        defaultIndex={[0]}
+        defaultIndex={[]}
         allowMultiple
         marginBottom="100px"
         onChange={handleAccordionChange}


### PR DESCRIPTION
https://trello.com/c/Hd8yfFuD

This helps
- reducing number of requests send to BE on initial view (info and
  filter data queries are immediately sent, section data queries upon
  expanding)
- provoke interaction with the dashboard (hopefully expand at least one
  section)
