### PR TITLE
Update Dashboard Movement section after completing shipment

### DIFF
--- a/front/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.test.tsx
+++ b/front/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.test.tsx
@@ -13,6 +13,7 @@ import { SHIPMENT_BY_ID_WITH_PRODUCTS_AND_LOCATIONS_QUERY } from "queries/querie
 import { UPDATE_SHIPMENT_WHEN_RECEIVING } from "queries/mutations";
 import { mockedCreateToast, mockedTriggerError } from "tests/setupTests";
 import { FakeGraphQLError, FakeGraphQLNetworkError } from "mocks/functions";
+import { MOVED_BOXES_QUERY } from "@boxtribute/shared-components/statviz/queries/queries";
 
 vi.mock("@auth0/auth0-react");
 window.scrollTo = vi.fn();
@@ -89,6 +90,7 @@ const mockUpdateShipmentWhenReceivingMutation = ({
   graphQlError = false,
   shipmentId = "1",
   lostBoxLabelIdentifiers = ["123"],
+  resultState = "Receiving" as string,
 }) => ({
   request: {
     query: UPDATE_SHIPMENT_WHEN_RECEIVING,
@@ -103,12 +105,29 @@ const mockUpdateShipmentWhenReceivingMutation = ({
         data: graphQlError
           ? null
           : {
-              updateShipmentWhenReceiving: generateMockShipment({ state: "Receiving" }),
+              updateShipmentWhenReceiving: generateMockShipment({ state: resultState }),
             },
         errors: graphQlError ? [new FakeGraphQLError()] : undefined,
       },
   error: networkError ? new FakeGraphQLNetworkError() : undefined,
 });
+
+// Mock for the background MOVED_BOXES_QUERY refetch triggered when shipment
+// transitions to "Completed" or "Lost"
+const mockMovedBoxesQuery = {
+  request: {
+    query: MOVED_BOXES_QUERY,
+    variables: { baseId: 1 },
+  },
+  result: {
+    data: {
+      movedBoxes: {
+        facts: [],
+        dimensions: { category: [], size: [], target: [] },
+      },
+    },
+  },
+};
 
 const noDeliveryTests = [
   {
@@ -199,6 +218,136 @@ describe("No Delivery Tests", () => {
       40000,
     );
   });
+});
+
+// ---------------------------------------------------------------------------
+// Background MOVED_BOXES_QUERY refetch tests
+// When UPDATE_SHIPMENT_WHEN_RECEIVING returns a shipment in state "Completed"
+// or "Lost", the component should fire a background MOVED_BOXES_QUERY refetch
+// so that the Dashboard Movement section stays up to date.
+// ---------------------------------------------------------------------------
+describe("MOVED_BOXES_QUERY background refetch after onBoxUndelivered", () => {
+  (["Completed", "Lost"] as const).forEach((terminalState) => {
+    it(`triggers MOVED_BOXES_QUERY refetch when mutation returns shipment state "${terminalState}"`, async () => {
+      const user = userEvent.setup();
+      boxReconciliationOverlayVar({
+        isOpen: true,
+        labelIdentifier: "123",
+        shipmentId: "1",
+      } as IBoxReconciliationOverlayVar);
+
+      // Track whether the MOVED_BOXES_QUERY mock was consumed by recording
+      // when its result function is called.
+      let movedBoxesQueryWasFetched = false;
+      const trackedMovedBoxesQueryMock = {
+        ...mockMovedBoxesQuery,
+        result: () => {
+          movedBoxesQueryWasFetched = true;
+          return mockMovedBoxesQuery.result;
+        },
+      };
+
+      render(<BoxReconciliationOverlay />, {
+        routePath: "/bases/:baseId",
+        initialUrl: "/bases/1",
+        mocks: [
+          queryShipmentDetailForBoxReconciliation,
+          mockUpdateShipmentWhenReceivingMutation({ resultState: terminalState }),
+          trackedMovedBoxesQueryMock,
+        ],
+        cache,
+      });
+
+      // Wait for the overlay to render
+      expect(await screen.findByText(/box 123/i)).toBeInTheDocument();
+
+      // Navigate to the NoDelivery button (same interaction path as 4.7.3.3)
+      const matchProductButton = await screen.findByRole("button", {
+        name: /1\. match products/i,
+      });
+      await user.click(matchProductButton);
+      const noDeliveryButton = screen.getByTestId("NoDeliveryButton");
+      await user.click(noDeliveryButton);
+
+      // Confirm in the AYS dialog
+      expect(await screen.findByText(/box not delivered\?/i)).toBeInTheDocument();
+      const yesButton = screen.getByTestId("AYSRightButton");
+      await user.click(yesButton);
+
+      // The success toast must fire first (mutation succeeded)
+      await waitFor(
+        () =>
+          expect(mockedCreateToast).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: expect.stringMatching(/Box marked as undelivered/i),
+            }),
+          ),
+        { timeout: 5000 },
+      );
+
+      // After the mutation resolves, the component should have fired the
+      // background MOVED_BOXES_QUERY refetch.
+      await waitFor(() => expect(movedBoxesQueryWasFetched).toBe(true), { timeout: 5000 });
+    }, 40000);
+  });
+
+  it('does NOT trigger MOVED_BOXES_QUERY refetch when mutation returns shipment state "Receiving"', async () => {
+    const user = userEvent.setup();
+    boxReconciliationOverlayVar({
+      isOpen: true,
+      labelIdentifier: "123",
+      shipmentId: "1",
+    } as IBoxReconciliationOverlayVar);
+
+    let movedBoxesQueryWasFetched = false;
+    const trackedMovedBoxesQueryMock = {
+      ...mockMovedBoxesQuery,
+      result: () => {
+        movedBoxesQueryWasFetched = true;
+        return mockMovedBoxesQuery.result;
+      },
+    };
+
+    render(<BoxReconciliationOverlay />, {
+      routePath: "/bases/:baseId",
+      initialUrl: "/bases/1",
+      mocks: [
+        queryShipmentDetailForBoxReconciliation,
+        // Returns "Receiving" — should NOT trigger refetch
+        mockUpdateShipmentWhenReceivingMutation({ resultState: "Receiving" }),
+        trackedMovedBoxesQueryMock,
+      ],
+      cache,
+    });
+
+    expect(await screen.findByText(/box 123/i)).toBeInTheDocument();
+
+    const matchProductButton = await screen.findByRole("button", {
+      name: /1\. match products/i,
+    });
+    await user.click(matchProductButton);
+    const noDeliveryButton = screen.getByTestId("NoDeliveryButton");
+    await user.click(noDeliveryButton);
+
+    expect(await screen.findByText(/box not delivered\?/i)).toBeInTheDocument();
+    const yesButton = screen.getByTestId("AYSRightButton");
+    await user.click(yesButton);
+
+    // Wait for the success toast to confirm the mutation completed
+    await waitFor(
+      () =>
+        expect(mockedCreateToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringMatching(/Box marked as undelivered/i),
+          }),
+        ),
+      { timeout: 5000 },
+    );
+
+    // Give any async side-effects time to settle, then confirm no refetch
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(movedBoxesQueryWasFetched).toBe(false);
+  }, 40000);
 });
 
 // Test case 4.7.1

--- a/front/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.tsx
+++ b/front/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useMutation, useQuery, useReactiveVar } from "@apollo/client";
+import { useMutation, useQuery, useReactiveVar, useApolloClient } from "@apollo/client";
 import { useAtomValue } from "jotai";
 import { boxReconciliationOverlayVar } from "queries/cache";
 import { SHIPMENT_BY_ID_WITH_PRODUCTS_AND_LOCATIONS_QUERY } from "queries/queries";
@@ -16,6 +16,7 @@ import {
   IProductWithSizeRangeData,
 } from "./components/BoxReconciliationView";
 import { selectedBaseIdAtom } from "stores/globalPreferenceStore";
+import { MOVED_BOXES_QUERY } from "../../../../shared-components/statviz/queries/queries";
 
 export interface IBoxReconciliationOverlayData {
   shipmentDetail: ShipmentDetailWithAutomatchProduct;
@@ -30,6 +31,7 @@ export function BoxReconciliationOverlay({
   closeOnEsc?: boolean;
   redirectToShipmentView?: boolean;
 }) {
+  const apolloClient = useApolloClient();
   const { createToast } = useNotification();
   const { triggerError } = useErrorHandling();
   const baseId = useAtomValue(selectedBaseIdAtom);
@@ -96,6 +98,28 @@ export function BoxReconciliationOverlay({
     [data],
   );
 
+  /**
+   * If the shipment reached a terminal receiving state (Completed or Lost),
+   * proactively refresh movedBoxes data in the background so the statistics
+   * view is up-to-date without requiring a manual page reload.
+   */
+  const refetchMovedBoxesIfShipmentCompleted = useCallback(
+    (shipmentState: string | null | undefined) => {
+      if (shipmentState === "Completed" || shipmentState === "Lost") {
+        apolloClient
+          .query({
+            query: MOVED_BOXES_QUERY,
+            variables: { baseId: parseInt(baseId, 10) },
+            fetchPolicy: "network-only",
+          })
+          .catch(() => {
+            // Background refetch failure is non-critical; ignore silently.
+          });
+      }
+    },
+    [apolloClient, baseId],
+  );
+
   const onBoxUndelivered = useCallback(
     (labelIdentifier: string) => {
       if (shipmentId) {
@@ -118,6 +142,9 @@ export function BoxReconciliationOverlay({
                 type: "success",
                 message: "Box marked as undelivered.",
               });
+              refetchMovedBoxesIfShipmentCompleted(
+                mutationResult.data?.updateShipmentWhenReceiving?.state,
+              );
               if (redirectToShipmentView)
                 navigate(`/bases/${baseId}/transfers/shipments/${shipmentId}`);
             }
@@ -135,6 +162,7 @@ export function BoxReconciliationOverlay({
       triggerError,
       onOverlayClose,
       createToast,
+      refetchMovedBoxesIfShipmentCompleted,
       redirectToShipmentView,
       navigate,
       baseId,
@@ -181,6 +209,9 @@ export function BoxReconciliationOverlay({
                 type: "success",
                 message: `Box ${labelIdentifier} was received to ${locationName}`,
               });
+              refetchMovedBoxesIfShipmentCompleted(
+                mutationResult.data?.updateShipmentWhenReceiving?.state,
+              );
             }
           })
           .catch(() => {
@@ -198,6 +229,7 @@ export function BoxReconciliationOverlay({
       shipmentId,
       shipmentDetail,
       updateShipmentWhenReceiving,
+      refetchMovedBoxesIfShipmentCompleted,
     ],
   );
 

--- a/front/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.tsx
+++ b/front/src/components/BoxReconciliationOverlay/BoxReconciliationOverlay.tsx
@@ -16,7 +16,7 @@ import {
   IProductWithSizeRangeData,
 } from "./components/BoxReconciliationView";
 import { selectedBaseIdAtom } from "stores/globalPreferenceStore";
-import { MOVED_BOXES_QUERY } from "../../../../shared-components/statviz/queries/queries";
+import { MOVED_BOXES_QUERY } from "@boxtribute/shared-components/statviz/queries/queries";
 
 export interface IBoxReconciliationOverlayData {
   shipmentDetail: ShipmentDetailWithAutomatchProduct;

--- a/front/src/views/Transfers/ShipmentView/ShipmentView.tsx
+++ b/front/src/views/Transfers/ShipmentView/ShipmentView.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@apollo/client";
+import { useMutation, useQuery, useApolloClient } from "@apollo/client";
 import { graphql } from "../../../../../graphql/graphql";
 import { formatDateKey } from "utils/helpers";
 import {
@@ -36,6 +36,7 @@ import { useLoadAndSetGlobalPreferences } from "hooks/useLoadAndSetGlobalPrefere
 import { availableBasesAtom } from "stores/globalPreferenceStore";
 import { User } from "../../../../../graphql/types";
 import { ShipmentDetail, ShipmentDetailWithAutomatchProduct, ShipmentState } from "queries/types";
+import { MOVED_BOXES_QUERY } from "../../../../../shared-components/statviz/queries/queries";
 
 enum ShipmentActionEvent {
   ShipmentStarted = "Shipment Started",
@@ -167,6 +168,7 @@ function MissingWeightOrMonetaryValueAlert({
 }
 
 function ShipmentView() {
+  const apolloClient = useApolloClient();
   const { triggerError } = useErrorHandling();
   const { createToast } = useNotification();
   const availableBases = useAtomValue(availableBasesAtom);
@@ -289,6 +291,20 @@ function ShipmentView() {
 
   const onMinusClick = () => setShowRemoveIcon(!showRemoveIcon);
 
+  const refetchMovedBoxes = useCallback(() => {
+    const targetBaseId = data?.shipment?.targetBase?.id;
+    if (!targetBaseId) return;
+    apolloClient
+      .query({
+        query: MOVED_BOXES_QUERY,
+        variables: { baseId: parseInt(targetBaseId, 10) },
+        fetchPolicy: "network-only",
+      })
+      .catch(() => {
+        // Background refetch failure is non-critical; ignore silently.
+      });
+  }, [apolloClient, data?.shipment?.targetBase?.id]);
+
   const onRemainingBoxesUndelivered = useCallback(() => {
     const lostBoxLabelIdentifiers = data?.shipment?.details
       .filter((shipmentDetail) => shipmentDetail.box.state === "Receiving")
@@ -312,6 +328,7 @@ function ShipmentView() {
             type: "success",
             message: "Changed the state of remaining boxes to undelivered",
           });
+          refetchMovedBoxes();
         }
       })
       .catch(() => {
@@ -326,6 +343,7 @@ function ShipmentView() {
     data,
     shipmentId,
     onShipmentOverlayClose,
+    refetchMovedBoxes,
   ]);
 
   const onRemoveBox = useCallback(

--- a/front/src/views/Transfers/ShipmentView/ShipmentView.tsx
+++ b/front/src/views/Transfers/ShipmentView/ShipmentView.tsx
@@ -213,7 +213,9 @@ function ShipmentView() {
     useMutation(REMOVE_BOX_FROM_SHIPMENT);
 
   const [cancelShipment, cancelShipmentStatus] = useMutation(CANCEL_SHIPMENT);
-  const [lostShipment, lostShipmentStatus] = useMutation(LOST_SHIPMENT);
+  const [lostShipment, lostShipmentStatus] = useMutation(LOST_SHIPMENT, {
+    onCompleted: () => refetchMovedBoxes(),
+  });
   const [sendShipment, sendShipmentStatus] = useMutation(SEND_SHIPMENT);
   const [startReceivingShipment, startReceivingShipmentStatus] =
     useMutation(START_RECEIVING_SHIPMENT);

--- a/front/src/views/Transfers/ShipmentView/ShipmentView.tsx
+++ b/front/src/views/Transfers/ShipmentView/ShipmentView.tsx
@@ -36,7 +36,7 @@ import { useLoadAndSetGlobalPreferences } from "hooks/useLoadAndSetGlobalPrefere
 import { availableBasesAtom } from "stores/globalPreferenceStore";
 import { User } from "../../../../../graphql/types";
 import { ShipmentDetail, ShipmentDetailWithAutomatchProduct, ShipmentState } from "queries/types";
-import { MOVED_BOXES_QUERY } from "../../../../../shared-components/statviz/queries/queries";
+import { MOVED_BOXES_QUERY } from "@boxtribute/shared-components/statviz/queries/queries";
 
 enum ShipmentActionEvent {
   ShipmentStarted = "Shipment Started",


### PR DESCRIPTION
https://trello.com/c/JUHiSgZq

- **Run MOVED_BOXES_QUERY in background when completing shipment during box reconciliation**
- **Run MOVED_BOXES_QUERY in background when marking shipment as lost**
