### PR TITLE
Hotfix for localstorage mocking

### DIFF
--- a/front/src/tests/setupTests.ts
+++ b/front/src/tests/setupTests.ts
@@ -70,6 +70,7 @@ Object.defineProperty(navigator, "userAgent", {
   // configurable: true
 });
 
+// needed to avoid "running clear() on undefined" when executing `pnpm test` outside docker or CI
 const mockLocalStorage = (() => {
   let store = {} as Storage;
 

--- a/front/src/tests/setupTests.ts
+++ b/front/src/tests/setupTests.ts
@@ -70,6 +70,32 @@ Object.defineProperty(navigator, "userAgent", {
   // configurable: true
 });
 
+const mockLocalStorage = (() => {
+  let store = {} as Storage;
+
+  return {
+    getItem(key: string) {
+      return store[key];
+    },
+
+    setItem(key: string, value: string) {
+      store[key] = value;
+    },
+
+    removeItem(key: string) {
+      delete store[key];
+    },
+
+    clear() {
+      store = {} as Storage;
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: mockLocalStorage,
+});
+
 beforeEach(() => {
   localStorage.clear();
   // Reset the cache before each test


### PR DESCRIPTION
This PR focusing on fixing an issue that was added with the latest usage of Local Storage, which broke all the tests since testing frameworks usually do not have access to the Local Storage API. With this quick mock, tests should be able to pass!