### PR TITLE
test: add unit tests for currencySymbol util

### DIFF
--- a/front/src/utils/currencySymbol.test.ts
+++ b/front/src/utils/currencySymbol.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { currencySymbol } from "./currencySymbol";
+
+describe("currencySymbol", () => {
+  it("returns the mapped symbol for a known currency code", () => {
+    expect(currencySymbol("EUR")).toBe("€");
+    expect(currencySymbol("USD")).toBe("$");
+    expect(currencySymbol("GBP")).toBe("£");
+  });
+
+  it("returns an empty string when the code is undefined", () => {
+    expect(currencySymbol(undefined)).toBe("");
+  });
+
+  it("returns an empty string when the code is null", () => {
+    expect(currencySymbol(null)).toBe("");
+  });
+
+  it("returns an empty string when the code is an empty string", () => {
+    expect(currencySymbol("")).toBe("");
+  });
+
+  it("falls back to the code itself for an unknown currency code", () => {
+    expect(currencySymbol("AUD")).toBe("AUD");
+  });
+});


### PR DESCRIPTION
## What changed
Add a unit test file for the `currencySymbol` util.

No production code is touched, this is test-only.

## Why
`front/src/utils/currencySymbol.ts` had zero test coverage.

It maps a currency code to a display symbol and is used by `formatMonetaryValue` in `front/src/utils/helpers.ts`, so its output is shown to users wherever a monetary value is rendered.

The util has three behaviours worth locking in: a known code returns its symbol, a null/undefined/empty code returns "", and an unknown code falls back to returning the code string itself. The tests pin each one.

## How to verify
```bash
pnpm install --frozen-lockfile
TZ=UTC pnpm vitest run front/src/utils/currencySymbol.test.ts
```

## Coverage
Before: 0% (no test file for this util) / After: all branches of `currencySymbol` covered.

## Checks run locally
- [x] Tests: PASS (5 passed, 0 failed)
- [x] Lint: PASS (`pnpm lint front/src/utils/currencySymbol.test.ts`)
- [x] Typecheck: PASS (`pnpm -C front tsc:check`)
- [x] Format: PASS (`prettier --check`)